### PR TITLE
Replace specific array lengths with minimums

### DIFF
--- a/App_Support.tex
+++ b/App_Support.tex
@@ -127,6 +127,28 @@ Both key and data will be copied into the destination \refstruct{pmix_info_t} - 
 \adviceuserend
 
 %%%%%%%%%%%
+\subsection{Test an info structure for required}
+\declaremacro{PMIX_INFO_REQUIRED}
+
+%%%%
+\summary
+
+Test the \refconst{PMIX_INFO_REQD} flag in a \refstruct{pmix_info_t} structure, returning \code{true} if the flag is set.
+
+\cspecificstart
+\begin{codepar}
+PMIX_INFO_REQUIRED(info);
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{d}{Pointer to the destination \refstruct{pmix_info_t} (pointer to \refstruct{pmix_info_t})}
+\argin{s}{Pointer to the source \refstruct{pmix_info_t} (pointer to \refstruct{pmix_info_t})}
+\end{arglist}
+
+This macro simplifies the transfer of key and data between two\refstruct{pmix_info_t} structures.
+
+%%%%%%%%%%%
 \subsection{Load a lookup data structure}
 \declaremacro{PMIX_PDATA_LOAD}
 

--- a/Chap_API_Proc_Mgmt.tex
+++ b/Chap_API_Proc_Mgmt.tex
@@ -312,12 +312,12 @@ This means that the resource manager should treat the failure of any process in 
 Note that different resource managers may respond to failures in different manners. The RM does not define a new identifier for the connected assemblage, nor does it define a new rank for each process within that group. In addition, the \ac{PMIx} server does not provide any tracking support for the assemblage. Thus, the caller is responsible for maintaining the membership list of the assemblage.
 
 The function will return once all participating processes have called either \refapi{PMIx_Connect} or its non-blocking version.
-The server is required to return any job-level info for the connecting processes that might not already have it (i.e., if the connect request involves \refarg{procs} from different namespaces, then each \refarg{proc} shall receive the job-level info from those namespaces other than their own). In addition, all members of the collection will receive notification of errors from processes in their combined assemblage. Processes that combine via \refapi{PMIx_Connect} must all depart the assemblage together – i.e., no member can depart the collective while leaving the remaining members in it.
+The server is required to return any job-level info for the connecting processes that might not already have it (i.e., if the connect request involves \refarg{procs} from different namespaces, then each \refarg{proc} shall receive the job-level info from those namespaces other than their own). In addition, all members of the collection will receive notification of errors from processes in their combined assemblage. Processes that combine via \refapi{PMIx_Connect} must call \refapi{PMIx_Disconnect} prior to finalizing and/or terminating.
 
 A process can only engage in \emph{one} connect operation involving the identical set of processes at a time.
 However, a process \emph{can} be simultaneously engaged in multiple connect operations, each involving a different set of processes.
 
-As in the case of the fence operation, the info array can be used to pass user-level directives regarding the algorithm to be used for the collective operation involved in the ``connect'', timeout constraints, and other options available from the host RM.
+As in the case of the fence operation, the info array can be used to pass user-level directives regarding the algorithm to be used for the collective operation involved in the ``connect'', timeout constraints, and other options available from the host \ac{RM}.
 
 
 %%%%%%%%%%%

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -28,18 +28,20 @@ Additional constants associated with specific data structures or types are defin
 %
 \declareconstitem{PMIX_MAX_NSLEN}
 Maximum namespace string length as an integer.
+\end{constantdesc}
 
 \adviceimplstart
-\refconst{PMIX_MAX_NSLEN} should have a minimum value of 64 characters. Namespace arrays in \ac{PMIx} defined structures must reserve
+\refconst{PMIX_MAX_NSLEN} should have a minimum value of 63 characters. Namespace arrays in \ac{PMIx} defined structures must reserve
 a space of size \refconst{PMIX_MAX_NSLEN}+1 to allow room for the \code{NULL} terminator
 \adviceimplend
 
+\begin{constantdesc}
 %
 \declareconstitem{PMIX_MAX_KEYLEN}
 Maximum key string length as an integer.
 
 \adviceimplstart
-\refconst{PMIX_MAX_KEYLEN} should have a minimum value of 64 characters. Key arrays in \ac{PMIx} defined structures must reserve
+\refconst{PMIX_MAX_KEYLEN} should have a minimum value of 63 characters. Key arrays in \ac{PMIx} defined structures must reserve
 a space of size \refconst{PMIX_MAX_KEYLEN}+1 to allow room for the \code{NULL} terminator
 \adviceimplend
 
