### PR TITLE
Minor typos in terms and definitions

### DIFF
--- a/Chap_Terms.tex
+++ b/Chap_Terms.tex
@@ -8,7 +8,7 @@ The \ac{PMIx} Standard has adopted the widespread use of key-value \textit{attri
 
 The \ac{PMIx} community has further adopted a policy that modification of existing released \acp{API} will only be permitted under extreme circumstances. In its effort to avoid introduction of any such backward incompatibility, the community has avoided the definitions of large numbers of \acp{API} that each focus on a narrow scope of functionality, and instead relied on the definition of fewer generic \acp{API} that include arrays of directives for ``tuning'' the function's behavior. Thus, modifications to the PMIx standard increasingly consist of the definition of new attributes along with a description of the \acp{API} to which they relate and the expected behavior when used with those \acp{API}.
 
-One area where this can become more complicated is regarding the attributes that provide directives to the client process and/or control the behavior of a \ac{PMIx} standard \ac{API}. For example, the \refattr{PMIX_TIMEOUT} attribute can be used to specify the time (in seconds) before the requested operation should time out.
+One area where this can become more complicated relates to the attributes that provide directives to the client process and/or control the behavior of a \ac{PMIx} standard \ac{API}. For example, the \refattr{PMIX_TIMEOUT} attribute can be used to specify the time (in seconds) before the requested operation should time out.
 The intent of this attribute is to allow the client to avoid hanging in a request that takes longer than the client wishes to wait, or may never return (e.g., a \refapi{PMIx_Fence} that a blocked participant never enters).
 
 If an application truly relies on the \refattr{PMIX_TIMEOUT} attribute in a call to \refapi{PMIx_Fence}, it should set the \textit{required} flag in the \refstruct{pmix_info_t} for that attribute. This informs the library and its \ac{SMS} host that it must return an immediate error if this attribute is not supported. By not setting the flag, the library and \ac{SMS} host are allowed to treat the attribute as optional, silently ignoring it if support is not available.
@@ -49,7 +49,7 @@ Some readers may wish to skip these sections, while readers interested in interf
 
 \adviceuserstart
 Throughout this document, material aimed at users and that illustrates usage is set off in this section.
-Some readers may wish to skip these sections, while readers interested in programming in \ac{MPI} may want to read them carefully.
+Some readers may wish to skip these sections, while readers interested in programming with the \ac{PMIx} \ac{API} may want to read them carefully.
 \adviceuserend
 
 \adviceimplstart


### PR DESCRIPTION
Signed-off-by: Aurélien Bouteiller <bouteill@icl.utk.edu>