### PR TITLE
Add a floating version marker

### DIFF
--- a/Chap_API_Data_Mgmt.tex
+++ b/Chap_API_Data_Mgmt.tex
@@ -25,6 +25,7 @@ Allocate memory for a \refstruct{pmix_data_buffer_t} object and initialize it
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 PMIX_DATA_BUFFER_CREATE(buffer);
@@ -53,6 +54,7 @@ Free a \refstruct{pmix_data_buffer_t} object and the data it contains
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 PMIX_DATA_BUFFER_RELEASE(buffer);
@@ -81,6 +83,7 @@ Initialize a statically declared \refstruct{pmix_data_buffer_t} object
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 PMIX_DATA_BUFFER_CONSTRUCT(buffer);
@@ -109,6 +112,7 @@ Release the data contained in a \refstruct{pmix_data_buffer_t} object
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 PMIX_DATA_BUFFER_DESTRUCT(buffer);
@@ -137,6 +141,7 @@ Load a blob into a \refstruct{pmix_data_buffer_t} object
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 PMIX_DATA_BUFFER_LOAD(buffer, data, size);
@@ -167,6 +172,7 @@ Unload the data from a \refstruct{pmix_data_buffer_t} object
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 PMIX_DATA_BUFFER_UNLOAD(buffer, data, size);
@@ -204,6 +210,7 @@ Pack one or more values of a specified type into a buffer, usually for transmiss
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -269,6 +276,7 @@ Unpack values from a \refstruct{pmix_data_buffer_t}
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -332,6 +340,7 @@ Copy a data value from one location to another.
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -373,6 +382,7 @@ Pretty-print a data value.
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -412,6 +422,7 @@ Copy a payload from one buffer to another
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t

--- a/Chap_API_Event.tex
+++ b/Chap_API_Event.tex
@@ -58,6 +58,7 @@ Register an event handler
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 void
@@ -150,6 +151,7 @@ Deregister an event handler.
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 void
@@ -190,6 +192,7 @@ registered event handler.
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t

--- a/Chap_API_Init.tex
+++ b/Chap_API_Init.tex
@@ -33,6 +33,7 @@ The APIs defined in this section can be used by any PMIx process, regardless of 
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 int PMIx_Initialized(void)
@@ -63,6 +64,7 @@ Get the PMIx version information.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 const char* PMIx_Get_version(void)
@@ -94,6 +96,7 @@ Initialize the \ac{PMIx} client.
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -151,6 +154,7 @@ Finalize the PMIx client library.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -196,6 +200,7 @@ Initialize the \ac{PMIx} library for operating as a tool.
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -260,6 +265,7 @@ Finalize the \ac{PMIx} library for a tool connection.
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -295,6 +301,7 @@ Initialize the \ac{PMIx} server.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -353,6 +360,7 @@ Finalize the PMIx server library.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t

--- a/Chap_API_Job_Mgmt.tex
+++ b/Chap_API_Job_Mgmt.tex
@@ -34,6 +34,7 @@ Request an allocation operation from the host resource manager.
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -119,6 +120,7 @@ Request a job control action.
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -204,6 +206,7 @@ Request that application processes be monitored.
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -273,6 +276,7 @@ Send a heartbeat to the \ac{RM}
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 void PMIx_Heartbeat(void)
@@ -304,6 +308,7 @@ Log data to a data service.
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t