@@ -345,7 +347,15 @@ This section defines various data types used by the PMIx APIs.
 \subsection{Key Structure}
 \declarestruct{pmix_key_t}
 
-The \refstruct{pmix_key_t} structure is a statically defined character array of length \refconst{PMIX_MAX_KEYLEN}+1, thus supporting keys of maximum length \refconst{PMIX_MAX_KEYLEN} to preserve space for a mandatory \code{NULL} terminator. Characters in the key must be the standard alphanumeric values supported by common utilities such as strcmp.
+The \refstruct{pmix_key_t} structure is a statically defined character array of length \refconst{PMIX_MAX_KEYLEN}+1, thus supporting keys of maximum length \refconst{PMIX_MAX_KEYLEN} to preserve space for a mandatory \code{NULL} terminator.
+
+\cspecificstart
+\begin{codepar}
+typedef char pmix_key_t[PMIX_MAX_KEYLEN+1];
+\end{codepar}
+\cspecificend
+
+Characters in the key must be the standard alphanumeric values supported by common utilities such as strcmp.
 
 %%%%%%%%%%%
 \subsection{Rank Structure}
@@ -353,19 +363,24 @@ The \refstruct{pmix_key_t} structure is a statically defined character array of 
 
 The \refstruct{pmix_rank_t} structure is a \code{uint32_t} type for rank values.
 
+\cspecificstart
+\begin{codepar}
+typedef uint32_t pmix_rank_t;
+\end{codepar}
+\cspecificend
+
 The following constants can be used to set a variable of the type \refstruct{pmix_rank_t}.
 Valid rank values start at \code{0}.
 
 \begin{constantdesc}
 %
-\declareconstitemvalue{PMIX_RANK_UNDEF}{UINT32_MAX}
-Define a value for requests for job-level data where the information itself is not associated with any specific rank, or when a request involves a rank that is not known.
-For example, when someone requests information thru one of the PMIx v1 legacy interfaces where the rank is typically encoded into the key itself, since there is no rank parameter in the PMIx v1 \refapi{PMIx_Get} API in that version.
+\declareconstitem{PMIX_RANK_UNDEF}
+A value to request job-level data where the information itself is not associated with any specific rank, or when passing a \refstruct{pmix_proc_t} identifier to an operation that only references the namespace field of that structure.
 %
-\declareconstitemvalue{PMIX_RANK_WILDCARD}{UINT32_MAX-1}
-Define a value to indicate that the user wants the data for the given key from every rank that posted that key.
+\declareconstitem{PMIX_RANK_WILDCARD}
+A value to indicate that the user wants the data for the given key from every rank that posted that key.
 %
-\declareconstitemvalue{PMIX_RANK_LOCAL_NODE}{UINT32_MAX-2}
+\declareconstitem{PMIX_RANK_LOCAL_NODE}
 Special rank value used to define groups of ranks for use in collectives.
 This constant defines the group of all ranks on a local node.
 %
@@ -398,72 +413,75 @@ The \refstruct{pmix_proc_state_t} structure is a \code{uint8_t} type for process
 
 The following constants can be used to set a variable of the type \refstruct{pmix_proc_state_t}.
 
+\adviceuserstart
+The fine-grained nature of the following constants may exceed the ability of an \ac{RM} to provide updated process state values during the process lifetime. This is particularly true of states in the launch process, and for short-lived processes.
+\adviceuserend
 
 \begin{constantdesc}
 %
-\declareconstitemvalue{PMIX_PROC_STATE_UNDEF}{0}
+\declareconstitem{PMIX_PROC_STATE_UNDEF}
 Undefined process state
 %
-\declareconstitemvalue{PMIX_PROC_STATE_PREPPED}{1}
+\declareconstitem{PMIX_PROC_STATE_PREPPED}
 Process is ready to be launched
 %
-\declareconstitemvalue{PMIX_PROC_STATE_LAUNCH_UNDERWAY}{2}
+\declareconstitem{PMIX_PROC_STATE_LAUNCH_UNDERWAY}
 Process launch is underway
 %
-\declareconstitemvalue{PMIX_PROC_STATE_RESTART}{3}
+\declareconstitem{PMIX_PROC_STATE_RESTART}
 Process is ready for restart
 %
-\declareconstitemvalue{PMIX_PROC_STATE_TERMINATE}{4}
+\declareconstitem{PMIX_PROC_STATE_TERMINATE}
 Process is marked for termination
 %
