### PR TITLE
Revert "Add a few missing constants"

### DIFF
--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -30,17 +30,6 @@ Maximum namespace string length as an integer.
 \declareconstitemvalue{PMIX_MAX_KEYLEN}{511}
 Maximum key string length as an integer.
 %
-\declareconstitemvalue{PMIX_RANK_UNDEF}{UINT32_MAX}
-Undefined rank - indicates that the rank has not been assigned
-%
-\declareconstitemvalue{PMIX_RANK_WILDCARD}{UINT32_MAX-1}
-Wildcard rank - used to reference job-wide values or operations
-%
-\declareconstitemvalue{PMIX_RANK_LOCAL_NODE}{UINT32_MAX-2}
-All ranks on a node - for use in collectives
-%
-\declareconstitemvalue{PMIX_ATTR_UNDEF}{NULL}
-Undefined attribute - indicates that the key has not been assigned
 \end{constantdesc}
 
 %%%%%%%%%%%


### PR DESCRIPTION
My bad - I missed that the constants were cited later.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>

This reverts commit c94f763ac65b9aab40a5aaaffbd6b581fb4ee291.