--- a/Chap_API_Key_Value_Mgmt.tex
+++ b/Chap_API_Key_Value_Mgmt.tex
@@ -25,6 +25,7 @@ Push a key/value pair into the client's namespace.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -77,6 +78,7 @@ Retrieve a key/value pair from the client's namespace.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -133,6 +135,7 @@ Nonblocking \refapi{PMIx_Get} operation.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -180,6 +183,7 @@ Store some data locally for retrieval by other areas of the proc.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -222,6 +226,7 @@ Push all previously \refapi{PMIx_Put} values to the local PMIx server.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t PMIx_Commit(void)
@@ -254,6 +259,7 @@ Execute a blocking barrier across the processes identified in the specified arra
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -306,6 +312,7 @@ Execute a nonblocking \refapi{PMIx_Fence} across the processes identified in the
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -366,6 +373,7 @@ Publish data for later access via \refapi{PMIx_Lookup}.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -422,6 +430,7 @@ Nonblocking \refapi{PMIx_Publish} routine.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -468,6 +477,7 @@ Lookup information published by this or another process with \refapi{PMIx_Publis
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -530,6 +540,7 @@ Nonblocking version of \refapi{PMIx_Lookup}.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -581,6 +592,7 @@ Unpublish data posted by this process using the given keys.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -629,6 +641,7 @@ Nonblocking version of \refapi{PMIx_Unpublish}.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t

--- a/Chap_API_Proc_Mgmt.tex
+++ b/Chap_API_Proc_Mgmt.tex
@@ -25,6 +25,7 @@ Abort the specified processes
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -79,6 +80,7 @@ Spawn a new job.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -176,6 +178,7 @@ Nonblocking version of the \refapi{PMIx_Spawn} routine.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -273,6 +276,7 @@ Connect namespaces.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -328,6 +332,7 @@ Nonblocking \refapi{PMIx_Connect_nb} routine.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -376,6 +381,7 @@ Disconnect a previously connected set of processes.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -423,6 +429,7 @@ Nonblocking \refapi{PMIx_Disconnect} routine.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -482,6 +489,7 @@ Obtain the array of processes within the specified namespace that are executing 
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -521,6 +529,7 @@ Return a list of nodes hosting processes within the given namespace.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t
@@ -556,17 +565,18 @@ Query information about the system in general.
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
+pmix_status_t
+PMIx_Query_info_nb(pmix_query_t queries[], size_t nqueries,
+                   pmix_info_cbfunc_t cbfunc, void *cbdata)
+
 typedef void (*pmix_info_cbfunc_t)(pmix_status_t status,
                                    pmix_info_t *info, size_t ninfo,
                                    void *cbdata,
                                    pmix_release_cbfunc_t release_fn,
-                                   void *release_cbdata);
-
-pmix_status_t
-PMIx_Query_info_nb(pmix_query_t queries[], size_t nqueries,
-                   pmix_info_cbfunc_t cbfunc, void *cbdata)
+                                   void *release_cbdata)
 \end{codepar}
 \cspecificend
 

--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -21,9 +21,11 @@ Generate a regular expression representation of the input string.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
-pmix_status_t PMIx_generate_regex(const char *input, char **regex)
+pmix_status_t
+PMIx_generate_regex(const char *input, char **regex)
 \end{codepar}
 \cspecificend
 