-\declareconstitemvalue{PMIX_PROC_STATE_RUNNING}{5}
+\declareconstitem{PMIX_PROC_STATE_RUNNING}
 Process has been locally \code{fork}'ed by the \ac{RM}
 %
-\declareconstitemvalue{PMIX_PROC_STATE_CONNECTED}{6}
+\declareconstitem{PMIX_PROC_STATE_CONNECTED}
 Process has connected to PMIx server
 %
-\declareconstitemvalue{PMIX_PROC_STATE_UNTERMINATED}{15}
+\declareconstitem{PMIX_PROC_STATE_UNTERMINATED}
 Define a ``boundary'' between this constant and \refconst{PMIX_PROC_STATE_CONNECTED} so users can easily and quickly determine if a process is still running or not.
 Any value less than this constant means that the process has not terminated.
 %
-\declareconstitemvalue{PMIX_PROC_STATE_TERMINATED}{20}
+\declareconstitem{PMIX_PROC_STATE_TERMINATED}
 Process has terminated and is no longer running
 %
-\declareconstitemvalue{PMIX_PROC_STATE_ERROR}{50}
+\declareconstitem{PMIX_PROC_STATE_ERROR}
 Define a boundary so users can easily and quickly determine if a process abnormally terminated.
 Any value above this constant means that the process has terminated abnormally.
 %
-\declareconstitemvalue{PMIX_PROC_STATE_KILLED_BY_CMD}{PMIX_PROC_STATE_ERROR+1}
+\declareconstitem{PMIX_PROC_STATE_KILLED_BY_CMD}
 Process was killed by a command
 %
-\declareconstitemvalue{PMIX_PROC_STATE_ABORTED}{PMIX_PROC_STATE_ERROR+2}
-Process was aborted
+\declareconstitem{PMIX_PROC_STATE_ABORTED}
+Process was aborted by a call to \refapi{PMIx_Abort}
 %
-\declareconstitemvalue{PMIX_PROC_STATE_FAILED_TO_START}{PMIX_PROC_STATE_ERROR+3}
+\declareconstitem{PMIX_PROC_STATE_FAILED_TO_START}
 Process failed to start
 %
-\declareconstitemvalue{PMIX_PROC_STATE_ABORTED_BY_SIG}{PMIX_PROC_STATE_ERROR+4}
+\declareconstitem{PMIX_PROC_STATE_ABORTED_BY_SIG}
 Process aborted by a signal
 %
-\declareconstitemvalue{PMIX_PROC_STATE_TERM_WO_SYNC}{PMIX_PROC_STATE_ERROR+5}
+\declareconstitem{PMIX_PROC_STATE_TERM_WO_SYNC}
 Process exited without calling \refapi{PMIx_Finalize}
 %
-\declareconstitemvalue{PMIX_PROC_STATE_COMM_FAILED}{PMIX_PROC_STATE_ERROR+6}
+\declareconstitem{PMIX_PROC_STATE_COMM_FAILED}
 Process communication has failed
 %
-\declareconstitemvalue{PMIX_PROC_STATE_CALLED_ABORT}{PMIX_PROC_STATE_ERROR+7}
+\declareconstitem{PMIX_PROC_STATE_CALLED_ABORT}
 Process called \refapi{PMIx_Abort}
 %
-\declareconstitemvalue{PMIX_PROC_STATE_MIGRATING}{PMIX_PROC_STATE_ERROR+8}
+\declareconstitem{PMIX_PROC_STATE_MIGRATING}
 Process failed and is waiting for resources before restarting
 %
-\declareconstitemvalue{PMIX_PROC_STATE_CANNOT_RESTART}{PMIX_PROC_STATE_ERROR+9}
+\declareconstitem{PMIX_PROC_STATE_CANNOT_RESTART}
 Process failed and cannot be restarted
 %
-\declareconstitemvalue{PMIX_PROC_STATE_TERM_NON_ZERO}{PMIX_PROC_STATE_ERROR+10}
+\declareconstitem{PMIX_PROC_STATE_TERM_NON_ZERO}
 Process exited with a non-zero status
 %
-\declareconstitemvalue{PMIX_PROC_STATE_FAILED_TO_LAUNCH}{PMIX_PROC_STATE_ERROR+11}
+\declareconstitem{PMIX_PROC_STATE_FAILED_TO_LAUNCH}
 Unable to launch process
 %
 \end{constantdesc}