@@ -59,6 +61,7 @@ Generate a regular expression representation of the input string.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 pmix_status_t PMIx_generate_ppn(const char *input, char **ppn)
@@ -93,9 +96,11 @@ Setup the data about a particular namespace.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
-pmix_status_t PMIx_server_register_nspace(const char nspace[],
+pmix_status_t
+PMIx_server_register_nspace(const char nspace[],
                         int nlocalprocs,
                         pmix_info_t info[], size_t ninfo,
                         pmix_op_cbfunc_t cbfunc, void *cbdata)
@@ -145,6 +150,7 @@ Deregister a namespace.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 void PMIx_server_deregister_nspace(const char nspace[],
@@ -178,9 +184,11 @@ Register a client process with the PMIx server library.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
-pmix_status_t PMIx_server_register_client(const pmix_proc_t *proc,
+pmix_status_t
+PMIx_server_register_client(const pmix_proc_t *proc,
                         uid_t uid, gid_t gid,
                         void *server_object,
                         pmix_op_cbfunc_t cbfunc, void *cbdata)
@@ -221,9 +229,11 @@ Deregister a client and purge all data relating to it.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
-void PMIx_server_deregister_client(const pmix_proc_t *proc,
+void
+PMIx_server_deregister_client(const pmix_proc_t *proc,
                         pmix_op_cbfunc_t cbfunc, void *cbdata)
 \end{codepar}
 \cspecificend
@@ -254,9 +264,11 @@ Setup the environment of a child process to be forked by the host.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
-pmix_status_t PMIx_server_setup_fork(const pmix_proc_t *proc,
+pmix_status_t
+PMIx_server_setup_fork(const pmix_proc_t *proc,
                         char ***env)
 \end{codepar}
 \cspecificend
@@ -289,6 +301,7 @@ Define a function by which the host server can request modex data from the local
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 typedef void (*pmix_dmodex_response_fn_t)(pmix_status_t status,
@@ -333,6 +346,7 @@ Provide a function by which the resource manager can request application-specifi
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 typedef void (*pmix_setup_application_cbfunc_t)(pmix_status_t status,
@@ -340,7 +354,8 @@ typedef void (*pmix_setup_application_cbfunc_t)(pmix_status_t status,
                         void *provided_cbdata,
                         pmix_op_cbfunc_t cbfunc, void *cbdata)
 
-pmix_status_t PMIx_server_setup_application(const char nspace[],
+pmix_status_t
+PMIx_server_setup_application(const char nspace[],
                         pmix_info_t info[], size_t ninfo,
                         pmix_setup_application_cbfunc_t cbfunc,
                         void *cbdata)
@@ -382,11 +397,13 @@ Provide a function by which the local \ac{PMIx} server can perform any applicati
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
-pmix_status_t PMIx_server_setup_local_support(const char nspace[],
-                                              pmix_info_t info[], size_t ninfo,
-                                              pmix_op_cbfunc_t cbfunc, void *cbdata);
+pmix_status_t
+PMIx_server_setup_local_support(const char nspace[],
+                                pmix_info_t info[], size_t ninfo,
+                                pmix_op_cbfunc_t cbfunc, void *cbdata);
 \end{codepar}
 \cspecificend
 
@@ -494,6 +511,7 @@ Notify the host server that a client connected to this server.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 typedef pmix_status_t (*pmix_server_client_connected_fn_t)(
@@ -547,6 +565,7 @@ Notify the host server that a client called \refapi{PMIx_Finalize}.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 typedef pmix_status_t (*pmix_server_client_finalized_fn_t)(
@@ -597,6 +616,7 @@ Notify PMIx Server that a local client called \refapi{PMIx_Abort}.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 typedef pmix_status_t (*pmix_server_abort_fn_t)(
@@ -646,6 +666,7 @@ At least one client called either \refapi{PMIx_Fence} or \refapi{PMIx_Fence_nb}.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 typedef pmix_status_t (*pmix_server_fencenb_fn_t)(
@@ -712,6 +733,7 @@ Used by the PMIx server to request its local host contact the PMIx server on the
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 typedef pmix_status_t (*pmix_server_dmodex_req_fn_t)(
@@ -765,6 +787,7 @@ Publish data per the PMIx API specification.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 typedef pmix_status_t (*pmix_server_publish_fn_t)(
@@ -825,6 +848,7 @@ Lookup published data.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 typedef pmix_status_t (*pmix_server_lookup_fn_t)(
@@ -884,6 +908,7 @@ Delete data from the data store.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 typedef pmix_status_t (*pmix_server_unpublish_fn_t)(
@@ -934,6 +959,7 @@ Spawn a set of applications/processes as per the \refapi{PMIx_Spawn} API.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 typedef pmix_status_t (*pmix_server_spawn_fn_t)(
@@ -1026,6 +1052,7 @@ Record the specified processes as ``connected''.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 typedef pmix_status_t (*pmix_server_connect_fn_t)(
@@ -1081,6 +1108,7 @@ Disconnect a previously connected set of processes.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 typedef pmix_status_t (*pmix_server_disconnect_fn_t)(
@@ -1135,6 +1163,7 @@ Register to receive notifications for the specified events.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
  typedef pmix_status_t (*pmix_server_register_events_fn_t)(
@@ -1201,6 +1230,7 @@ Deregister to receive notifications for the specified events.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
  typedef pmix_status_t (*pmix_server_deregister_events_fn_t)(
@@ -1239,6 +1269,7 @@ Notify the specified processes of an event.
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 typedef pmix_status_t (*pmix_server_notify_event_fn_t)(pmix_status_t code,
@@ -1287,6 +1318,7 @@ Callback function for incoming connection requests from local clients.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 typedef void (*pmix_connection_cbfunc_t)(
@@ -1319,6 +1351,7 @@ Register a socket the host server can monitor for connection requests.
 %%%%
 \format
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 typedef pmix_status_t (*pmix_server_listener_fn_t)(
@@ -1357,6 +1390,7 @@ Query information from the resource manager.
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 typedef pmix_status_t (*pmix_server_query_fn_t)(
@@ -1414,6 +1448,7 @@ Callback function for incoming tool connections.
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 typedef void (*pmix_tool_connection_cbfunc_t)(
@@ -1448,6 +1483,7 @@ Register that a tool has connected to the server.
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 typedef void (*pmix_server_tool_connection_fn_t)(
@@ -1497,6 +1533,7 @@ Log data on behalf of a client.
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 typedef void (*pmix_server_log_fn_t)(
@@ -1552,6 +1589,7 @@ Request allocation modifications on behalf of a client.
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 typedef pmix_status_t (*pmix_server_alloc_fn_t)(
@@ -1627,6 +1665,7 @@ Execute a job control action on behalf of a client.
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 typedef pmix_status_t (*pmix_server_job_control_fn_t)(
@@ -1696,6 +1735,7 @@ Request that a client be monitored for activity.
 %%%%
 \format
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 /* Request that a client be monitored for activity */

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -2941,6 +2941,7 @@ Note that the provided string is statically defined and must NOT be \code{free}'
 
 String representation of a \refstruct{pmix_status_t}.
 
+\versionMarker{1.0}
 \cspecificstart
 \begin{codepar}
 const char*
@@ -2954,6 +2955,7 @@ PMIx_Error_string(pmix_status_t status);
 
 String representation of a \refstruct{pmix_proc_state_t}.
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 const char*
@@ -2967,6 +2969,7 @@ PMIx_Proc_state_string(pmix_proc_state_t state);
 
 String representation of a \refstruct{pmix_scope_t}.
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 const char*
@@ -2980,6 +2983,7 @@ PMIx_Scope_string(pmix_scope_t scope);
 
 String representation of a \refstruct{pmix_persistence_t}.
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 const char*
@@ -2993,6 +2997,7 @@ PMIx_Persistence_string(pmix_persistence_t persist);
 
 String representation of a \refstruct{pmix_data_range_t}.
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 const char*
@@ -3006,6 +3011,7 @@ PMIx_Data_range_string(pmix_data_range_t range);
 
 String representation of a \refstruct{pmix_info_directives_t}.
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 const char*
@@ -3019,6 +3025,7 @@ PMIx_Info_directives_string(pmix_info_directives_t directives);
 
 String representation of a \refstruct{pmix_data_type_t}.
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 const char*
@@ -3032,6 +3039,7 @@ PMIx_Data_type_string(pmix_data_type_t type);
 
 String representation of a \refstruct{pmix_alloc_directive_t}.
 
+\versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
 const char*

--- a/History.tex
+++ b/History.tex
@@ -13,7 +13,7 @@ The following \acp{API} were introduced in v2 of the PMIx Standard:
 \item Client APIs
 \begin{itemize}
 \item \refapi{PMIx_Query_info_nb}, \refapi{PMIx_Log_nb}
-\item \refapi{PMIx_Allocation_request_nb}, \refapi{PMIx_Job_control_nb}, \refapi{PMIx_Process_monitor_nb}
+\item \refapi{PMIx_Allocation_request_nb}, \refapi{PMIx_Job_control_nb}, \refapi{PMIx_Process_monitor_nb}, \refapi{PMIx_Heartbeat}
 \end{itemize}
 \item Server APIs
 \begin{itemize}
@@ -36,7 +36,7 @@ The following \acp{API} were introduced in v2 of the PMIx Standard:
 \end{itemize}
 \end{itemize}
 
-The \refapi{PMIx_Init} \ac{API} was modified in v2 of the standard from its \textit{ad hoc} v1 signature to include passing of a \refstruct{pmix_info_t} array for flexibility and ``future-proofing'' of the \ac{API}. In addition, the PMIx\_Notify\_error, PMIx\_Register\_errhandler, and PMIx\_Deregister\_errhandler \acp{API} were replaced.
+The \refapi{PMIx_Init} \ac{API} was modified in v2 of the standard from its \textit{ad hoc} v1 signature to include passing of a \refstruct{pmix_info_t} array for flexibility and ``future-proofing'' of the \ac{API}. In addition, the \code{PMIx_Notify_error}, \code{PMIx_Register_errhandler}, and \code{PMIx_Deregister_errhandler} \acp{API} were replaced.
 
 %%%%%%%%%% Version 1.0
 \section{Version 1.0: June 12, 2015}

--- a/pmix-standard.tex
+++ b/pmix-standard.tex
@@ -46,7 +46,7 @@
 
 % Text to appear in the footer on even-numbered pages:
 \newcommand{\VER}{2.0 (draft)}
-\newcommand{\VERDATE}{August 2018}
+\newcommand{\VERDATE}{September 2018}
 \newcommand{\footerText}{PMIx Standard -- Version \VER{} -- \VERDATE}
 
 % Unified style sheet for PMIx documents:

--- a/pmix.sty
+++ b/pmix.sty
@@ -105,7 +105,7 @@
 
 \usepackage{changepage}   % allows left/right-page margin readjustments
 
-\setlength{\oddsidemargin}{0.45in}
+\setlength{\oddsidemargin}{0.185in}
 \setlength{\evensidemargin}{0.185in}
 \raggedbottom
 
@@ -141,6 +141,26 @@
 \newenvironment{compactitem}
 {\begin{itemize}[itemsep=-1.2ex]}
 {\end{itemize}}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Floating version
+%\usepackage[showboxes]{textpos}
+\usepackage{textpos}
+
+\setlength{\TPHorizModule}{1pt}%
+\setlength{\TPVertModule}{\TPHorizModule}%
+\TPMargin{1pt}%
+
+\newcommand{\versionMarker}[1]{%
+ % y is 8 = \parskip
+ \begin{textblock}{50}(-55,8)%
+   \textit{PMIx v#1}%
+   \raggedright
+ \end{textblock}%
+}
+% Alternative is to make a box inline, but that gets tricky when positioning close
+% to codepar's
+% \makebox[-7pt][r]{\textit{PMIx #4}\raggedright}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Enumerated list with lowercase alphabet lettering
@@ -272,6 +292,7 @@
 \newcommand{\descr} {\littleheader{Description}}
 \newcommand{\format} {\littleheader{Format}}
 \newcommand{\summary} {\littleheader{Summary}}
+\newcommand{\history} {\littleheader{History}}
 \newcommand{\priattr} {\littleheader{PRI Attributes}}
 \newcommand{\reqattr} {\littleheader{\ac{RM} Required Attributes}}
 \newcommand{\optattr} {\littleheader{\ac{RM} Optional Attributes}}


### PR DESCRIPTION
 * `\versionMarker{2.0}` will put `PMIx v2.0` in the left margin
   between the line number and the location of the marker.
 * Fixes Issue #5 