@@ -611,8 +629,13 @@ The following constants can be used to set a variable of the type \refstruct{pmi
 
 \begin{constantdesc}
 %
-\declareconstitemvalue{PMIX_INFO_REQD}{0x0001}
-The behavior defined in the \refstruct{pmix_info_t} array is required, and not optional.
+\declareconstitem{PMIX_INFO_REQD}
+The behavior defined in the \refstruct{pmix_info_t} array is required, and not optional. This is a bit-mask value.
+
+\adviceuserstart
+Users are advised to use the provided \refmacro{PMIX_INFO_REQUIRED} macro for testing this flag
+\adviceuserend
+
 %
 \end{constantdesc}
 
@@ -641,7 +664,7 @@ Attributes in the accompanying \refstruct{pmix_info_t} array may be used to spec
 \declareconstitem{PMIX_ALLOC_REAQUIRE}
 Reacquire resources that were previously ``lent'' back to the scheduler.
 %
-\declareconstitemvalue{PMIX_ALLOC_EXTERNAL}{128}
+\declareconstitem{PMIX_ALLOC_EXTERNAL}
 A value boundary above which implementers are free to define their own directive values.
 %
 \end{constantdesc}
@@ -983,8 +1006,8 @@ Allocation directive (\refstruct{pmix_alloc_directive_t})
 \declareconstitemDEP{PMIX_INFO_ARRAY}{2.0}
 Info array
 %
-\declareconstitemvalue{PMIX_DATA_TYPE_MAX}{500}
-A boundary for implementers so they can add their own data types.
+\declareconstitem{PMIX_DATA_TYPE_MAX}
+A boundary for implementers above which they can add their own data types.
 %
 \end{constantdesc}
 

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -26,13 +26,26 @@ Additional constants associated with specific data structures or types are defin
 
 \begin{constantdesc}
 %
-\declareconstitemvalue{PMIX_MAX_NSLEN}{255}
+\declareconstitem{PMIX_MAX_NSLEN}
 Maximum namespace string length as an integer.
+
+\adviceimplstart
+\refconst{PMIX_MAX_NSLEN} should have a minimum value of 64 characters. Namespace arrays in \ac{PMIx} defined structures must reserve
+a space of size \refconst{PMIX_MAX_NSLEN}+1 to allow room for the \code{NULL} terminator
+\adviceimplend
+
 %
-\declareconstitemvalue{PMIX_MAX_KEYLEN}{511}
+\declareconstitem{PMIX_MAX_KEYLEN}
 Maximum key string length as an integer.
+
+\adviceimplstart
+\refconst{PMIX_MAX_KEYLEN} should have a minimum value of 64 characters. Key arrays in \ac{PMIx} defined structures must reserve
+a space of size \refconst{PMIX_MAX_KEYLEN}+1 to allow room for the \code{NULL} terminator
+\adviceimplend
+
 %
 \end{constantdesc}
+
 
 %%%%%%%%%%%
 \subsection{Error Constants}
@@ -327,6 +340,12 @@ Definitions should always be based on the \refconst{PMIX_EXTERNAL_ERR_BASE} cons
 \section{Data Types}
 
 This section defines various data types used by the PMIx APIs.
+
+%%%%%%%%%%%
+\subsection{Key Structure}
+\declarestruct{pmix_key_t}
+
+The \refstruct{pmix_key_t} structure is a statically defined character array of length \refconst{PMIX_MAX_KEYLEN}+1, thus supporting keys of maximum length \refconst{PMIX_MAX_KEYLEN} to preserve space for a mandatory \code{NULL} terminator. Characters in the key must be the standard alphanumeric values supported by common utilities such as strcmp.
 
 %%%%%%%%%%%
 \subsection{Rank Structure}

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -39,14 +39,13 @@ a space of size \refconst{PMIX_MAX_NSLEN}+1 to allow room for the \code{NULL} te
 %
 \declareconstitem{PMIX_MAX_KEYLEN}
 Maximum key string length as an integer.
+%
+\end{constantdesc}
 
 \adviceimplstart
 \refconst{PMIX_MAX_KEYLEN} should have a minimum value of 63 characters. Key arrays in \ac{PMIx} defined structures must reserve
 a space of size \refconst{PMIX_MAX_KEYLEN}+1 to allow room for the \code{NULL} terminator
 \adviceimplend
-
-%
-\end{constantdesc}
 
 
 %%%%%%%%%%%
@@ -347,7 +346,7 @@ This section defines various data types used by the PMIx APIs.
 \subsection{Key Structure}
 \declarestruct{pmix_key_t}
 
-The \refstruct{pmix_key_t} structure is a statically defined character array of length \refconst{PMIX_MAX_KEYLEN}+1, thus supporting keys of maximum length \refconst{PMIX_MAX_KEYLEN} to preserve space for a mandatory \code{NULL} terminator.
+The \refstruct{pmix_key_t} structure is a statically defined character array of length \refconst{PMIX_MAX_KEYLEN}+1, thus supporting keys of maximum length \refconst{PMIX_MAX_KEYLEN} while preserving space for a mandatory \code{NULL} terminator.
 
 \cspecificstart
 \begin{codepar}
@@ -355,7 +354,30 @@ typedef char pmix_key_t[PMIX_MAX_KEYLEN+1];
 \end{codepar}
 \cspecificend
 
-Characters in the key must be the standard alphanumeric values supported by common utilities such as strcmp.
+Characters in the key must be standard alphanumeric values supported by common utilities such as \textit{strcmp}.
+
+\adviceuserstart
+Passing a \refstruct{pmix_key_t} value to the standard \textit{sizeof} utility can result in compiler warnings of incorrect returned value. Users are advised to avoid using \textit{sizeof(pmix_key_t)} and instead rely on the \refstruct{PMIX_MAX_KEYLEN} constant.
+\adviceuserend
+
+%%%%%%%%%%%
+\subsection{Namespace Structure}
+\declarestruct{pmix_nspace_t}
+
+The \refstruct{pmix_nspace_t} structure is a statically defined character array of length \refconst{PMIX_MAX_NSLEN}+1, thus supporting namespaces of maximum length \refconst{PMIX_MAX_NSLEN} while preserving space for a mandatory \code{NULL} terminator.
+
+\cspecificstart
+\begin{codepar}
+typedef char pmix_nspace_t[PMIX_MAX_NSLEN+1];
+\end{codepar}
+\cspecificend
+
+Characters in the namespace must be standard alphanumeric values supported by common utilities such as \textit{strcmp}.
+
+\adviceuserstart
+Passing a \refstruct{pmix_nspace_t} value to the standard \textit{sizeof} utility can result in compiler warnings of incorrect returned value. Users are advised to avoid using \textit{sizeof(pmix_nspace_t)} and instead rely on the \refstruct{PMIX_MAX_NSLEN} constant.
+\adviceuserend
+
 
 %%%%%%%%%%%
 \subsection{Rank Structure}
@@ -370,7 +392,7 @@ typedef uint32_t pmix_rank_t;
 \cspecificend
 
 The following constants can be used to set a variable of the type \refstruct{pmix_rank_t}.
-Valid rank values start at \code{0}.
+Valid rank values start at zero.
 
 \begin{constantdesc}
 %
@@ -397,7 +419,7 @@ It contains a reference to the namespace and the \refstruct{pmix_rank_t} within 
 \cspecificstart
 \begin{codepar}
 typedef struct pmix_proc \{
-    char nspace[PMIX_MAX_NSLEN+1];
+    pmix_nspace_t nspace;
     pmix_rank_t rank;
 \} pmix_proc_t;
 \end{codepar}
@@ -681,7 +703,7 @@ The \refstruct{pmix_pdata_t} structure is used by \refapi{PMIx_Lookup} to descri
 \begin{codepar}
 typedef struct pmix_pdata \{
     pmix_proc_t proc;
-    char key[PMIX_MAX_KEYLEN+1];
+    pmix_key_t key;
     pmix_value_t value;
 \} pmix_pdata_t;
 \end{codepar}
@@ -747,7 +769,7 @@ This structure has been deprecated and will be removed in future versions of the
 \cspecificstart
 \begin{codepar}
 typedef struct pmix_modex_data \{
-    char nspace[PMIX_MAX_NSLEN+1];
+    pmix_nspace_t nspace;
     int rank;
     uint8_t *blob;
     size_t size;
@@ -833,7 +855,7 @@ The \refstruct{pmix_info_t} structure defines a key/value pair with associated d
 \cspecificstart
 \begin{codepar}
 typedef struct pmix_info_t \{
-    char key[PMIX_MAX_KEYLEN+1];
+    pmix_key_t key;
     pmix_info_directives_t flags;
     pmix_value_t value;
 \} pmix_info_t;


### PR DESCRIPTION
Don't standardize the values of PMIX_MAX_NSLEN and PMIX_MAX_KEYLEN.
Instead, standardize the name of those values and provide recommended
minimums.

Prototype a definition for pmix_key_t, but hold off on a precise
definition pending further direction.

Clarify PMIx_Connect language a bit - more to come.

Refs #72 

Signed-off-by: Ralph Castain <rhc@open-mpi.org>