### PR TITLE
Update to version 3 of the standard

### DIFF
--- a/Acknowledgements.tex
+++ b/Acknowledgements.tex
@@ -8,6 +8,29 @@ This document represents the work of many people who have contributed to the PMI
 Without the hard work and dedication of these people this document would not have been possible.
 The sections below list some of the active participants and organizations in the various PMIx standard iterations.
 
+%%%%%%%%%% Version 3.0
+\section{Version 3.0}
+
+The following list includes some of the active participants in the PMIx v2 standardization process.
+
+\begin{itemize}
+\item Ralph H. Castain, Andrew Friedley, Brandon Yates
+\item Joshua Hursey
+\item Aurelien Bouteiller and George Bosilca
+\item Dirk Schubert
+\item Kevin Harms
+\end{itemize}
+
+\begin{itemize}
+\item Intel Corporation
+\item IBM, Inc.
+\item University of Tennessee, Knoxville
+\item The Exascale Computing Project, an initiative of the US Department of Energy
+\item National Science Foundation
+\item Argonne National Laboratory
+\item Allinea (ARM)
+\end{itemize}
+
 %%%%%%%%%% Version 2.0
 \section{Version 2.0}
 

--- a/Chap_API_Job_Mgmt.tex
+++ b/Chap_API_Job_Mgmt.tex
@@ -1,7 +1,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Chapter: Job Allocation Management
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\chapter{Job Allocation Management and Reporting}
+\chapter{Job Management and Reporting}
 \label{chap:api_job_mgmt}
 
 The job management \acp{API} provide an application with the ability to orchestrate its operation in partnership with the \ac{SMS}.
@@ -191,7 +191,87 @@ These are primarily used in the following scenarios:
 \item \textit{Resilient} applications that need to request replacement resources in the face of failures
 \item \textit{Rigid} jobs where the user has requested a static allocation of resources for a fixed period of time, but realizes that they underestimated their required time while executing
 \end{itemize}
-\ac{PMIx} attempts to address this range of use-cases with a single, flexible \ac{API}.
+\ac{PMIx} attempts to address this range of use-cases with a flexible \ac{API}.
+
+%%%%%%%%%%%
+\subsection{\code{PMIx_Allocation_request}}
+\declareapi{PMIx_Allocation_request}
+
+%%%%
+\summary
+
+Request an allocation operation from the host resource manager.
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+pmix_status_t
+PMIx_Allocation_request(pmix_alloc_directive_t directive,
+                        pmix_info_t info[], size_t ninfo);
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{directive}{Allocation directive (handle)}
+\argin{info}{Array of \refstruct{pmix_info_t} structures (array of handles)}
+\argin{ninfo}{Number of elements in the \refarg{info} array (integer)}
+\end{arglist}
+
+Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant.
+
+\reqattrstart
+\ac{PMIx} libraries are not required to directly support any attributes for this function. However, any provided attributes must be passed to the host \ac{SMS} daemon for processing, and the \ac{PMIx} library is \textit{required} to add the \refPRIAttributeItem{PMIX_USERID} and the \refPRIAttributeItem{PMIX_GRPID} attributes of the client process making the request.
+
+Host environments that implement support for this operation are required to support the following attributes:
+
+\pasteAttributeItem{PMIX_ALLOC_ID}
+\pasteAttributeItem{PMIX_ALLOC_NUM_NODES}
+\pasteAttributeItem{PMIX_ALLOC_NUM_CPUS}
+\pasteAttributeItem{PMIX_ALLOC_TIME}
+
+\reqattrend
+
+\optattrstart
+The following attributes are optional for host environments that support this operation:
+
+\pasteAttributeItem{PMIX_ALLOC_NODE_LIST}
+\pasteAttributeItem{PMIX_ALLOC_NUM_CPU_LIST}
+\pasteAttributeItem{PMIX_ALLOC_CPU_LIST}
+\pasteAttributeItem{PMIX_ALLOC_MEM_SIZE}
+\pasteAttributeItem{PMIX_ALLOC_NETWORK}
+\pasteAttributeItem{PMIX_ALLOC_NETWORK_ID}
+\pasteAttributeItem{PMIX_ALLOC_BANDWIDTH}
+\pasteAttributeItem{PMIX_ALLOC_NETWORK_QOS}
+\pasteAttributeItem{PMIX_ALLOC_NETWORK_TYPE}
+\pasteAttributeItem{PMIX_ALLOC_NETWORK_PLANE}
+\pasteAttributeItem{PMIX_ALLOC_NETWORK_ENDPTS}
+\pasteAttributeItem{PMIX_ALLOC_NETWORK_ENDPTS_NODE}
+\pasteAttributeItem{PMIX_ALLOC_NETWORK_SEC_KEY}
+
+\optattrend
+
+%%%%
+\descr
+
+Request an allocation operation from the host resource manager.
+Several broad categories are envisioned, including the ability to:
+
+\begin{compactitem}
+%
+\item Request allocation of additional resources, including memory, bandwidth, and compute.
+This should be accomplished in a non-blocking manner so that the application can continue to progress while waiting for resources to become available.
+Note that the new allocation will be disjoint from (i.e., not affiliated with) the allocation of the requestor - thus the termination of one allocation will not impact the other.
+%
+\item Extend the reservation on currently allocated resources, subject to scheduling availability and priorities.
+This includes extending the time limit on current resources, and/or requesting additional resources be allocated to the requesting job.
+Any additional allocated resources will be considered as part of the current allocation, and thus will be released at the same time.
+%
+\item Return no-longer-required resources to the scheduler.
+This includes the ``loan'' of resources back to the scheduler with a promise to return them upon subsequent request.
+\end{compactitem}
 
 %%%%%%%%%%%
 \subsection{\code{PMIx_Allocation_request_nb}}
@@ -248,42 +328,116 @@ The following attributes are optional for host environments that support this op
 \pasteAttributeItem{PMIX_ALLOC_NETWORK_ID}
 \pasteAttributeItem{PMIX_ALLOC_BANDWIDTH}
 \pasteAttributeItem{PMIX_ALLOC_NETWORK_QOS}
+\pasteAttributeItem{PMIX_ALLOC_NETWORK_TYPE}
+\pasteAttributeItem{PMIX_ALLOC_NETWORK_PLANE}
+\pasteAttributeItem{PMIX_ALLOC_NETWORK_ENDPTS}
+\pasteAttributeItem{PMIX_ALLOC_NETWORK_ENDPTS_NODE}
+\pasteAttributeItem{PMIX_ALLOC_NETWORK_SEC_KEY}
 
 \optattrend
 
 %%%%
 \descr
 
-Request an allocation operation from the host resource manager.
-Several broad categories are envisioned, including the ability to:
+Non-blocking form of the \refapi{PMIx_Allocation_request} \ac{API}.
 
-\begin{compactitem}
-%
-\item Request allocation of additional resources, including memory, bandwidth, and compute.
-This should be accomplished in a non-blocking manner so that the application can continue to progress while waiting for resources to become available.
-Note that the new allocation will be disjoint from (i.e., not affiliated with) the allocation of the requestor - thus the termination of one allocation will not impact the other.
-%
-\item Extend the reservation on currently allocated resources, subject to scheduling availability and priorities.
-This includes extending the time limit on current resources, and/or requesting additional resources be allocated to the requesting job.
-Any additional allocated resources will be considered as part of the current allocation, and thus will be released at the same time.
-%
-\item Return no-longer-required resources to the scheduler.
-This includes the ``loan'' of resources back to the scheduler with a promise to return them upon subsequent request.
-\end{compactitem}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\section{Job Control}
+\label{chap:api_job_mgmt:jctrl}
+
+This section defines \acp{API} that enable the application and host environment to coordinate the response to failures and other events.
+This can include requesting termination of the entire job or a subset of processes within a job, but can
+also be used in combination with other \ac{PMIx} capabilities (e.g., allocation support and event notification) for more nuanced responses. For example, an application notified of an incipient over-temperature condition on a node could use the \refapi{PMIx_Allocation_request_nb} interface to request replacement nodes while simultaneously using the \refapi{PMIx_Job_control_nb} interface to direct that a checkpoint event be delivered to all processes in the application. If replacement resources are not available, the application might use the \refapi{PMIx_Job_control_nb} interface to request that the job continue at a lower power setting, perhaps sufficient to avoid the over-temperature failure.
+
+The job control \acp{API} can also be used by an application to register itself as available for preemption when operating in an environment such as a cloud or where incentives, financial or otherwise, are provided to jobs willing to be preempted. Registration can include attributes indicating how many resources are being offered for preemption (e.g., all or only some portion), whether the application will require time to prepare for preemption, etc. Jobs that
+request a warning will receive an event notifying them of an impending preemption (possibly including information as to the resources that will be taken away, how much time the application will be given prior to being preempted, whether the preemption will be a suspension or full termination, etc.) so they have an opportunity to save
+their work. Once the application is ready, it calls the provided event completion callback function to indicate that
+the SMS is free to suspend or terminate it, and can include directives regarding any desired restart.
+
+%%%%%%%%%%%
+\subsection{\code{PMIx_Job_control}}
+\declareapi{PMIx_Job_control}
+
+%%%%
+\summary
+
+Request a job control action.
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+pmix_status_t
+PMIx_Job_control(const pmix_proc_t targets[], size_t ntargets,
+                 const pmix_info_t directives[], size_t ndirs)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{targets}{Array of proc structures (array of handles)}
+\argin{ntargets}{Number of element in the \refarg{targets} array (integer)}
+\argin{directives}{Array of info structures (array of handles)}
+\argin{ndirs}{Number of element in the \refarg{directives} array (integer)}
+\argin{cbfunc}{Callback function \refapi{pmix_info_cbfunc_t} (function reference)}
+\argin{cbdata}{Data to be passed to the callback function (memory reference)}
+\end{arglist}
+
+Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant.
+
+\reqattrstart
+\ac{PMIx} libraries are not required to directly support any attributes for this function. However, any provided attributes must be passed to the host \ac{SMS} daemon for processing, and the \ac{PMIx} library is \textit{required} to add the \refPRIAttributeItem{PMIX_USERID} and the \refPRIAttributeItem{PMIX_GRPID} attributes of the client process making the request.
+
+Host environments that implement support for this operation are required to support the following attributes:
+
+\pastePRRTEAttributeItem{PMIX_JOB_CTRL_ID}
+\pastePRRTEAttributeItem{PMIX_JOB_CTRL_PAUSE}
+\pastePRRTEAttributeItem{PMIX_JOB_CTRL_RESUME}
+\pastePRRTEAttributeItem{PMIX_JOB_CTRL_KILL}
+\pastePRRTEAttributeItem{PMIX_JOB_CTRL_SIGNAL}
+\pastePRRTEAttributeItem{PMIX_JOB_CTRL_TERMINATE}
+\pastePRRTEAttributeItem{PMIX_REGISTER_CLEANUP}
+\pastePRRTEAttributeItem{PMIX_REGISTER_CLEANUP_DIR}
+\pastePRRTEAttributeItem{PMIX_CLEANUP_RECURSIVE}
+\pastePRRTEAttributeItem{PMIX_CLEANUP_EMPTY}
+\pastePRRTEAttributeItem{PMIX_CLEANUP_IGNORE}
+\pastePRRTEAttributeItem{PMIX_CLEANUP_LEAVE_TOPDIR}
+
+\reqattrend
+
+\optattrstart
+The following attributes are optional for host environments that support this operation:
+
+\pasteAttributeItem{PMIX_JOB_CTRL_CANCEL}
+\pasteAttributeItem{PMIX_JOB_CTRL_RESTART}
+\pasteAttributeItem{PMIX_JOB_CTRL_CHECKPOINT}
+\pasteAttributeItem{PMIX_JOB_CTRL_CHECKPOINT_EVENT}
+\pasteAttributeItem{PMIX_JOB_CTRL_CHECKPOINT_SIGNAL}
+\pasteAttributeItem{PMIX_JOB_CTRL_CHECKPOINT_TIMEOUT}
+\pasteAttributeItem{PMIX_JOB_CTRL_CHECKPOINT_METHOD}
+\pasteAttributeItem{PMIX_JOB_CTRL_PROVISION}
+\pasteAttributeItem{PMIX_JOB_CTRL_PROVISION_IMAGE}
+\pasteAttributeItem{PMIX_JOB_CTRL_PREEMPTIBLE}
+
+\optattrend
+
+%%%%
+\descr
+
+Request a job control action.
+The \refarg{targets} array identifies the processes to which the requested job control action is to be applied.
+A \code{NULL} value can be used to indicate all processes in the caller's namespace.
+The use of \refconst{PMIX_RANK_WILDARD} can also be used to indicate that all processes in the given namespace are to be included.
+
+The directives are provided as \refstruct{pmix_info_t} structures in the \refarg{directives} array.
 
 
 %%%%%%%%%%%
 \subsection{\code{PMIx_Job_control_nb}}
 \declareapi{PMIx_Job_control_nb}
-
-The \refapi{PMIx_Job_control_nb} \ac{API} enables the application and \ac{SMS} to coordinate the response to failures and other events.
-This can include requesting termination of the entire job or a subset of processes within a job, but can
-also be used in combination with other \ac{PMIx} capabilities (e.g., allocation support and event notification) for more nuanced responses. For example, an application notified of an incipient over-temperature condition on a node could use the \refapi{PMIx_Allocation_request_nb} interface to request replacement nodes while simultaneously using the \refapi{PMIx_Job_control_nb} interface to direct that a checkpoint event be delivered to all processes in the application. If replacement resources are not available, the application might use the \refapi{PMIx_Job_control_nb} interface to request that the job continue at a lower power setting, perhaps sufficient to avoid the over-temperature failure.
-
-The job control API can also be used by an application to register itself as available for preemption when operating in an environment such as a cloud or where incentives, financial or otherwise, are provided to jobs willing to be preempted. Registration can include attributes indicating how many resources are being offered for preemption (e.g., all or only some portion), whether the application will require time to prepare for preemption, etc. Jobs that
-request a warning will receive an event notifying them of an impending preemption (possibly including information as to the resources that will be taken away, how much time the application will be given prior to being preempted, whether the preemption will be a suspension or full termination, etc.) so they have an opportunity to save
-their work. Once the application is ready, it calls the provided event completion callback function to indicate that
-the SMS is free to suspend or terminate it, and can include directives regarding any desired restart.
 
 %%%%
 \summary
@@ -347,13 +501,7 @@ The following attributes are optional for host environments that support this op
 %%%%
 \descr
 
-Request a job control action.
-The \refarg{targets} array identifies the processes to which the requested job control action is to be applied.
-A \code{NULL} value can be used to indicate all processes in the caller's namespace.
-The use of \refconst{PMIX_RANK_WILDARD} can also be used to indicate that all processes in the given namespace are to be included.
-
-The directives are provided as \refstruct{pmix_info_t} structures in the \refarg{directives} array.
-The callback function provides a \refarg{status} to indicate whether or not the request was granted, and to provide some information as to the reason for any denial in the \refapi{pmix_info_cbfunc_t} array of \refstruct{pmix_info_t} structures.
+Non-blocking form of the \refapi{PMIx_Job_control} \ac{API}. The callback function provides a \refarg{status} to indicate whether or not the request was granted, and to provide some information as to the reason for any denial in the \refapi{pmix_info_cbfunc_t} array of \refstruct{pmix_info_t} structures.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -368,6 +516,72 @@ job. Various watchdog methods have been developed for detecting this situation, 
 from the application and monitoring a specified file for changes in size and/or modification time.
 
 At the request of \ac{SMS} vendors and members, a monitoring support interface has been included in the PMIx v2 standard. The defined \ac{API} allows applications to request monitoring, directing what is to be monitored, the frequency of the associated check, whether or not the application is to be notified (via the event notification subsystem) of stall detection, and other characteristics of the operation. In addition, heartbeat and file monitoring methods have been included in the \ac{PRI} but are active only when requested.
+
+%%%%%%%%%%%
+\subsection{\code{PMIx_Process_monitor}}
+\declareapi{PMIx_Process_monitor}
+
+%%%%
+\summary
+
+Request that application processes be monitored.
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+pmix_status_t
+PMIx_Process_monitor(const pmix_info_t *monitor, pmix_status_t error,
+                     const pmix_info_t directives[], size_t ndirs)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{monitor}{info (handle)}
+\argin{error}{status (integer)}
+\argin{directives}{Array of info structures (array of handles)}
+\argin{ndirs}{Number of elements in the \refarg{directives} array (integer)}
+\end{arglist}
+
+Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant.
+
+\optattrstart
+The following attributes may be implemented by a \ac{PMIx} library or by the host environment. If supported by the \ac{PMIx} server library, then the library must not pass the supported attributes to the host environment. All attributes not directly supported by the server library must be passed to the host environment if it supports this operation, and the library is \textit{required} to add the \refPRIAttributeItem{PMIX_USERID} and the \refPRIAttributeItem{PMIX_GRPID} attributes of the requesting process:
+
+\pastePRIAttributeItem{PMIX_MONITOR_ID}
+\pastePRIAttributeItem{PMIX_MONITOR_CANCEL}
+\pastePRIAttributeItem{PMIX_MONITOR_APP_CONTROL}
+\pastePRIAttributeItem{PMIX_MONITOR_HEARTBEAT}
+\pastePRIAttributeItem{PMIX_MONITOR_HEARTBEAT_TIME}
+\pastePRIAttributeItem{PMIX_MONITOR_HEARTBEAT_DROPS}
+\pastePRIAttributeItem{PMIX_MONITOR_FILE}
+\pastePRIAttributeItem{PMIX_MONITOR_FILE_SIZE}
+\pastePRIAttributeItem{PMIX_MONITOR_FILE_ACCESS}
+\pastePRIAttributeItem{PMIX_MONITOR_FILE_MODIFY}
+\pastePRIAttributeItem{PMIX_MONITOR_FILE_CHECK_TIME}
+\pastePRIAttributeItem{PMIX_MONITOR_FILE_DROPS}
+
+\optattrend
+
+%%%%
+\descr
+
+Request that application processes be monitored via several possible methods.
+For example, that the server monitor this process for periodic heartbeats as an indication that the process has not become ``wedged''.
+When a monitor detects the specified alarm condition, it will generate an event notification using the provided error code and passing along any available relevant information.
+It is up to the caller to register a corresponding event handler.
+
+The \refarg{monitor} argument is an attribute indicating the type of monitor being requested.
+For example, \refattr{PMIX_MONITOR_FILE} to indicate that the requestor is asking that a file be monitored.
+
+The \refarg{error} argument is the status code to be used when generating an event notification alerting that the monitor has been triggered.
+The range of the notification defaults to \refconst{PMIX_RANGE_NAMESPACE}.
+This can be changed by providing a \refconst{PMIX_RANGE} directive.
+
+The \refarg{directives} argument characterizes the monitoring request (e.g., monitor file size) and frequency of checking to be done
+
 
 %%%%%%%%%%%
 \subsection{\code{PMIx_Process_monitor_nb}}
@@ -423,22 +637,8 @@ The following attributes may be implemented by a \ac{PMIx} library or by the hos
 %%%%
 \descr
 
-Request that application processes be monitored via several possible methods.
-For example, that the server monitor this process for periodic heartbeats as an indication that the process has not become ``wedged''.
-When a monitor detects the specified alarm condition, it will generate an event notification using the provided error code and passing along any available relevant information.
-It is up to the caller to register a corresponding event handler.
 
-The \refarg{monitor} argument is an attribute indicating the type of monitor being requested.
-For example, \refattr{PMIX_MONITOR_FILE} to indicate that the requestor is asking that a file be monitored.
-
-The \refarg{error} argument is the status code to be used when generating an event notification alerting that the monitor has been triggered.
-The range of the notification defaults to \refconst{PMIX_RANGE_NAMESPACE}.
-This can be changed by providing a \refconst{PMIX_RANGE} directive.
-
-The \refarg{directives} argument characterizes the monitoring request (e.g., monitor file size) and frequency of checking to be done
-
-The \refarg{cbfunc} function provides a \refarg{status} to indicate whether or not the request was granted, and to provide some information as to the reason for any denial in the \refapi{pmix_info_cbfunc_t} array of \refstruct{pmix_info_t} structures.
-
+Non-blocking form of the \refapi{PMIx_Process_monitor} \ac{API}. The \refarg{cbfunc} function provides a \refarg{status} to indicate whether or not the request was granted, and to provide some information as to the reason for any denial in the \refapi{pmix_info_cbfunc_t} array of \refstruct{pmix_info_t} structures.
 
 %%%%%%%%%%%
 \subsection{\code{PMIx_Heartbeat}}
@@ -455,7 +655,7 @@ Send a heartbeat to the \ac{PMIx} server library
 \versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
-void PMIx_Heartbeat(void)
+PMIx_Heartbeat(void)
 \end{codepar}
 \cspecificend
 
@@ -473,6 +673,87 @@ A simplified macro wrapping \refapi{PMIx_Process_monitor_nb} that sends a heartb
 
 The logging interface supports posting information by applications and SMS elements to persistent storage. This function is \textit{not} intended for output of computational results, but rather for reporting status and saving state information such as inserting computation progress reports into the application's \ac{SMS} job log or error reports to the local syslog.
 
+\subsection{\code{PMIx_Log}}
+\declareapi{PMIx_Log}
+
+%%%%
+\summary
+
+Log data to a data service.
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+pmix_status_t
+PMIx_Log(const pmix_info_t data[], size_t ndata,
+            const pmix_info_t directives[], size_t ndirs)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{data}{Array of info structures (array of handles)}
+\argin{ndata}{Number of elements in the \refarg{data} array (\code{size_t})}
+\argin{directives}{Array of info structures (array of handles)}
+\argin{ndirs}{Number of elements in the \refarg{directives} array (\code{size_t})}
+\end{arglist}
+
+Return codes are one of the following:
+
+\begin{constantdesc}
+    \item \refconst{PMIX_SUCCESS} The logging request was successful.
+    \item \refconst{PMIX_ERR_BAD_PARAM} The logging request contains at least one incorrect entry.
+    \item \refconst{PMIX_ERR_NOT_SUPPORTED} The \ac{PMIx} implementation or host environment does not support this function.
+\end{constantdesc}
+
+\reqattrstart
+If the \ac{PMIx} library does not itself perform this operation, then it is required to pass any attributes provided by the client to the host environment for processing. In addition, it must include the following attributes in the passed \refarg{info} array:
+
+\pastePRIAttributeItem{PMIX_USERID}
+\pastePRIAttributeItem{PMIX_GRPID}
+
+Host environments or \ac{PMIx} libraries that implement support for this operation are required to support the following attributes:
+
+\pastePRIAttributeItem{PMIX_LOG_STDERR}
+\pastePRIAttributeItem{PMIX_LOG_STDOUT}
+\pastePRIAttributeItem{PMIX_LOG_SYSLOG}
+\pastePRIAttributeItem{PMIX_LOG_LOCAL_SYSLOG}
+\pastePRIAttributeItem{PMIX_LOG_GLOBAL_SYSLOG}
+\pastePRIAttributeItem{PMIX_LOG_SYSLOG_PRI}
+\pastePRIAttributeItem{PMIX_LOG_ONCE}
+
+\reqattrend
+
+\optattrstart
+The following attributes are optional for host environments or \ac{PMIx} libraries that support this operation:
+
+\pastePRIAttributeItem{PMIX_LOG_SOURCE}
+\pastePRIAttributeItem{PMIX_LOG_TIMESTAMP}
+\pastePRIAttributeItem{PMIX_LOG_GENERATE_TIMESTAMP}
+\pastePRIAttributeItem{PMIX_LOG_TAG_OUTPUT}
+\pastePRIAttributeItem{PMIX_LOG_TIMESTAMP_OUTPUT}
+\pastePRIAttributeItem{PMIX_LOG_XML_OUTPUT}
+\pastePRRTEAttributeItem{PMIX_LOG_EMAIL}
+\pastePRRTEAttributeItem{PMIX_LOG_EMAIL_ADDR}
+\pastePRRTEAttributeItem{PMIX_LOG_EMAIL_SUBJECT}
+\pastePRRTEAttributeItem{PMIX_LOG_EMAIL_MSG}
+\pasteAttributeItem{PMIX_LOG_JOB_RECORD}
+\pasteAttributeItem{PMIX_LOG_GLOBAL_DATASTORE}
+
+\optattrend
+
+%%%%
+\descr
+
+Log data subject to the services offered by the host environment. The data to be logged is provided in the \refarg{data} array. The (optional) \refarg{directives} can be used to direct the choice of logging channel.
+
+\adviceuserstart
+It is strongly recommended that the \refapi{PMIx_Log} API not be used by applications for streaming data as it is not a ``performant'' transport and can perturb the application since it involves the local \ac{PMIx} server and host \ac{SMS} daemon. Note that a return of \refconst{PMIX_SUCCESS} only denotes that the data was successfully handed to the appropriate system call (for local channels) or the host environment and does not indicate receipt at the final destination.
+\adviceuserend
+
+%
 \subsection{\code{PMIx_Log_nb}}
 \declareapi{PMIx_Log_nb}
 
@@ -506,9 +787,10 @@ PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
 Return codes are one of the following:
 
 \begin{constantdesc}
-\item \refconst{PMIX_SUCCESS} The logging request is valid and is being processed. The resulting status from the operation will be provided in the callback function.
-\item \refconst{PMIX_ERR_BAD_PARAM} The logging request contains at least one incorrect entry that prevents it from being processed. The callback function will \emph{not} be called.
-\item \refconst{PMIX_ERR_NOT_SUPPORTED} The \ac{PMIx} implementation does not support this function. The callback function will \emph{not} be called.
+    \item \refconst{PMIX_SUCCESS} The logging request is valid and is being processed. The resulting status from the operation will be provided in the callback function.
+    \item \refconst{PMIX_ERR_BAD_PARAM} The logging request contains at least one incorrect entry that prevents it from being processed. The callback function will \emph{not} be called.
+    \item \refconst{PMIX_ERR_NOT_SUPPORTED} The \ac{PMIx} implementation or host environment does not support this function. The callback function will \emph{not} be called.
+    \item \refconst{PMIX_OPERATION_SUCCEEDED} The request has been completed - the callback function will \emph{not} be called.
 \end{constantdesc}
 
 \reqattrstart
@@ -517,22 +799,33 @@ If the \ac{PMIx} library does not itself perform this operation, then it is requ
 \pastePRIAttributeItem{PMIX_USERID}
 \pastePRIAttributeItem{PMIX_GRPID}
 
-Host environments that implement support for this operation are required to support the following attributes:
+Host environments or \ac{PMIx} libraries that implement support for this operation are required to support the following attributes:
 
 \pastePRIAttributeItem{PMIX_LOG_STDERR}
 \pastePRIAttributeItem{PMIX_LOG_STDOUT}
 \pastePRIAttributeItem{PMIX_LOG_SYSLOG}
+\pastePRIAttributeItem{PMIX_LOG_LOCAL_SYSLOG}
+\pastePRIAttributeItem{PMIX_LOG_GLOBAL_SYSLOG}
+\pastePRIAttributeItem{PMIX_LOG_SYSLOG_PRI}
+\pastePRIAttributeItem{PMIX_LOG_ONCE}
 
 \reqattrend
 
 \optattrstart
-The following attributes are optional for host environments that support this operation:
+The following attributes are optional for host environments or \ac{PMIx} libraries that support this operation:
 
-\pastePRRTEAttributeItem{PMIX_LOG_MSG}
+\pastePRIAttributeItem{PMIX_LOG_SOURCE}
+\pastePRIAttributeItem{PMIX_LOG_TIMESTAMP}
+\pastePRIAttributeItem{PMIX_LOG_GENERATE_TIMESTAMP}
+\pastePRIAttributeItem{PMIX_LOG_TAG_OUTPUT}
+\pastePRIAttributeItem{PMIX_LOG_TIMESTAMP_OUTPUT}
+\pastePRIAttributeItem{PMIX_LOG_XML_OUTPUT}
 \pastePRRTEAttributeItem{PMIX_LOG_EMAIL}
 \pastePRRTEAttributeItem{PMIX_LOG_EMAIL_ADDR}
 \pastePRRTEAttributeItem{PMIX_LOG_EMAIL_SUBJECT}
 \pastePRRTEAttributeItem{PMIX_LOG_EMAIL_MSG}
+\pasteAttributeItem{PMIX_LOG_JOB_RECORD}
+\pasteAttributeItem{PMIX_LOG_GLOBAL_DATASTORE}
 
 \optattrend
 
@@ -543,7 +836,7 @@ Log data subject to the services offered by the host environment. The data to be
 The callback function will be executed when the log operation has been completed. The \refarg{data} and \refarg{directives} arrays must be maintained until the callback is provided.
 
 \adviceuserstart
-It is strongly recommended that the \refapi{PMIx_Log_nb} API not be used by applications for streaming data as it is not a ``performant'' transport and can perturb the application since it involves the local \ac{PMIx} server and host \ac{SMS} daemon.
+It is strongly recommended that the \refapi{PMIx_Log_nb} API not be used by applications for streaming data as it is not a ``performant'' transport and can perturb the application since it involves the local \ac{PMIx} server and host \ac{SMS} daemon. Note that a return of \refconst{PMIX_SUCCESS} only denotes that the data was successfully handed to the appropriate system call (for local channels) or the host environment and does not indicate receipt at the final destination.
 \adviceuserend
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/Chap_API_Proc_Mgmt.tex
+++ b/Chap_API_Proc_Mgmt.tex
@@ -529,4 +529,199 @@ We recommend that implementation of the \refattr{PMIX_TIMEOUT} attribute be left
 Nonblocking \refapi{PMIx_Disconnect} routine. The callback function is called once all processes identified in \refarg{procs} have called either \refapi{PMIx_Disconnect_nb} or its blocking version, \textit{and} the host environment has completed any required supporting operations.
 
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\section{IO Forwarding}
+\label{chap:api_proc_mgmt:iof}
+
+This section defines functions by which tools (e.g., debuggers) can request forwarding of input/output to/from other processes. The term ``tool'' widely refers to non-computational programs executed by the user or system administrator on a command line. Tools almost always interact with either the host environment, user applications, or both to perform administrative and support functions. For example, a debugger tool might be used to remotely control the processes of a parallel application, monitoring their behavior on a step-by-step basis.
+
+Underlying the operation of many tools is a common need to forward stdin from the tool to targeted processes, and to return stdout/stderr from those processes for display on the user’s console. Historically, each tool developer was responsible for creating their own \ac{IO} forwarding subsystem. However, with the introduction of \ac{PMIx} as a standard mechanism for interacting between applications and the host environment, it has become possible to relieve tool developers of this burden.
+
+\advicermstart
+The responsibility of the host environment in forwarding of \ac{IO} falls into the following areas:
+
+\begin{itemize}
+    \item Capturing output from specified child processes
+    \item Forwarding that output to the host of the \ac{PMIx} server library that requested it
+    \item Delivering that payload to the \ac{PMIx} server library via the \refapi{PMIx_server_IOF_deliver} \ac{API} for final disposition
+\end{itemize}
+
+It is the responsibility of the \ac{PMIx} library to buffer, format, and deliver the payload to the requesting client.
+\advicermend
+
+\adviceuserstart
+The forwarding of \ac{IO} via \ac{PMIx} requires that both the host environment and the tool support \ac{PMIx}, but does not impose any similar requirements on the application itself.
+\adviceuserend
+
+
+%%%%%%%%%%%
+\subsection{\code{PMIx_IOF_pull}}
+\declareapi{PMIx_IOF_pull}
+
+%%%%
+\summary
+
+Register to receive output forwarded from a remote process.
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+pmix_status_t
+PMIx_IOF_pull(const pmix_proc_t procs[], size_t nprocs,
+              const pmix_info_t directives[], size_t ndirs,
+              pmix_iof_channel_t channel, pmix_iof_cbfunc_t cbfunc,
+              pmix_hdlr_reg_cbfunc_t regcbfunc, void *regcbdata)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{procs}{Array of proc structures identifying desired source processes (array of handles)}
+\argin{nprocs}{Number of elements in the \refarg{procs} array (integer)}
+\argin{directives}{Array of \refstruct{pmix_info_t} structures (array of handles)}
+\argin{ndirs}{Number of elements in the \refarg{directives} array (integer)}
+\argin{channel}{Bitmask of IO channels included in the request (\refstruct{pmix_iof_channel_t})}
+\argin{cbfunc}{Callback function for delivering relevant output (function reference)}
+\argin{regcbfunc}{Function to be called when registration is completed (function reference)}
+\argin{regcbdata}{Data to be passed to the \refarg{regcbfunc} callback function (memory reference)}
+\end{arglist}
+
+Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{regcbfunc} will \textit{not} be called
+
+\reqattrstart
+The following attributes are required for \ac{PMIx} libraries that support \ac{IO} forwarding:
+
+\pastePRIAttributeItem{PMIX_IOF_CACHE_SIZE}
+\pastePRIAttributeItem{PMIX_IOF_DROP_OLDEST}
+\pastePRIAttributeItem{PMIX_IOF_DROP_NEWEST}
+
+\reqattrend
+
+\optattrstart
+The following attributes are optional for \ac{PMIx} libraries that support \ac{IO} forwarding:
+
+\pastePRIAttributeItem{PMIX_IOF_BUFFERING_SIZE}
+\pastePRIAttributeItem{PMIX_IOF_BUFFERING_TIME}
+\pastePRIAttributeItem{PMIX_IOF_TAG_OUTPUT}
+\pastePRIAttributeItem{PMIX_IOF_TIMESTAMP_OUTPUT}
+\pastePRIAttributeItem{PMIX_IOF_XML_OUTPUT}
+
+\optattrend
+
+%%%%
+\descr
+
+Register to receive output forwarded from a remote process.
+
+\adviceuserstart
+Providing a \code{NULL} function pointer for the \refarg{cbfunc} parameter will cause output for the indicated channels to be written to their corresponding stdout/stderr file descriptors. Use of \refconst{PMIX_RANK_WILDCARD} to specify all processes in a given namespace is supported but should be used carefully due to bandwidth considerations.
+\adviceuserend
+
+%%%%%%%%%%%
+\subsection{\code{PMIx_IOF_deregister}}
+\declareapi{PMIx_IOF_deregister}
+
+%%%%
+\summary
+
+Deregister from output forwarded from a remote process.
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+pmix_status_t
+PMIx_IOF_deregister(size_t iofhdlr,
+                    const pmix_info_t directives[], size_t ndirs,
+                    pmix_op_cbfunc_t cbfunc, void *cbdata)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{iofhdlr}{Registration number returned from the call to PMIx_IOF_pull (\code{size_t})}
+\argin{directives}{Array of \refstruct{pmix_info_t} structures (array of handles)}
+\argin{ndirs}{Number of elements in the \refarg{directives} array (integer)}
+\argin{cbfunc}{Callback function to be called when deregistration has been completed. (function reference)}
+\argin{cbdata}{Data to be passed to the \refarg{cbfunc} callback function (memory reference)}
+\end{arglist}
+
+Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{cbfunc} will \textit{not} be called
+
+%%%%
+\descr
+
+Deregister from output forwarded from a remote process
+
+\adviceimplstart
+Any currently buffered \ac{IO} should be flushed upon receipt of a deregistration request. All received \ac{IO} after receipt of the request shall be discarded.
+\adviceimplend
+
+
+%%%%%%%%%%%
+\subsection{\code{PMIx_IOF_push}}
+\declareapi{PMIx_IOF_push}
+
+%%%%
+\summary
+
+Push data collected locally (typically from stdin or a file) to stdin of the target recipients.
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+pmix_status_t
+PMIx_IOF_push(const pmix_proc_t targets[], size_t ntargets,
+              pmix_byte_object_t *bo,
+              const pmix_info_t directives[], size_t ndirs,
+              pmix_op_cbfunc_t cbfunc, void *cbdata)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{targets}{Array of proc structures identifying desired target processes (array of handles)}
+\argin{ntargets}{Number of elements in the \refarg{targets} array (integer)}
+\argin{bo}{Pointer to \refstruct{pmix_byte_object_t} containing the payload to be delivered (handle)}
+\argin{directives}{Array of \refstruct{pmix_info_t} structures (array of handles)}
+\argin{ndirs}{Number of elements in the \refarg{directives} array (integer)}
+\argin{directives}{Array of \refstruct{pmix_info_t} structures (array of handles)}
+\argin{cbfunc}{Callback function to be called when operation has been completed. (function reference)}
+\argin{cbdata}{Data to be passed to the \refarg{cbfunc} callback function (memory reference)}
+\end{arglist}
+
+Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{cbfunc} will \textit{not} be called
+
+\reqattrstart
+The following attributes are required for \ac{PMIx} libraries that support \ac{IO} forwarding:
+
+\pastePRIAttributeItem{PMIX_IOF_CACHE_SIZE}
+\pastePRIAttributeItem{PMIX_IOF_DROP_OLDEST}
+\pastePRIAttributeItem{PMIX_IOF_DROP_NEWEST}
+
+\reqattrend
+
+\optattrstart
+The following attributes are optional for \ac{PMIx} libraries that support \ac{IO} forwarding:
+
+\pastePRIAttributeItem{PMIX_IOF_BUFFERING_SIZE}
+\pastePRIAttributeItem{PMIX_IOF_BUFFERING_TIME}
+
+\optattrend
+
+%%%%
+\descr
+
+Push data collected locally (typically from stdin or a file) to stdin of the target recipients.
+
+\adviceuserstart
+Execution of the \refarg{cbfunc} callback function serves as notice that the \ac{PMIx} library no longer requires the caller to maintain the \refarg{bo} data object - it does \textit{not} indicate delivery of the payload to the targets. Use of \refconst{PMIX_RANK_WILDCARD} to specify all processes in a given namespace is supported but should be used carefully due to bandwidth considerations.
+\adviceuserend
+
+

--- a/Chap_API_Security.tex
+++ b/Chap_API_Security.tex
@@ -1,0 +1,143 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Chapter: Security
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\chapter{Security}
+\label{chap:api_security}
+
+Applications and tools often interact with each other in ways that require verification of the identity of the user making the request, and access to that user's relevant authorizations. This is particularly important when tools connect directly to a system-level \ac{PMIx} server that may be operating at a privileged level. A variety of system management software packages provide this service, but the lack of standardized interfaces makes portability problematic.
+
+This section defines two \ac{PMIx} client-side \acp{API} for this purpose. These are most likely to be used by user-space applications/tools, but are not restricted to that realm.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\section{Obtaining Credentials}
+\label{chap:api_security:obtain}
+
+The \ac{API} for obtaining a credential is defined as a non-blocking operation since the host environment may have to contact a remote credential service. The definition takes into account the potential that the returned credential could be sent via some mechanism to another application that resides in an environment using a different security mechanism. Thus, provision is made for the system to return additional information (e.g., the identity of the issuing agent) outside of the credential itself and visible to the application.
+
+%%%%%%%%%%%
+\subsection{\code{PMIx_Get_credential}}
+\declareapi{PMIx_Get_credential}
+
+%%%%
+\summary
+
+Request a credential from the \ac{PMIx} server library or the host environment
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+pmix_status_t PMIx_Get_credential(const pmix_info_t info[], size_t ninfo,
+                             pmix_credential_cbfunc_t cbfunc, void *cbdata)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{info}{Array of \refattr{pmix_info_t} structures (array of handles)}
+\argin{ninfo}{Number of elements in the \refarg{info} array (\code{size_t})}
+\argin{cbfunc}{Callback function to return credential (function reference)}
+\argin{cbdata}{Data to be passed to the callback function (memory reference)}
+\end{arglist}
+
+Returns one of the following:
+
+\begin{itemize}
+    \item \refconst{PMIX_SUCCESS}, indicating that the request has been communicated to the local \ac{PMIx} server - result will be returned in the provided \refarg{cbfunc}
+    \item a \ac{PMIx} error constant indicating either an error in the input or that the request is unsupported - the \refarg{cbfunc} will \textit{not} be called
+\end{itemize}
+
+\reqattrstart
+\ac{PMIx} libraries are not required to directly support any attributes for this function. However, if the request cannot be processed by the library itself, then any attributes provided by the client must be passed to the host environment for processing. In addition, the following attributes are required to be included in the passed \refarg{info} array:
+
+\pastePRIAttributeItem{PMIX_USERID}
+\pastePRIAttributeItem{PMIX_GRPID}
+
+\reqattrend
+
+\optattrstart
+The following attributes are optional for host environments that support this operation:
+
+\pasteAttributeItem{PMIX_TIMEOUT}
+
+\optattrend
+
+%%%%
+\descr
+
+Request a credential from the \ac{PMIx} server library or the host environment
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\section{Validating Credentials}
+\label{chap:api_security:validate}
+
+The \ac{API} for validating a credential is again defined as a non-blocking operation since the host environment may have to contact a remote credential service. Provision is made for the system to return additional information regarding possible authorization limitations beyond simple authentication.
+
+%%%%%%%%%%%
+\subsection{\code{PMIx_Validate_credential}}
+\declareapi{PMIx_Validate_credential}
+
+%%%%
+\summary
+
+Request validation of a credential by the \ac{PMIx} server library or the host environment
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+pmix_status_t PMIx_Validate_credential(const pmix_byte_object_t *cred,
+                             const pmix_info_t info[], size_t ninfo,
+                             pmix_validation_cbfunc_t cbfunc, void *cbdata)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{cred}{Pointer to \refstruct{pmix_byte_object_t} containing the credential (handle)}
+\argin{info}{Array of \refattr{pmix_info_t} structures (array of handles)}
+\argin{ninfo}{Number of elements in the \refarg{info} array (\code{size_t})}
+\argin{cbfunc}{Callback function to return result (function reference)}
+\argin{cbdata}{Data to be passed to the callback function (memory reference)}
+\end{arglist}
+
+Returns one of the following:
+
+\begin{itemize}
+    \item \refconst{PMIX_SUCCESS}, indicating that the request has been communicated to the local \ac{PMIx} server - result will be returned in the provided \refarg{cbfunc}
+    \item a \ac{PMIx} error constant indicating either an error in the input or that the request is unsupported - the \refarg{cbfunc} will \textit{not} be called
+\end{itemize}
+
+\reqattrstart
+\ac{PMIx} libraries are not required to directly support any attributes for this function. However, if the request cannot be processed by the library itself, then any attributes provided by the client must be passed to the host environment for processing. In addition, the following attributes are required to be included in the passed \refarg{info} array:
+
+\pastePRIAttributeItem{PMIX_USERID}
+\pastePRIAttributeItem{PMIX_GRPID}
+
+\reqattrend
+
+\optattrstart
+The following attributes are optional for host environments that support this operation:
+
+\pasteAttributeItem{PMIX_TIMEOUT}
+
+\optattrend
+
+\adviceimplstart
+We recommend that implementation of the \refattr{PMIX_TIMEOUT} attribute be left to the host environment due to race condition considerations between completion of the operation versus internal timeout in the \ac{PMIx} server library. Implementers that choose to support \refattr{PMIX_TIMEOUT} directly in the \ac{PMIx} server library must take care to resolve the race condition and should avoid passing \refattr{PMIX_TIMEOUT} to the host environment so that multiple competing timeouts are not created.
+\adviceimplend
+
+
+%%%%
+\descr
+
+Request validation of a credential by the \ac{PMIx} server library or the host environment
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -471,6 +471,31 @@ PMIx_server_setup_application(const pmix_nspace_t nspace,
 
 Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant.
 
+\reqattrstart
+\ac{PMIx} libraries that support this operation are required to support the following:
+
+\pastePRIAttributeItem{PMIX_SETUP_APP_ENVARS}
+\pastePRIAttributeItem{PMIX_SETUP_APP_NONENVARS}
+\pastePRIAttributeItem{PMIX_SETUP_APP_ALL}
+\pastePRIAttributeItem{PMIX_ALLOC_NETWORK}
+\pastePRIAttributeItem{PMIX_ALLOC_NETWORK_ID}
+\pastePRIAttributeItem{PMIX_ALLOC_NETWORK_SEC_KEY}
+\pastePRIAttributeItem{PMIX_ALLOC_NETWORK_TYPE}
+\pastePRIAttributeItem{PMIX_ALLOC_NETWORK_PLANE}
+\pastePRIAttributeItem{PMIX_ALLOC_NETWORK_ENDPTS}
+\pastePRIAttributeItem{PMIX_ALLOC_NETWORK_ENDPTS_NODE}
+
+\reqattrend
+
+\optattrstart
+\ac{PMIx} libraries that support this operation may support the following:
+
+\pastePRIAttributeItem{PMIX_ALLOC_BANDWIDTH}
+\pastePRIAttributeItem{PMIX_ALLOC_NETWORK_QOS}
+\pastePRIAttributeItem{PMIX_ALLOC_TIME}
+
+\optattrend
+
 %%%%
 \descr
 
@@ -481,8 +506,6 @@ Host environments are \textit{required} to execute this operation prior to launc
 \advicermend
 
 This is defined as a non-blocking operation in case contributing subsystems need to perform some potentially time consuming action (e.g., query a remote service) before responding. The returned data must be distributed by the \ac{RM} and subsequently delivered to the local \ac{PMIx} server on each node where application processes will execute prior to initiating execution of those processes.
-
-In the callback function, the returned \refarg{info} array is owned by the \ac{PMIx} server library and will be free'd when the provided \refarg{cbfunc} is called.
 
 \adviceimplstart
 Support for harvesting of environmental variables and providing of local configuration information by the \ac{PMIx} implementation is optional.
@@ -514,7 +537,7 @@ PMIx_server_setup_local_support(const pmix_nspace_t nspace,
 \begin{arglist}
 \argin{nspace}{Namespace (string)}
 \argin{info}{Array of info structures (array of handles)}
-\argin{ninfo}{Number of elements in the \refarg{info} array (integer)}
+\argin{ninfo}{Number of elements in the \refarg{info} array (\code{size_t})}
 \argin{cbfunc}{Callback function \refapi{pmix_op_cbfunc_t} (function reference)}
 \argin{cbdata}{Data to be passed to the callback function (memory reference)}
 \end{arglist}
@@ -530,6 +553,124 @@ Provide a function by which the local \ac{PMIx} server can perform any applicati
 \advicermstart
 Host environments are \textit{required} to execute this operation prior to starting any local application processes from the specified namespace.
 \advicermend
+
+%%%%%%%%%%%
+\subsection{\code{PMIx_server_IOF_deliver}}
+\declareapi{PMIx_server_IOF_deliver}
+
+%%%%
+\summary
+
+Provide a function by which the host environment can pass forwarded \ac{IO} to the \ac{PMIx} server library for distribution to its clients.
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+pmix_status_t
+PMIx_server_IOF_deliver(const pmix_proc_t *source,
+                        pmix_iof_channel_t channel,
+                        const pmix_byte_object_t *bo,
+                        const pmix_info_t info[], size_t ninfo,
+                        pmix_op_cbfunc_t cbfunc, void *cbdata);
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{source}{Pointer to \refstruct{pmix_proc_t} identifying source of the \ac{IO} (handle)}
+\argin{channel}{\ac{IO} channel of the data (\refstruct{pmix_iof_channel_t})}
+\argin{bo}{Pointer to \refstruct{pmix_byte_object_t} containing the payload to be delivered (handle)}
+\argin{info}{Array of \refstruct{pmix_info_t} metadata describing the data (array of handles)}
+\argin{ninfo}{Number of elements in the \refarg{info} array (\code{size_t})}
+\argin{cbfunc}{Callback function \refapi{pmix_op_cbfunc_t} (function reference)}
+\argin{cbdata}{Data to be passed to the callback function (memory reference)}
+\end{arglist}
+
+Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{cbfunc} will \textit{not} be called
+
+%%%%
+\descr
+
+Provide a function by which the host environment can pass forwarded \ac{IO} to the \ac{PMIx} server library for distribution to its clients. The \ac{PMIx} server library is responsible for determining which of its clients have actually registered for the provided data and delivering it. The \refarg{cbfunc} callback function will be called once the \ac{PMIx} server library no longer requires access to the provided data.
+
+%%%%%%%%%%%
+\subsection{\code{PMIx_server_collect_inventory}}
+\declareapi{PMIx_server_collect_inventory}
+
+%%%%
+\summary
+
+Collect inventory of resources on a node
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+pmix_status_t
+PMIx_server_collect_inventory(const pmix_info_t directives[], size_t ndirs,
+                              pmix_info_cbfunc_t cbfunc, void *cbdata);
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{directives}{Array of \refstruct{pmix_info_t} directing the request (array of handles)}
+\argin{ndirs}{Number of elements in the \refarg{directives} array (\code{size_t})}
+\argin{cbfunc}{Callback function to return collected data (function reference)}
+\argin{cbdata}{Data to be passed to the callback function (memory reference)}
+\end{arglist}
+
+Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{cbfunc} will \textit{not} be called
+
+%%%%
+\descr
+
+Provide a function by which the host environment can request its \ac{PMIx} server library collect an inventory of local resources. Supported resources depends upon the \ac{PMIx} implementation, but may include the local node topology and network interfaces.
+
+\advicermstart
+This is a non-blocking \ac{API} as it may involve somewhat lengthy operations to obtain the requested information. Inventory collection is expected to be a rare event – at system startup and upon command from a system administrator. Inventory updates are expected to involve a smaller operation involving only the changed information. For example, replacement of a node would generate an event to notify the scheduler with an inventory update without invoking a global inventory operation.
+\advicermend
+
+%%%%%%%%%%%
+\subsection{\code{PMIx_server_IOF_deliver}}
+\declareapi{PMIx_server_IOF_deliver}
+
+%%%%
+\summary
+
+Pass collected inventory to the \ac{PMIx} server library for storage
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+pmix_status_t
+PMIx_server_deliver_inventory(const pmix_info_t info[], size_t ninfo,
+                              const pmix_info_t directives[], size_t ndirs,
+                              pmix_op_cbfunc_t cbfunc, void *cbdata);
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{info}{Array of \refstruct{pmix_info_t} containing the inventory (array of handles)}
+\argin{ninfo}{Number of elements in the \refarg{info} array (\code{size_t})}
+\argin{directives}{Array of \refstruct{pmix_info_t} directing the request (array of handles)}
+\argin{ndirs}{Number of elements in the \refarg{directives} array (\code{size_t})}
+\argin{cbfunc}{Callback function \refapi{pmix_op_cbfunc_t} (function reference)}
+\argin{cbdata}{Data to be passed to the callback function (memory reference)}
+\end{arglist}
+
+Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{cbfunc} will \textit{not} be called
+
+%%%%
+\descr
+
+Provide a function by which the host environment can pass inventory information obtained from a node to the \ac{PMIx} server library for storage. Inventory data is subsequently used by the \ac{PMIx} server library for allocations in response to \refapi{PMIx_server_setup_application}, and may be available to the library's host via the \ac{PMIx_Get} \ac{API} (depending upon \ac{PMIx} implementation). The \refarg{cbfunc} callback function will be called once the \ac{PMIx} server library no longer requires access to the provided data.
 
 %%%%%%%%%%%
 \section{Server Function Pointers}
@@ -566,7 +707,7 @@ List of function pointers that a PMIx server passes to \refapi{PMIx_server_init}
 
 \cspecificstart
 \begin{codepar}
-typedef struct pmix_server_module_2_0_0_t {
+typedef struct pmix_server_module_3_0_0_t {
     /* v1x interfaces */
     pmix_server_client_connected_fn_t   client_connected;
     pmix_server_client_finalized_fn_t   client_finalized;
@@ -590,6 +731,11 @@ typedef struct pmix_server_module_2_0_0_t {
     pmix_server_alloc_fn_t              allocate;
     pmix_server_job_control_fn_t        job_control;
     pmix_server_monitor_fn_t            monitor;
+    /* v3x interfaces */
+    pmix_server_get_cred_fn_t           get_credential;
+    pmix_server_validate_cred_fn_t      validate_credential;
+    pmix_server_iof_fn_t                iof_pull;
+    pmix_server_stdin_fn_t              push_stdin;
 } pmix_server_module_t;
 \end{codepar}
 \cspecificend
@@ -1752,7 +1898,7 @@ typedef pmix_status_t (*pmix_server_alloc_fn_t)(
 \argin{cbdata}{Data to be passed to the callback function (memory reference)}
 \end{arglist}
 
-Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant.
+Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{cbfunc} will \textit{not} be called
 
 \reqattrstart
 \ac{PMIx} libraries are required to pass any provided attributes to the host environment for processing. In addition, the following attributes are required to be included in the passed \refarg{info} array:
@@ -1836,10 +1982,10 @@ typedef pmix_status_t (*pmix_server_job_control_fn_t)(
 \argin{cbdata}{Data to be passed to the callback function (memory reference)}
 \end{arglist}
 
-Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant.
+Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{cbfunc} will \textit{not} be called
 
 \reqattrstart
-\ac{PMIx} libraries are required to pass any provided attributes to the host environment for processing. In addition, the following attributes are required to be included in the passed \refarg{info} array:
+\ac{PMIx} libraries are required to pass any attributes provided by the client to the host environment for processing. In addition, the following attributes are required to be included in the passed \refarg{info} array:
 
 \pastePRIAttributeItem{PMIX_USERID}
 \pastePRIAttributeItem{PMIX_GRPID}
@@ -1897,7 +2043,6 @@ Request that a client be monitored for activity.
 \versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
-/* Request that a client be monitored for activity */
 typedef pmix_status_t (*pmix_server_monitor_fn_t)(
                              const pmix_proc_t *requestor,
                              const pmix_info_t *monitor, pmix_status_t error,
@@ -1919,7 +2064,7 @@ typedef pmix_status_t (*pmix_server_monitor_fn_t)(
 Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. This entry point is only called for monitoring requests that are not directly supported by the \ac{PRI}.
 
 \reqattrstart
-If supported by the \ac{PMIx} server library, then the library must not pass any supported attributes to the host environment. All attributes not directly supported by the server library must be passed to the host environment if it provides this module entry. In addition, the following attributes are required to be included in the passed \refarg{info} array:
+If supported by the \ac{PMIx} server library, then the library must not pass any supported attributes to the host environment. Any attributes provided by the client that are not directly supported by the server library must be passed to the host environment if it provides this module entry. In addition, the following attributes are required to be included in the passed \refarg{info} array:
 
 \pastePRIAttributeItem{PMIX_USERID}
 \pastePRIAttributeItem{PMIX_GRPID}
@@ -1929,7 +2074,7 @@ Host environments are not required to support any specific monitoring attributes
 \reqattrend
 
 \optattrstart
-The following attributes may be implemented by a  host environment.
+The following attributes may be implemented by a host environment.
 
 \pastePRIAttributeItem{PMIX_MONITOR_ID}
 \pastePRIAttributeItem{PMIX_MONITOR_CANCEL}
@@ -1950,6 +2095,268 @@ The following attributes may be implemented by a  host environment.
 \descr
 
 Request that a client be monitored for activity.
+
+\advicermstart
+If this module entry is provided and called by the \ac{PMIx} server library, then the host environment must either provide the requested services or return \refconst{PMIX_ERR_NOT_SUPPORTED} to the provided \refarg{cbfunc}.
+\advicermend
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%  v3 Module Functions
+%%%%%%%%%%%
+\subsection{\code{pmix_server_get_cred_fn_t}}
+\declareapi{pmix_server_get_cred_fn_t}
+
+%%%%
+\summary
+
+Request a credential from the host environment
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+typedef pmix_status_t (*pmix_server_get_cred_fn_t)(
+                             const pmix_proc_t *proc,
+                             const pmix_info_t directives[], size_t ndirs,
+                             pmix_credential_cbfunc_t cbfunc, void *cbdata);
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{proc}{\refstruct{pmix_proc_t} structure of requesting process (handle)}
+\argin{directives}{Array of info structures (array of handles)}
+\argin{ndirs}{Number of elements in the \refarg{info} array (integer)}
+\argin{cbfunc}{Callback function to return the credential (function reference)}
+\argin{cbdata}{Data to be passed to the callback function (memory reference)}
+\end{arglist}
+
+Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{cbfunc} will \textit{not} be called
+
+\reqattrstart
+If the \ac{PMIx} library does not itself provide the requested credential, then it is required to pass any attributes provided by the client to the host environment for processing. In addition, it must include the following attributes in the passed \refarg{info} array:
+
+\pastePRIAttributeItem{PMIX_USERID}
+\pastePRIAttributeItem{PMIX_GRPID}
+
+\reqattrend
+
+\optattrstart
+The following attributes are optional for host environments that support this operation:
+
+\pasteAttributeItem{PMIX_CRED_TYPE}
+\pasteAttributeItem{PMIX_TIMEOUT}
+
+\optattrend
+
+\adviceimplstart
+We recommend that implementation of the \refattr{PMIX_TIMEOUT} attribute be left to the host environment due to race condition considerations between completion of the operation versus internal timeout in the \ac{PMIx} server library. Implementers that choose to support \refattr{PMIX_TIMEOUT} directly in the \ac{PMIx} server library must take care to resolve the race condition and should avoid passing \refattr{PMIX_TIMEOUT} to the host environment so that multiple competing timeouts are not created.
+\adviceimplend
+
+
+%%%%
+\descr
+
+Request a credential from the host environment
+
+\advicermstart
+If this module entry is provided and called by the \ac{PMIx} server library, then the host environment must either provide the requested credential in the callback function or immediately return an error to the caller.
+\advicermend
+
+%%%%%%%%%%%
+\subsection{\code{pmix_server_validate_cred_fn_t}}
+\declareapi{pmix_server_validate_cred_fn_t}
+
+%%%%
+\summary
+
+Request validation of a credential
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+typedef pmix_status_t (*pmix_server_validate_cred_fn_t)(
+                             const pmix_proc_t *proc,
+                             const pmix_byte_object_t *cred,
+                             const pmix_info_t directives[], size_t ndirs,
+                             pmix_validation_cbfunc_t cbfunc, void *cbdata);
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{proc}{\refstruct{pmix_proc_t} structure of requesting process (handle)}
+\argin{cred}{Pointer to \refstruct{pmix_byte_object_t} containing the credential (handle)}
+\argin{directives}{Array of info structures (array of handles)}
+\argin{ndirs}{Number of elements in the \refarg{info} array (integer)}
+\argin{cbfunc}{Callback function to return the result (function reference)}
+\argin{cbdata}{Data to be passed to the callback function (memory reference)}
+\end{arglist}
+
+Returns one of the following:
+
+\begin{itemize}
+    \item \refconst{PMIX_SUCCESS}, indicating that the request is being processed by the host environment - result will be returned in the provided \refarg{cbfunc}
+    \item \refconst{PMIX_OPERATION_SUCCEEDED}, indicating that the request was immediately processed and returned \textit{success} - the \refarg{cbfunc} will \textit{not} be called
+    \item a PMIx error constant indicating either an error in the input or that the request was immediately processed and failed - the \refarg{cbfunc} will \textit{not} be called
+\end{itemize}
+
+\reqattrstart
+If the \ac{PMIx} library does not itself validate the credential, then it is required to pass any attributes provided by the client to the host environment for processing. In addition, it must include the following attributes in the passed \refarg{info} array:
+
+\pastePRIAttributeItem{PMIX_USERID}
+\pastePRIAttributeItem{PMIX_GRPID}
+
+Host environments are not required to support any specific attributes.
+
+\reqattrend
+
+\optattrstart
+The following attributes are optional for host environments that support this operation:
+
+\pasteAttributeItem{PMIX_TIMEOUT}
+
+\optattrend
+
+\adviceimplstart
+We recommend that implementation of the \refattr{PMIX_TIMEOUT} attribute be left to the host environment due to race condition considerations between completion of the operation versus internal timeout in the \ac{PMIx} server library. Implementers that choose to support \refattr{PMIX_TIMEOUT} directly in the \ac{PMIx} server library must take care to resolve the race condition and should avoid passing \refattr{PMIX_TIMEOUT} to the host environment so that multiple competing timeouts are not created.
+\adviceimplend
+
+
+%%%%
+\descr
+
+Request validation of a credential obtained from the host environment via a prior call to the \refapi{pmix_server_get_cred_fn_t} module entry.
+
+%%%%%%%%%%%
+\subsection{\code{pmix_server_iof_fn_t}}
+\declareapi{pmix_server_iof_fn_t}
+
+%%%%
+\summary
+
+Request the specified IO channels be forwarded from the given array of procs.
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+typedef pmix_status_t (*pmix_server_iof_fn_t)(
+                             const pmix_proc_t procs[], size_t nprocs,
+                             const pmix_info_t directives[], size_t ndirs,
+                             pmix_iof_channel_t channels,
+                             pmix_op_cbfunc_t cbfunc, void *cbdata);
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{procs}{Array \refstruct{pmix_proc_t} identifiers whose \ac{IO} is being requested (handle)}
+\argin{nprocs}{Number of elements in \refarg{procs} (\code{size_t})}
+\argin{directives}{Array of \refstruct{pmix_info_t} structures further defining the request (array of handles)}
+\argin{ndirs}{Number of elements in the \refarg{info} array (integer)}
+\argin{channels}{Bitmask identifying the channels to be forwarded (\refstruct{pmix_iof_channel_t})}
+\argin{cbfunc}{Callback function \refapi{pmix_op_cbfunc_t} (function reference)}
+\argin{cbdata}{Data to be passed to the callback function (memory reference)}
+\end{arglist}
+
+Returns one of the following:
+
+\begin{itemize}
+    \item \refconst{PMIX_SUCCESS}, indicating that the request is being processed by the host environment - result will be returned in the provided \refarg{cbfunc}
+    \item a PMIx error constant indicating either an error in the input or that the request is unsupported - the \refarg{cbfunc} will \textit{not} be called
+\end{itemize}
+
+\reqattrstart
+The following attributes are required to be included in the passed \refarg{info} array:
+
+\pastePRIAttributeItem{PMIX_USERID}
+\pastePRIAttributeItem{PMIX_GRPID}
+
+Host environments that provide this module entry point are required to support the following attributes:
+
+\pastePRRTEAttributeItem{PMIX_IOF_CACHE_SIZE}
+\pastePRRTEAttributeItem{PMIX_IOF_DROP_OLDEST}
+\pastePRRTEAttributeItem{PMIX_IOF_DROP_NEWEST}
+
+\reqattrend
+
+\optattrstart
+The following attributes may be supported by a host environment.
+
+\pasteAttributeItem{PMIX_IOF_BUFFERING_SIZE}
+\pasteAttributeItem{PMIX_IOF_BUFFERING_TIME}
+
+\optattrend
+
+%%%%
+\descr
+
+Request the specified IO channels be forwarded from the given array of procs. An error shall be returned in the callback function if the requested service from \textit{any} of the requested procs cannot be provided.
+
+\adviceimplstart
+The forwarding of stdin is a \textit{push} process - procs cannot request that it be \textit{pulled} from some other source. Requests including the \refconst{PMIX_FWD_STDIN_CHANNEL} channel will return a \refconst{PMIX_ERR_NOT_SUPPORTED} error.
+\adviceimplend
+
+
+%%%%%%%%%%%
+\subsection{\code{pmix_server_stdin_fn_t}}
+\declareapi{pmix_server_stdin_fn_t}
+
+%%%%
+\summary
+
+Pass stdin data to the host environment for transmission to specified recipients.
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+typedef pmix_status_t (*pmix_server_stdin_fn_t)(
+                             const pmix_proc_t *source,
+                             const pmix_proc_t targets[], size_t ntargets,
+                             const pmix_info_t directives[], size_t ndirs,
+                             const pmix_byte_object_t *bo,
+                             pmix_op_cbfunc_t cbfunc, void *cbdata);
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{source}{\refstruct{pmix_proc_t} structure of source process (handle)}
+\argin{targets}{Array of \refstruct{pmix_proc_t} target identifiers (handle)}
+\argin{ntargets}{Number of elements in the \refarg{targets} array (integer)}
+\argin{directives}{Array of info structures (array of handles)}
+\argin{ndirs}{Number of elements in the \refarg{info} array (integer)}
+\argin{bo}{Pointer to \refstruct{pmix_byte_object_t} containing the payload (handle)}
+\argin{cbfunc}{Callback function \refapi{pmix_op_cbfunc_t} (function reference)}
+\argin{cbdata}{Data to be passed to the callback function (memory reference)}
+\end{arglist}
+
+Returns one of the following:
+
+\begin{itemize}
+    \item \refconst{PMIX_SUCCESS}, indicating that the request is being processed by the host environment - result will be returned in the provided \refarg{cbfunc}
+    \item a PMIx error constant indicating either an error in the input or that the request is unsupported - the \refarg{cbfunc} will \textit{not} be called
+\end{itemize}
+
+\reqattrstart
+The following attributes are required to be included in the passed \refarg{info} array:
+
+\pastePRIAttributeItem{PMIX_USERID}
+\pastePRIAttributeItem{PMIX_GRPID}
+
+\reqattrend
+
+%%%%
+\descr
+
+Passes stdin to the host environment for transmission to specified recipients. The host environment is responsible for forwarding the data to all locations that host the specified \refarg{targets} and delivering the payload to the \ac{PMIx} server library connected to those clients.
 
 \advicermstart
 If this module entry is provided and called by the \ac{PMIx} server library, then the host environment must either provide the requested services or return \refconst{PMIX_ERR_NOT_SUPPORTED} to the provided \refarg{cbfunc}.

--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -635,8 +635,8 @@ This is a non-blocking \ac{API} as it may involve somewhat lengthy operations to
 \advicermend
 
 %%%%%%%%%%%
-\subsection{\code{PMIx_server_IOF_deliver}}
-\declareapi{PMIx_server_IOF_deliver}
+\subsection{\code{PMIx_server_deliver_inventory}}
+\declareapi{PMIx_server_deliver_inventory}
 
 %%%%
 \summary

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -51,27 +51,24 @@ a space of size \refconst{PMIX_MAX_KEYLEN}+1 to allow room for the \code{NULL} t
 
 
 %%%%%%%%%%%
-\subsection{Error Constants}
+\subsection{PMIx Error Constants}
 \label{api:struct:errors}
 \declarestruct{pmix_status_t}
 
 The \refstruct{pmix_status_t} structure is an \code{int} type for return status.
 
 The tables shown in this section define the possible values for \refstruct{pmix_status_t}.
-PMIx errors are required to always be negative, with 0 reserved for \refconst{PMIX_SUCCESS}.
+PMIx errors are required to always be negative, with 0 reserved for \refconst{PMIX_SUCCESS}. Values in the list that were deprecated in later standards are denoted as such. Values added to the list in this version of the standard are shown in \textbf{\color{magenta}magenta}.
 
+\adviceimplstart
 A PMIx implementation must define all of the constants defined in this section, even if they will never return the specific value to the caller.
+\adviceimplend
 
 \adviceuserstart
 Other than \refconst{PMIX_SUCCESS} (which is required to be zero), the actual value of any \ac{PMIx} error constant is left to the \ac{PMIx} library implementer. Thus, users are advised to always refer to constant by name, and not a specific implementation's value, for portability between implementations and compatibility across library versions.
 \adviceuserend
 
-%%%%%%%%%%%
-\subsubsection{PMIx v1 Error Constants}
-
-The following list contains those constants defined in the PMIx v1 standard.
-Those values in the list that were deprecated in later standards are denoted as such.
-\ac{PMIx} errors are always negative, with \code{0} reserved for success.
+\subsubsection{General Error Constants}
 
 \begin{constantdesc}
 %
@@ -228,15 +225,6 @@ Communication failure
 \declareconstitem{PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER}
 Unpacking past the end of the buffer provided
 %
-\end{constantdesc}
-
-%%%%%%%%%%%
-\subsubsection{PMIx v2 Error Constants}
-
-The following list contains constants added in the PMIx v2 standard.
-
-\begin{constantdesc}
-%
 \declareconstitem{PMIX_ERR_LOST_CONNECTION_TO_SERVER}
 Lost connection to server
 %
@@ -275,7 +263,7 @@ Process terminated without calling \refapi{PMIx_Finalize}, or was a member of an
 %
 \end{constantdesc}
 
-The following list contains operational error constants introduced in the v2 standard.
+\subsubsection{Operational Error Constants}
 
 \begin{constantdesc}
 %
@@ -297,9 +285,36 @@ The \ac{GDS} action has completed
 \declareconstitem{PMIX_ERR_INVALID_OPERATION}
 The requested operation is supported by the implementation and host environment, but fails to meet a requirement (e.g., requesting to \textit{disconnect} from processes without first \textit{connecting} to them).
 
+\declareconstitemNEW{PMIX_PROC_HAS_CONNECTED}
+A tool or client has connected to the \ac{PMIx} server
+%
+\declareconstitemNEW{PMIX_CONNECT_REQUESTED}
+Connection has been requested by a PMIx-based tool
+%
+\declareconstitemNEW{PMIX_MODEL_RESOURCES}
+Resource usage by a programming model has changed
+%
+\declareconstitemNEW{PMIX_OPENMP_PARALLEL_ENTERED}
+An OpenMP parallel code region has been entered
+%
+\declareconstitemNEW{PMIX_OPENMP_PARALLEL_EXITED}
+An OpenMP parallel code region has completed
+%
+\declareconstitemNEW{PMIX_LAUNCH_DIRECTIVE}
+Launcher directives have been received from a PMIx-enabled tool
+%
+\declareconstitemNEW{PMIX_LAUNCHER_READY}
+Application launcher (e.g., mpiexec) is ready to receive directives from a PMIx-enabled tool
+%
+\declareconstitemNEW{PMIX_OPERATION_IN_PROGRESS}
+A requested operation is already in proigress
+%
+\declareconstitemNEW{PMIX_OPERATION_SUCCEEDED}
+The requested operation was performed atomically - no callback function will be executed
+
 \end{constantdesc}
 
-The following list contains system error constants introduced in the v2 standard.
+\subsubsection{System error constants}
 
 \begin{constantdesc}
 %
@@ -311,7 +326,7 @@ Node is marked as offline
 %
 \end{constantdesc}
 
-The following list contains event handler error constants introduced in the v2 standard.
+\subsubsection{Event handler error constants}
 
 \begin{constantdesc}
 %
@@ -348,7 +363,7 @@ Definitions should always be based on the \refconst{PMIX_EXTERNAL_ERR_BASE} cons
 %%%%%%%%%%%
 \section{Data Types}
 
-This section defines various data types used by the PMIx APIs.
+This section defines various data types used by the PMIx APIs. The version of the standard in which a particular data type was introduced is shown in the margin.
 
 %%%%%%%%%%%
 \subsection{Key Structure}
@@ -371,6 +386,25 @@ References to keys in \ac{PMIx} v1 rwere defined simply as an array of character
 Passing a \refstruct{pmix_key_t} value to the standard \textit{sizeof} utility can result in compiler warnings of incorrect returned value. Users are advised to avoid using \textit{sizeof(pmix_key_t)} and instead rely on the \refstruct{PMIX_MAX_KEYLEN} constant.
 \adviceuserend
 
+\subsubsection{Key support macro}
+\declaremacro{pmix_check_key}
+
+Compare the key in a \refstruct{pmix_info_t} to a given value
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+PMIX_CHECK_KEY(a, b)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{a}{Pointer to the structure whose key is to be checked (pointer to \refstruct{pmix_info_t})}
+\argin{b}{String value to be compared against (\code{char*})}
+\end{arglist}
+
+Returns \code{true} if the key matches the given value
+
 %%%%%%%%%%%
 \subsection{Namespace Structure}
 \declarestruct{pmix_nspace_t}
@@ -391,6 +425,25 @@ References to namespace values in \ac{PMIx} v1 rwere defined simply as an array 
 
 Passing a \refstruct{pmix_nspace_t} value to the standard \textit{sizeof} utility can result in compiler warnings of incorrect returned value. Users are advised to avoid using \textit{sizeof(pmix_nspace_t)} and instead rely on the \refstruct{PMIX_MAX_NSLEN} constant.
 \adviceuserend
+
+\subsubsection{Namespace support macro}
+\declaremacro{pmix_check_nspace}
+
+Compare the string in a \refstruct{pmix_nspace_t} to a given value
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+PMIX_CHECK_NSPACE(a, b)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{a}{Pointer to the structure whose value is to be checked (pointer to \refstruct{pmix_nspace_t})}
+\argin{b}{String value to be compared against (\code{char*})}
+\end{arglist}
+
+Returns \code{true} if the namespace matches the given value
 
 
 %%%%%%%%%%%
@@ -531,6 +584,30 @@ PMIX_PROC_LOAD(m, n, r)
 \argin{n}{Namespace to be loaded (\refstruct{pmix_nspace_t})}
 \argin{r}{Rank to be assigned (\refstruct{pmix_rank_t})}
 \end{arglist}
+
+\subsubsection{Compare identifiers}
+\declaremacro{pmix_check_procid}
+
+Compare two \refstruct{pmix_proc_t} identifiers
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+PMIX_CHECK_PROCID(a, b)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{a}{Pointer to a structure whose ID is to be compared (pointer to \refstruct{pmix_proc_t})}
+\argin{b}{Pointer to a structure whose ID is to be compared (pointer to \refstruct{pmix_proc_t})}
+\end{arglist}
+
+Returns \code{true} if the two structures contain matching namespaces and:
+
+\begin{itemize}
+    \item the ranks are the same value
+    \item one of the ranks is \refconst{PMIX_RANK_WILDCARD}
+\end{itemize}
 
 
 %%%%%%%%%%%
@@ -787,6 +864,9 @@ Range is specified in the \refstruct{pmix_info_t} associated with this call.
 \declareconstitem{PMIX_RANGE_PROC_LOCAL}
 Data is only available to this process.
 %
+\declareconstitemNEW{PMIX_RANGE_INVALID}
+Invalid value
+%
 \end{constantdesc}
 
 \adviceuserstart
@@ -817,6 +897,9 @@ Retain data until the application terminates.
 %
 \declareconstitem{PMIX_PERSIST_SESSION}
 Retain data until the session/allocation terminates.
+%
+\declareconstitemNEW{PMIX_PERSIST_INVALID}
+Invalid value
 %
 \end{constantdesc}
 
@@ -865,9 +948,6 @@ typedef struct pmix_value \{
         pmix_data_array_t *darray;      // version 2.0
         void *ptr;                      // version 2.0
         pmix_alloc_directive_t adir;    // version 2.0
-        /**** DEPRECATED in PMIx 2 ****/
-        pmix_info_array_t *array;
-        /******************************/
     \} data;
 \} pmix_value_t;
 \end{codepar}
@@ -947,7 +1027,7 @@ PMIX_VALUE_FREE(m, n)
 \end{arglist}
 
 %%%%%%%%%%%
-\subsection{Load a \refstruct{pmix_value_t} structure}
+\subsubsection{Load a value structure}
 \declaremacro{PMIX_VALUE_LOAD}
 
 %%%%
@@ -1011,9 +1091,30 @@ The data will be copied into the destination \refstruct{pmix_value_t} - thus, an
 
 
 %%%%%%%%%%%
+\subsubsection{Retrieve a numerical value from a \refstruct{pmix_value_t}}
+\declaremacro{PMIX_VALUE_FREE}
+
+Retrieve a numerical value from a \refstruct{pmix_value_t} structure
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+PMIX_VALUE_GET_NUMBER(s, m, n, t)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argout{s}{Status code for the request (\refstruct{pmix_status_t})}
+\argin{m}{Pointer to the\refstruct{pmix_value_t} structure (handle)}
+\argout{n}{Variable to be set to the value (match expected type)}
+\argin{t}{Type of number expected in \refarg{m} (\refstruct{pmix_data_type_t})}
+\end{arglist}
+
+Sets the provided variable equal to the numerical value contained in the given \refstruct{pmix_value_t}, returning success if the data type of the value matches the expected type and \refconst{PMIX_ERR_BAD_PARAM} if it doesn't
+
+%%%%%%%%%%%
 \subsection{Info and Info Array Structures}
 \declarestruct{pmix_info_t}
-\declarestruct{pmix_info_array}
 
 The \refstruct{pmix_info_t} structure defines a key/value pair with associated directive. All fields were defined in version 1.0 unless otherwise marked.
 
@@ -1025,23 +1126,6 @@ typedef struct pmix_info_t \{
     pmix_info_directives_t flags;    // version 2.0
     pmix_value_t value;
 \} pmix_info_t;
-\end{codepar}
-\cspecificend
-
-The \refstruct{pmix_info_array} structure defines an array of \refstruct{pmix_info_t} structures.
-
-\notestart
-\noteheader
-The \refstruct{pmix_info_array} structure has been deprecated and will be removed in future versions of the \ac{PMIx} Standard.
-\noteend
-
-\versionMarker{1.0}
-\cspecificstart
-\begin{codepar}
-typedef struct pmix_info_array \{
-    size_t size;
-    pmix_info_t *array;
-\} pmix_info_array_t;
 \end{codepar}
 \cspecificend
 
@@ -1250,6 +1334,27 @@ PMIX_INFO_REQUIRED(info);
 
 This macro simplifies the setting of the \refstruct{PMIX_INFO_REQD} flag in \refstruct{pmix_info_t} structures.
 
+%%%%
+\subsubsection{Mark an info structure as optional}
+\declaremacro{PMIX_INFO_OPTIONAL}
+
+%%%%
+\summary
+Unsets the \refconst{PMIX_INFO_REQD} flag in a \refstruct{pmix_info_t} structure.
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+PMIX_INFO_OPTIONAL(info);
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{info}{Pointer to the \refstruct{pmix_info_t} (pointer to \refstruct{pmix_info_t})}
+\end{arglist}
+
+This macro simplifies marking a \refstruct{pmix_info_t} structure as \textit{optional}.
+
 %%%%%%%%%%%
 \subsubsection{Test an info structure for \textit{required} directive}
 \declaremacro{PMIX_INFO_IS_REQUIRED}
@@ -1272,6 +1377,27 @@ PMIX_INFO_IS_REQUIRED(info);
 
 This macro simplifies the testing of the required flag in \refstruct{pmix_info_t} structures.
 
+%%%%%%%%%%%
+\subsubsection{Test an info structure for \textit{optional} directive}
+\declaremacro{PMIX_INFO_IS_OPTIONAL}
+
+%%%%
+\summary
+
+Test a \refstruct{pmix_info_t} structure, returning \code{true} if the structure is \textit{optional}.
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+PMIX_INFO_IS_OPTIONAL(info);
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{info}{Pointer to the \refstruct{pmix_info_t} (pointer to \refstruct{pmix_info_t})}
+\end{arglist}
+
+This macro simplifies the testing of the required flag in \refstruct{pmix_info_t} structures.
 
 
 %%%%%%%%%%%
@@ -1303,6 +1429,151 @@ A value boundary above which implementers are free to define their own directive
 %
 \end{constantdesc}
 
+
+%%%%%%%%%%%
+\subsection{IOF Channels}
+\declarestruct{pmix_iof_channel_t}
+
+\versionMarker{3.0}
+The \refstruct{pmix_iof_channel_t} structure is a \code{uint16_t} type that defines a set of bit-mask flags for specifying IO forwarding channels. These can be OR'd together to reference multiple channels
+
+\begin{constantdesc}
+%
+\declareconstitemNEW{PMIX_FWD_NO_CHANNELS}
+Forward no channels
+%
+\declareconstitemNEW{PMIX_FWD_STDIN_CHANNEL}
+Forward stdin
+%
+\declareconstitemNEW{PMIX_FWD_STDOUT_CHANNEL}
+Forward stdout
+%
+\declareconstitemNEW{PMIX_FWD_STDERR_CHANNEL}
+Forward stderr
+%
+\declareconstitemNEW{PMIX_FWD_STDDIAG_CHANNEL}
+Forward stddiag, if available
+%
+\declareconstitemNEW{PMIX_FWD_ALL_CHANNELS}
+Forward all available channels
+%
+\end{constantdesc}
+
+
+%%%%%%%%%%%
+\subsection{Environmental Variable Structure}
+\declarestruct{pmix_envar_t}
+
+\versionMarker{3.0}
+Define a structure for specifying environment variable modifications.
+Standard environment variables (e.g., PATH, LD_LIBRARY_PATH, and LD_PRELOAD)
+take multiple arguments separated by delimiters. Unfortunately, the delimiters
+depend upon the variable itself - some use semi-colons, some colons, etc. Thus,
+the operation requires not only the name of the variable to be modified and
+the value to be inserted, but also the separator to be used when composing
+the aggregate value
+
+\cspecificstart
+\begin{codepar}
+typedef struct {
+    char *envar;
+    char *value;
+    char separator;
+} pmix_envar_t;
+\end{codepar}
+\cspecificend
+
+
+\subsection{Environmental variable support macros}
+
+The following macros are provided to support the \refstruct{pmix_envar_t} structure.
+
+\subsubsection{Initialize the \refstruct{pmix_envar_t} structure}
+\declaremacro{PMIX_ENVAR_CONSTRUCT}
+
+Initialize the \refstruct{pmix_envar_t} fields
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+PMIX_ENVAR_CONSTRUCT(m)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{m}{Pointer to the structure to be initialized (pointer to \refstruct{pmix_envar_t})}
+\end{arglist}
+
+\subsubsection{Destruct the \refstruct{pmix_envar_t} structure}
+\declaremacro{PMIX_ENVAR_DESTRUCT}
+
+Clear the \refstruct{pmix_envar_t} fields
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+PMIX_ENVAR_DESTRUCT(m)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{m}{Pointer to the structure to be destructed (pointer to \refstruct{pmix_envar_t})}
+\end{arglist}
+
+
+\subsubsection{Create a \refstruct{pmix_envar_t} array}
+\declaremacro{PMIX_ENVAR_CREATE}
+
+Allocate and initialize an array of \refstruct{pmix_envar_t} structures
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+PMIX_ENVAR_CREATE(m, n)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\arginout{m}{Address where the pointer to the array of \refstruct{pmix_envar_t} structures shall be stored (handle)}
+\argin{n}{Number of structures to be allocated (\code{size_t})}
+\end{arglist}
+
+
+\subsubsection{Free a\refstruct{pmix_envar_t} array}
+\declaremacro{PMIX_ENVAR_FREE}
+
+Release an array of \refstruct{pmix_envar_t} structures
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+PMIX_ENVAR_FREE(m, n)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{m}{Pointer to the array of \refstruct{pmix_envar_t} structures (handle)}
+\argin{n}{Number of structures in the array (\code{size_t})}
+\end{arglist}
+
+\subsubsection{Load a\refstruct{pmix_envar_t} structure}
+\declaremacro{PMIX_ENVAR_LOAD}
+
+Load values into a \refstruct{pmix_envar_t}
+
+\versionMarker{2.0}
+\cspecificstart
+\begin{codepar}
+PMIX_ENVAR_LOAD(m, e, v, s)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{m}{Pointer to the structure to be loaded (pointer to \refstruct{pmix_envar_t})}
+\argin{e}{Environmental variable name (\code{char*})}
+\argin{v}{Value of variable (\code{char*})}
+\argin{v}{Separator character (\code{char})}
+\end{arglist}
 
 
 %%%%%%%%%%%
@@ -1643,101 +1914,6 @@ PMIX_QUERY_FREE(m, n)
 \end{arglist}
 
 %%%%%%%%%%%
-\subsection{Modex Structure}
-\declarestruct{pmix_modex_data_t}
-
-The \refstruct{pmix_modex_data_t} structure describes the \ac{BCX} information.
-
-\notestart
-\noteheader
-This structure and its supporting macros have been deprecated and will be removed in future versions of the \ac{PMIx} Standard.
-\noteend
-
-\versionMarker{1.0}
-\cspecificstart
-\begin{codepar}
-typedef struct pmix_modex_data \{
-    pmix_nspace_t nspace;
-    int rank;
-    uint8_t *blob;
-    size_t size;
-\} pmix_modex_data_t;
-\end{codepar}
-\cspecificend
-
-\subsection{Modex data structure support macros}
-The following macros are provided to support the \refstruct{pmix_modex_t} structure.
-
-\subsubsection{Initialize the \refstruct{pmix_modex_t} structure}
-\declaremacro{PMIX_MODEX_CONSTRUCT}
-
-Initialize the \refstruct{pmix_modex_t} fields
-
-\versionMarker{1.0}
-\cspecificstart
-\begin{codepar}
-PMIX_MODEX_CONSTRUCT(m)
-\end{codepar}
-\cspecificend
-
-\begin{arglist}
-\argin{m}{Pointer to the structure to be initialized (pointer to \refstruct{pmix_modex_t})}
-\end{arglist}
-
-\subsubsection{Destruct the \refstruct{pmix_modex_t} structure}
-\declaremacro{PMIX_MODEX_DESTRUCT}
-
-Destruct the \refstruct{pmix_modex_t} fields
-
-\versionMarker{1.0}
-\cspecificstart
-\begin{codepar}
-PMIX_MODEX_DESTRUCT(m)
-\end{codepar}
-\cspecificend
-
-\begin{arglist}
-\argin{m}{Pointer to the structure to be destructed (pointer to \refstruct{pmix_modex_t})}
-\end{arglist}
-
-%%%%%%%%%%%
-\subsubsection{Create a \refstruct{pmix_modex_t} array}
-\declaremacro{PMIX_MODEX_CREATE}
-
-Allocate and initialize an array of \refstruct{pmix_modex_t} structures
-
-\versionMarker{1.0}
-\cspecificstart
-\begin{codepar}
-PMIX_MODEX_CREATE(m, n)
-\end{codepar}
-\cspecificend
-
-\begin{arglist}
-\arginout{m}{Address where the pointer to the array of \refstruct{pmix_modex_t} structures shall be stored (handle)}
-\argin{n}{Number of structures to be allocated (\code{size_t})}
-\end{arglist}
-
-
-%%%%%%%%%%%
-\subsubsection{Free a\refstruct{pmix_modex_t} array}
-\declaremacro{PMIX_MODEX_FREE}
-
-Release an array of \refstruct{pmix_modex_t} structures
-
-\versionMarker{1.0}
-\cspecificstart
-\begin{codepar}
-PMIX_MODEX_FREE(m, n)
-\end{codepar}
-\cspecificend
-
-\begin{arglist}
-\argin{m}{Pointer to the array of \refstruct{pmix_modex_t} structures (handle)}
-\argin{n}{Number of structures in the array (\code{size_t})}
-\end{arglist}
-
-%%%%%%%%%%%
 \section{Data Packing/Unpacking Types and Structures}
 
 This section defines types and structures used to pack and unpack data passed through the PMIx API.
@@ -1964,14 +2140,11 @@ typedef struct pmix_data_array \{
 \subsection{Generalized Data Types Used for Packing/Unpacking}
 \declarestruct{pmix_data_type_t}
 
-The \refstruct{pmix_data_type_t} structure is a \code{uint16_t} type for identifying the data type for packing/unpacking purposes.
+The \refstruct{pmix_data_type_t} structure is a \code{uint16_t} type for identifying the data type for packing/unpacking purposes. New data type values introduced in this version of the Standard are shown in \textbf{\color{magenta}magenta}.
 
 \adviceimplstart
 The following constants can be used to set a variable of the type \refstruct{pmix_data_type_t}. Data types in the \ac{PMIx} Standard are defined in terms of the C-programming language. Implementers wishing to support other languages should provide the equivalent definitions in a language-appropriate manner. Additionally, a PMIx implementation may choose to add additional types.
 \adviceimplend
-
-\subsubsection{PMIx v1 Data Types}
-The following types were introduced in version 1 of the \ac{PMIx} Standard.
 
 \begin{constantdesc}
 %
@@ -2035,6 +2208,9 @@ Time value (\code{struct timeval})
 \declareconstitem{PMIX_TIME}
 Time (\code{time_t})
 %
+\declareconstitem{PMIX_STATUS}
+Status code {\refstruct{pmix_status_t}}
+%
 \declareconstitem{PMIX_VALUE}
 Value (\refstruct{pmix_value_t})
 %
@@ -2065,44 +2241,29 @@ Modex
 \declareconstitem{PMIX_PERSIST}
 Persistance (\refstruct{pmix_persistence_t})
 %
-\declareconstitemDEP{PMIX_INFO_ARRAY}{2.0}
-Info array
-%
-\end{constantdesc}
-
-
-\subsubsection{PMIx v2 Data Types}
-The following types were introduced in version 2 of the \ac{PMIx} Standard.
-
-\begin{constantdesc}
-
-%
-\declareconstitem{PMIX_STATUS}
-Status (\refstruct{pmix_status_t})
-%
 \declareconstitem{PMIX_POINTER}
-Pointer (\code{void*})
+Pointer to an object (\code{void*})
 %
 \declareconstitem{PMIX_SCOPE}
 Scope (\refstruct{pmix_scope_t})
 %
 \declareconstitem{PMIX_DATA_RANGE}
-Data range (\refstruct{pmix_data_range_t})
+Range for data (\refstruct{pmix_data_range_t})
 %
 \declareconstitem{PMIX_COMMAND}
-Command
+PMIx command code (used internally)
 %
 \declareconstitem{PMIX_INFO_DIRECTIVES}
-Info directives
+Directives flag for \refstruct{pmix_info_t} (\refstruct{pmix_info_directives_t})
 %
 \declareconstitem{PMIX_DATA_TYPE}
-Data type
+Data type code (\refstruct{pmix_data_type_t})
 %
 \declareconstitem{PMIX_PROC_STATE}
 Process state (\refstruct{pmix_proc_state_t})
 %
 \declareconstitem{PMIX_PROC_INFO}
-Process info (\refstruct{pmix_proc_info_t})
+Process information (\refstruct{pmix_proc_info_t})
 %
 \declareconstitem{PMIX_DATA_ARRAY}
 Data array (\refstruct{pmix_data_array_t})
@@ -2111,19 +2272,21 @@ Data array (\refstruct{pmix_data_array_t})
 Process rank (\refstruct{pmix_rank_t})
 %
 \declareconstitem{PMIX_QUERY}
-Query
+Query structure (\refstruct{pmix_query_t})
 %
 \declareconstitem{PMIX_COMPRESSED_STRING}
-Compressed string (with zlib)
+String compressed with zlib (\code{char*})
 %
 \declareconstitem{PMIX_ALLOC_DIRECTIVE}
 Allocation directive (\refstruct{pmix_alloc_directive_t})
 %
-\declareconstitem{PMIX_DATA_TYPE_MAX}
-A boundary for implementers above which they can add their own data types.
+\declareconstitemNEW{PMIX_IOF_CHANNEL}
+Input/output forwarding channel (\refstruct{pmix_iof_channel_t})
+%
+\declareconstitemNEW{PMIX_ENVAR}
+Environmental variable structure (\refstruct{pmix_envar_t})
 %
 \end{constantdesc}
-
 
 %%%%%%%%%%%
 \section{Reserved attributes}
@@ -2152,22 +2315,22 @@ Constant representing an undefined attribute.
 These attributes are defined to assist the caller with initialization.
 
 %
-\declareNewAttribute{PMIX_EVENT_BASE}{"pmix.evbase"}{struct event_base *}{
+\declareAttribute{PMIX_EVENT_BASE}{"pmix.evbase"}{struct event_base *}{
 Pointer to libevent\footnote{\url{http://libevent.org/}} \code{event_base} to use in place of the internal progress thread.
 }
 
 %
-\declareNewAttribute{PMIX_SERVER_TOOL_SUPPORT}{"pmix.srvr.tool"}{bool}{
+\declareAttribute{PMIX_SERVER_TOOL_SUPPORT}{"pmix.srvr.tool"}{bool}{
 The host \ac{RM} wants to declare itself as willing to accept tool connection requests.
 }
 
 %
-\declareNewAttribute{PMIX_SERVER_REMOTE_CONNECTIONS}{"pmix.srvr.remote"}{bool}{
+\declareAttribute{PMIX_SERVER_REMOTE_CONNECTIONS}{"pmix.srvr.remote"}{bool}{
 Allow connections from remote tools. Forces the PMIx server to not exclusively use loopback device.
 }
 
 %
-\declareNewAttribute{PMIX_SERVER_SYSTEM_SUPPORT}{"pmix.srvr.sys"}{bool}{
+\declareAttribute{PMIX_SERVER_SYSTEM_SUPPORT}{"pmix.srvr.sys"}{bool}{
 The host \ac{RM} wants to declare itself as being the local system server for PMIx connection requests.
 }
 
@@ -2177,28 +2340,33 @@ Top-level temporary directory for all \emph{client} processes connected to this 
 }
 
 %
-\declareNewAttribute{PMIX_SYSTEM_TMPDIR}{"pmix.sys.tmpdir"}{char*}{
+\declareAttribute{PMIX_SYSTEM_TMPDIR}{"pmix.sys.tmpdir"}{char*}{
 Temporary directory for this system, and where a PMIx server that declares itself to be a system-level server will place a \emph{tool} rendezvous point and contact information.
 }
 
 %
-\declareNewAttribute{PMIX_REGISTER_NODATA}{"pmix.reg.nodata"}{bool}{
+\declareAttribute{PMIX_REGISTER_NODATA}{"pmix.reg.nodata"}{bool}{
 Registration is for the namespace only. Do not copy job data.
 }
 
 %
-\declareNewAttribute{PMIX_SERVER_ENABLE_MONITORING}{"pmix.srv.monitor"}{bool}{
+\declareAttribute{PMIX_SERVER_ENABLE_MONITORING}{"pmix.srv.monitor"}{bool}{
 Enable PMIx internal monitoring by the PMIx server.
 }
 
 %
-\declareNewAttribute{PMIX_SERVER_NSPACE}{"pmix.srv.nspace"}{char*}{
+\declareAttribute{PMIX_SERVER_NSPACE}{"pmix.srv.nspace"}{char*}{
 Name of the namespace to use for this PMIx server.
 }
 
 %
-\declareNewAttribute{PMIX_SERVER_RANK}{"pmix.srv.rank"}{pmix_rank_t}{
+\declareAttribute{PMIX_SERVER_RANK}{"pmix.srv.rank"}{pmix_rank_t}{
 Rank of this PMIx server
+}
+
+%
+\declareNewAttribute{PMIX_SERVER_GATEWAY}{"pmix.srv.gway"}{bool}{
+Server is acting as a gateway for PMIx requests that cannot be serviced on backend nodes (e.g., logging to email)
 }
 
 
@@ -2209,53 +2377,63 @@ Rank of this PMIx server
 These attributes are defined to assist PMIx-enabled tools to connect with the PMIx server.
 
 %
-\declareNewAttribute{PMIX_TOOL_NSPACE}{"pmix.tool.nspace"}{char*}{
+\declareAttribute{PMIX_TOOL_NSPACE}{"pmix.tool.nspace"}{char*}{
 Name of the namespace to use for this tool.
 }
 
 %
-\declareNewAttribute{PMIX_TOOL_RANK}{"pmix.tool.rank"}{uint32_t}{
+\declareAttribute{PMIX_TOOL_RANK}{"pmix.tool.rank"}{uint32_t}{
 Rank of this tool.
 }
 
 %
-\declareNewAttribute{PMIX_SERVER_PIDINFO}{"pmix.srvr.pidinfo"}{pid_t}{
+\declareAttribute{PMIX_SERVER_PIDINFO}{"pmix.srvr.pidinfo"}{pid_t}{
 \ac{PID} of the target PMIx server for a tool.
 }
 
 %
-\declareNewAttribute{PMIX_CONNECT_TO_SYSTEM}{"pmix.cnct.sys"}{bool}{
+\declareAttribute{PMIX_CONNECT_TO_SYSTEM}{"pmix.cnct.sys"}{bool}{
 The requestor requires that a connection be made only to a local, system-level PMIx server.
 }
 
 %
-\declareNewAttribute{PMIX_CONNECT_SYSTEM_FIRST}{"pmix.cnct.sys.first"}{bool}{
+\declareAttribute{PMIX_CONNECT_SYSTEM_FIRST}{"pmix.cnct.sys.first"}{bool}{
 Preferentially, look for a system-level PMIx server first.
 }
 
 %
-\declareNewAttribute{PMIX_SERVER_URI}{"pmix.srvr.uri"}{char*}{
+\declareAttribute{PMIX_SERVER_URI}{"pmix.srvr.uri"}{char*}{
 \ac{URI} of the PMIx server to be contacted.
 }
 
 %
-\declareNewAttribute{PMIX_SERVER_HOSTNAME}{"pmix.srvr.host"}{char*}{
+\declareAttribute{PMIX_SERVER_HOSTNAME}{"pmix.srvr.host"}{char*}{
 Host where target PMIx server is located.
 }
 
 %
-\declareNewAttribute{PMIX_CONNECT_MAX_RETRIES}{"pmix.tool.mretries"}{uint32_t}{
+\declareAttribute{PMIX_CONNECT_MAX_RETRIES}{"pmix.tool.mretries"}{uint32_t}{
 Maximum number of times to try to connect to PMIx server.
 }
 
 %
-\declareNewAttribute{PMIX_CONNECT_RETRY_DELAY}{"pmix.tool.retry"}{uint32_t}{
+\declareAttribute{PMIX_CONNECT_RETRY_DELAY}{"pmix.tool.retry"}{uint32_t}{
 Time in seconds between connection attempts to a PMIx server.
 }
 
 %
-\declareNewAttribute{PMIX_TOOL_DO_NOT_CONNECT}{"pmix.tool.nocon"}{bool}{
+\declareAttribute{PMIX_TOOL_DO_NOT_CONNECT}{"pmix.tool.nocon"}{bool}{
 The tool wants to use internal PMIx support, but does not want to connect to a PMIx server.
+}
+
+%
+\declareNewAttribute{PMIX_RECONNECT_SERVER}{"pmix.tool.recon"}{bool}{
+Tool is requesting to change server connections
+}
+
+%
+\declareNewAttribute{PMIX_LAUNCHER}{"pmix.tool.launcher"}{bool}{
+Tool is a launcher and needs rendezvous files created
 }
 
 
@@ -2263,7 +2441,7 @@ The tool wants to use internal PMIx support, but does not want to connect to a P
 \subsection{Identification attributes}
 \label{api:struct:attributes:ident}
 
-These attributes are defined to identify a process and it's associated PMIx-enabled library.
+These attributes are defined to identify a process
 
 %
 \declareAttribute{PMIX_USERID}{"pmix.euid"}{uint32_t}{
@@ -2281,39 +2459,79 @@ Path to shared memory data storage (dstore) files.
 }
 
 %
-\declareNewAttribute{PMIX_VERSION_INFO}{"pmix.version"}{char*}{
+\declareAttribute{PMIX_VERSION_INFO}{"pmix.version"}{char*}{
 PMIx version of contractor.
 }
 
 %
-\declareNewAttribute{PMIX_PROGRAMMING_MODEL}{"pmix.pgm.model"}{char*}{
-Programming model being initialized (e.g., ``MPI'' or ``OpenMP'')
-}
-
-%
-\declareNewAttribute{PMIX_MODEL_LIBRARY_NAME}{"pmix.mdl.name"}{char*}{
-Programming model implementation ID (e.g., ``OpenMPI'' or ``MPICH'')
-}
-
-%
-\declareNewAttribute{PMIX_MODEL_LIBRARY_VERSION}{"pmix.mld.vrs"}{char*}{
-Programming model version string (e.g., ``2.1.1'')
-}
-
-%
-\declareNewAttribute{PMIX_THREADING_MODEL}{"pmix.threads"}{char*}{
-Threading model used (e.g., ``pthreads'')
-}
-
-%
-\declareNewAttribute{PMIX_REQUESTOR_IS_TOOL}{"pmix.req.tool"}{bool}{
+\declareAttribute{PMIX_REQUESTOR_IS_TOOL}{"pmix.req.tool"}{bool}{
 The requesting process is a PMIx tool.
 }
 
 %
-\declareNewAttribute{PMIX_REQUESTOR_IS_CLIENT}{"pmix.req.client"}{bool}{
+\declareAttribute{PMIX_REQUESTOR_IS_CLIENT}{"pmix.req.client"}{bool}{
 The requesting process is a PMIx client.
 }
+
+%%%%%%%%%%%
+\subsection{Programming model attributes}
+\label{api:struct:attributes:model}
+
+These attributes are associated with programming models.
+
+%
+\declareAttribute{PMIX_PROGRAMMING_MODEL}{"pmix.pgm.model"}{char*}{
+Programming model being initialized (e.g., ``MPI'' or ``OpenMP'')
+}
+
+%
+\declareAttribute{PMIX_MODEL_LIBRARY_NAME}{"pmix.mdl.name"}{char*}{
+Programming model implementation ID (e.g., ``OpenMPI'' or ``MPICH'')
+}
+
+%
+\declareAttribute{PMIX_MODEL_LIBRARY_VERSION}{"pmix.mld.vrs"}{char*}{
+Programming model version string (e.g., ``2.1.1'')
+}
+
+%
+\declareAttribute{PMIX_THREADING_MODEL}{"pmix.threads"}{char*}{
+Threading model used (e.g., ``pthreads'')
+}
+
+%
+\declareNewAttribute{PMIX_MODEL_NUM_THREADS}{"pmix.mdl.nthrds"}{uint64_t}{
+Number of active threads being used by the model
+}
+
+%
+\declareNewAttribute{PMIX_MODEL_NUM_CPUS}{"pmix.mdl.ncpu"}{uint64_t}{
+Number of cpus being used by the model
+}
+
+%
+\declareNewAttribute{PMIX_MODEL_CPU_TYPE}{"pmix.mdl.cputype"}{char*}{
+Granularity - ``hwthread'', ``core'', etc.
+}
+
+%
+\declareNewAttribute{PMIX_MODEL_PHASE_NAME}{"pmix.mdl.phase"}{char*}{
+User-assigned name for a phase in the application execution (e.g., ``cfd reduction'')
+}
+
+%
+\declareNewAttribute{PMIX_MODEL_PHASE_TYPE}{"pmix.mdl.ptype"}{char*}{
+Type of phase being executed (e.g., ``matrix multiply'')
+}
+
+%
+\declareNewAttribute{PMIX_MODEL_AFFINITY_POLICY}{"pmix.mdl.tap"}{char*}{
+Thread affinity policy - e.g.:
+         "master" (thread co-located with master thread),
+         "close" (thread located on cpu close to master thread),
+         "spread" (threads load-balanced across available cpus)
+}
+
 
 
 %%%%%%%%%%%
@@ -2323,17 +2541,17 @@ The requesting process is a PMIx client.
 These attributes are used to describe a UNIX socket for rendezvous with the local \ac{RM}.
 
 %
-\declareNewAttribute{PMIX_USOCK_DISABLE}{"pmix.usock.disable"}{bool}{
+\declareAttribute{PMIX_USOCK_DISABLE}{"pmix.usock.disable"}{bool}{
 Disable legacy UNIX socket (usock) support
 }
 
 %
-\declareNewAttribute{PMIX_SOCKET_MODE}{"pmix.sockmode"}{uint32_t}{
+\declareAttribute{PMIX_SOCKET_MODE}{"pmix.sockmode"}{uint32_t}{
 POSIX \var{mode_t} (9 bits valid)
 }
 
 %
-\declareNewAttribute{PMIX_SINGLE_LISTENER}{"pmix.sing.listnr"}{bool}{
+\declareAttribute{PMIX_SINGLE_LISTENER}{"pmix.sing.listnr"}{bool}{
 Use only one rendezvous socket, letting priorities and/or environment parameters select the active transport.
 }
 
@@ -2345,42 +2563,42 @@ Use only one rendezvous socket, letting priorities and/or environment parameters
 These attributes are used to describe a TCP socket for rendezvous with the local \ac{RM}.
 
 %
-\declareNewAttribute{PMIX_TCP_REPORT_URI}{"pmix.tcp.repuri"}{char*}{
+\declareAttribute{PMIX_TCP_REPORT_URI}{"pmix.tcp.repuri"}{char*}{
 If provided, directs that the TCP \ac{URI} be reported and indicates the desired method of reporting: \code{'-'} for stdout, \code{'+'} for stderr, or filename.
 }
 
 %
-\declareNewAttribute{PMIX_TCP_URI}{"pmix.tcp.uri"}{char*}{
+\declareAttribute{PMIX_TCP_URI}{"pmix.tcp.uri"}{char*}{
 The \ac{URI} of the PMIx server to connect to, or a file name containing it in the form of \code{file:<name of file containing it>}.
 }
 
 %
-\declareNewAttribute{PMIX_TCP_IF_INCLUDE}{"pmix.tcp.ifinclude"}{char*}{
+\declareAttribute{PMIX_TCP_IF_INCLUDE}{"pmix.tcp.ifinclude"}{char*}{
 Comma-delimited list of devices and/or \ac{CIDR} notation to include when establishing the TCP connection.
 }
 
 %
-\declareNewAttribute{PMIX_TCP_IF_EXCLUDE}{"pmix.tcp.ifexclude"}{char*}{
+\declareAttribute{PMIX_TCP_IF_EXCLUDE}{"pmix.tcp.ifexclude"}{char*}{
 Comma-delimited list of devices and/or \ac{CIDR} notation to exclude when establishing the TCP connection.
 }
 
 %
-\declareNewAttribute{PMIX_TCP_IPV4_PORT}{"pmix.tcp.ipv4"}{int}{
+\declareAttribute{PMIX_TCP_IPV4_PORT}{"pmix.tcp.ipv4"}{int}{
 The IPv4 port to be used.
 }
 
 %
-\declareNewAttribute{PMIX_TCP_IPV6_PORT}{"pmix.tcp.ipv6"}{int}{
+\declareAttribute{PMIX_TCP_IPV6_PORT}{"pmix.tcp.ipv6"}{int}{
 The IPv6 port to be used.
 }
 
 %
-\declareNewAttribute{PMIX_TCP_DISABLE_IPV4}{"pmix.tcp.disipv4"}{bool}{
+\declareAttribute{PMIX_TCP_DISABLE_IPV4}{"pmix.tcp.disipv4"}{bool}{
 Set to \code{true} to disable IPv4 family of addresses.
 }
 
 %
-\declareNewAttribute{PMIX_TCP_DISABLE_IPV6}{"pmix.tcp.disipv6"}{bool}{
+\declareAttribute{PMIX_TCP_DISABLE_IPV6}{"pmix.tcp.disipv6"}{bool}{
 Set to \code{true} to disable IPv6 family of addresses.
 }
 
@@ -2392,7 +2610,7 @@ Set to \code{true} to disable IPv6 family of addresses.
 These attributes are used to define the behavior of the \ac{GDS} used to manage key/value pairs.
 
 %
-\declareNewAttribute{PMIX_GDS_MODULE}{"pmix.gds.mod"}{char*}{
+\declareAttribute{PMIX_GDS_MODULE}{"pmix.gds.mod"}{char*}{
 Comma-delimited string of desired modules.
 }
 
@@ -2446,7 +2664,7 @@ Full path to the subdirectory under \refattr{PMIX_NSDIR} assigned to the process
 }
 
 %
-\declareNewAttribute{PMIX_TDIR_RMCLEAN}{"pmix.tdir.rmclean"}{bool}{
+\declareAttribute{PMIX_TDIR_RMCLEAN}{"pmix.tdir.rmclean"}{bool}{
 Resource Manager will clean session directories
 }
 
@@ -2458,12 +2676,17 @@ Resource Manager will clean session directories
 These attributes are used to describe information about relative ranks as assigned by the \ac{RM}.
 
 %
-\declareNewAttribute{PMIX_PROCID}{"pmix.procid"}{pmix_proc_t}{
+\declareNewAttribute{PMIX_CLUSTER_ID}{"pmix.clid"}{char*}{
+A string name for the cluster this proc is executing on
+}
+
+%
+\declareAttribute{PMIX_PROCID}{"pmix.procid"}{pmix_proc_t}{
 Process identifier
 }
 
 %
-\declareNewAttribute{PMIX_NSPACE}{"pmix.nspace"}{char*}{
+\declareAttribute{PMIX_NSPACE}{"pmix.nspace"}{char*}{
 Namespace of the job.
 }
 
@@ -2518,12 +2741,12 @@ Lowest rank in this application within this job.
 }
 
 %
-\declareNewAttribute{PMIX_PROC_PID}{"pmix.ppid"}{pid_t}{
+\declareAttribute{PMIX_PROC_PID}{"pmix.ppid"}{pid_t}{
 \ac{PID} of specified process.
 }
 
 %
-\declareNewAttribute{PMIX_SESSION_ID}{"pmix.session.id"}{uint32_t}{
+\declareAttribute{PMIX_SESSION_ID}{"pmix.session.id"}{uint32_t}{
 Session identifier.
 }
 
@@ -2533,7 +2756,7 @@ Comma-delimited list of nodes running processes for the specified namespace.
 }
 
 %
-\declareNewAttribute{PMIX_ALLOCATED_NODELIST}{"pmix.alist"}{char*}{
+\declareAttribute{PMIX_ALLOCATED_NODELIST}{"pmix.alist"}{char*}{
 Comma-delimited list of all nodes in this allocation regardless of whether or not they currently host processes.
 }
 
@@ -2568,13 +2791,18 @@ Colon-delimited cpusets of local peers within the specified namespace.
 }
 
 %
-\declareNewAttribute{PMIX_LOCALITY}{"pmix.loc"}{uint16_t}{
+\declareAttribute{PMIX_LOCALITY}{"pmix.loc"}{uint16_t}{
 Relative locality of two processes.
 }
 
 %
-\declareNewAttribute{PMIX_PARENT_ID}{"pmix.parent"}{pmix_proc_t}{
+\declareAttribute{PMIX_PARENT_ID}{"pmix.parent"}{pmix_proc_t}{
 Process identifier of the parent process of the calling process.
+}
+
+%
+\declareNewAttribute{PMIX_EXIT_CODE}{"pmix.exit.code"}{int}{
+Exit code returned when process terminated
 }
 
 
@@ -2595,12 +2823,12 @@ Number of processes in this job.
 }
 
 %
-\declareNewAttribute{PMIX_JOB_NUM_APPS}{"pmix.job.napps"}{uint32_t}{
+\declareAttribute{PMIX_JOB_NUM_APPS}{"pmix.job.napps"}{uint32_t}{
 Number of applications in this job.
 }
 
 %
-\declareNewAttribute{PMIX_APP_SIZE}{"pmix.app.size"}{uint32_t}{
+\declareAttribute{PMIX_APP_SIZE}{"pmix.app.size"}{uint32_t}{
 Number of processes in this application.
 }
 
@@ -2620,7 +2848,7 @@ Maximum number of processes for this job.
 }
 
 %
-\declareNewAttribute{PMIX_NUM_NODES}{"pmix.num.nodes"}{uint32_t}{
+\declareAttribute{PMIX_NUM_NODES}{"pmix.num.nodes"}{uint32_t}{
 Number of nodes in this namespace.
 }
 
@@ -2632,17 +2860,17 @@ Number of nodes in this namespace.
 These attributes are used to describe memory available and used in the system.
 
 %
-\declareNewAttribute{PMIX_AVAIL_PHYS_MEMORY}{"pmix.pmem"}{uint64_t}{
+\declareAttribute{PMIX_AVAIL_PHYS_MEMORY}{"pmix.pmem"}{uint64_t}{
 Total available physical memory on this node.
 }
 
 %
-\declareNewAttribute{PMIX_DAEMON_MEMORY}{"pmix.dmn.mem"}{float}{
+\declareAttribute{PMIX_DAEMON_MEMORY}{"pmix.dmn.mem"}{float}{
 Megabytes of memory currently used by the \ac{RM} daemon.
 }
 
 %
-\declareNewAttribute{PMIX_CLIENT_AVG_MEMORY}{"pmix.cl.mem.avg"}{float}{
+\declareAttribute{PMIX_CLIENT_AVG_MEMORY}{"pmix.cl.mem.avg"}{float}{
 Average Megabytes of memory used by client processes.
 }
 
@@ -2674,12 +2902,22 @@ Pointer to the PMIx client's internal hwloc topology object.
 }
 
 %
-\declareNewAttribute{PMIX_TOPOLOGY_SIGNATURE}{"pmix.toposig"}{char*}{
+\declareNewAttribute{PMIX_TOPOLOGY_XML}{"pmix.topo.xml"}{char*}{
+\ac{XML}-based description of topology
+}
+
+%
+\declareNewAttribute{PMIX_TOPOLOGY_FILE}{"pmix.topo.file"}{char*}{
+Full path to file containing \ac{XML} topology description
+}
+
+%
+\declareAttribute{PMIX_TOPOLOGY_SIGNATURE}{"pmix.toposig"}{char*}{
 Topology signature string.
 }
 
 %
-\declareNewAttribute{PMIX_LOCALITY_STRING}{"pmix.locstr"}{char*}{
+\declareAttribute{PMIX_LOCALITY_STRING}{"pmix.locstr"}{char*}{
 String describing a process's bound location.
 The string is of the form:\\
 \code{NM\%s:SK\%s:L3\%s:L2\%s:L1\%s:CR\%s:HT\%s}\\
@@ -2698,28 +2936,38 @@ This means numa node \code{0}, socket \code{0}, L3 caches \code{0,1,2,3,4}, L2 c
 }
 
 %
-\declareNewAttribute{PMIX_HWLOC_SHMEM_ADDR}{"pmix.hwlocaddr"}{size_t}{
-Address of the hwloc shared memory segment.
+\declareAttribute{PMIX_HWLOC_SHMEM_ADDR}{"pmix.hwlocaddr"}{size_t}{
+Address of the HWLOC shared memory segment.
 }
 
 %
-\declareNewAttribute{PMIX_HWLOC_SHMEM_SIZE}{"pmix.hwlocsize"}{size_t}{
-Size of the hwloc shared memory segment.
+\declareAttribute{PMIX_HWLOC_SHMEM_SIZE}{"pmix.hwlocsize"}{size_t}{
+Size of the HWLOC shared memory segment.
 }
 
 %
-\declareNewAttribute{PMIX_HWLOC_SHMEM_FILE}{"pmix.hwlocfile"}{char*}{
-Path to the hwloc shared memory file.
+\declareAttribute{PMIX_HWLOC_SHMEM_FILE}{"pmix.hwlocfile"}{char*}{
+Path to the HWLOC shared memory file.
 }
 
 %
-\declareNewAttribute{PMIX_HWLOC_XML_V1}{"pmix.hwlocxml1"}{char*}{
-\ac{XML} representation of local topology using hwloc's v1.x format.
+\declareAttribute{PMIX_HWLOC_XML_V1}{"pmix.hwlocxml1"}{char*}{
+\ac{XML} representation of local topology using HWLOC's v1.x format.
 }
 
 %
-\declareNewAttribute{PMIX_HWLOC_XML_V2}{"pmix.hwlocxml2"}{char*}{
-\ac{XML} representation of local topology using hwloc's v2.x format.
+\declareAttribute{PMIX_HWLOC_XML_V2}{"pmix.hwlocxml2"}{char*}{
+\ac{XML} representation of local topology using HWLOC's v2.x format.
+}
+
+%
+\declareNewAttribute{PMIX_HWLOC_SHARE_TOPO}{"pmix.hwlocsh"}{bool}{
+Share the HWLOC topology via shared memory
+}
+
+%
+\declareNewAttribute{PMIX_HWLOC_HOLE_KIND}{"pmix.hwlocholek"}{char*}{
+Kind of VM ``hole'' HWLOC should use for shared memory
 }
 
 
@@ -2741,7 +2989,7 @@ The timeout parameter can help avoid ``hangs'' due to programming errors that pr
 }
 
 %
-\declareNewAttribute{PMIX_IMMEDIATE}{"pmix.immediate"}{bool}{
+\declareAttribute{PMIX_IMMEDIATE}{"pmix.immediate"}{bool}{
 Specified operation should immediately return an error from the PMIx server if the requested data cannot be found - do not request it from the host \ac{RM}.
 }
 
@@ -2756,7 +3004,7 @@ Comma-delimited list of algorithms to use for the collective operation.
 }
 
 %
-\declareAttribute{PMIX_COLLECTIVE_ALGO_REQD}{"pmix.calreqd"}{bool}{
+\declareDepAttribute{PMIX_COLLECTIVE_ALGO_REQD}{"pmix.calreqd"}{bool}{
 If \code{true}, indicates that the requested choice of algorithm is mandatory.
 }
 
@@ -2786,19 +3034,19 @@ Look only in the client's local data store for the requested value - do not requ
 }
 
 %
-\declareNewAttribute{PMIX_EMBED_BARRIER}{"pmix.embed.barrier"}{bool}{
+\declareAttribute{PMIX_EMBED_BARRIER}{"pmix.embed.barrier"}{bool}{
 Execute a blocking fence operation before executing the specified operation.
 By default, \refapi{PMIx_Finalize} does not include an internal barrier operation.
 This attribute directs \refapi{PMIx_Finalize} to execute a barrier as part of the finalize operation.
 }
 
 %
-\declareNewAttribute{PMIX_JOB_TERM_STATUS}{"pmix.job.term.status"}{pmix_status_t}{
+\declareAttribute{PMIX_JOB_TERM_STATUS}{"pmix.job.term.status"}{pmix_status_t}{
 Status to be returned upon job termination.
 }
 
 %
-\declareNewAttribute{PMIX_PROC_STATE_STATUS}{"pmix.proc.state"}{pmix_proc_state_t}{
+\declareAttribute{PMIX_PROC_STATE_STATUS}{"pmix.proc.state"}{pmix_proc_state_t}{
 Process state
 }
 
@@ -2811,7 +3059,7 @@ Attributes used by the host environment to pass data to its PMIx server library.
 The data will then be parsed and provided to the local PMIx clients.
 
 %
-\declareNewAttribute{PMIX_REGISTER_NODATA}{"pmix.reg.nodata"}{bool}{
+\declareAttribute{PMIX_REGISTER_NODATA}{"pmix.reg.nodata"}{bool}{
 Registration is for this namespace only, do not copy job data.
 }
 
@@ -2836,18 +3084,18 @@ Process mapping in Argonne National Laboratory's PMI-1/PMI-2 notation.
 }
 
 %
-\declareNewAttribute{PMIX_APP_MAP_TYPE}{"pmix.apmap.type"}{char*}{
+\declareAttribute{PMIX_APP_MAP_TYPE}{"pmix.apmap.type"}{char*}{
 Type of mapping used to layout the application (e.g., \code{cyclic}).
 }
 
 %
-\declareNewAttribute{PMIX_APP_MAP_REGEX}{"pmix.apmap.regex"}{char*}{
+\declareAttribute{PMIX_APP_MAP_REGEX}{"pmix.apmap.regex"}{char*}{
 Regular expression describing the result of the process mapping.
 }
 
 
 %%%%%%%%%%%
-\subsection{Srever-to-Client attributes}
+\subsection{Server-to-Client attributes}
 \label{api:struct:attributes:server2client}
 
 Attributes used internally to communicate data from the PMIx server to the PMIx client.
@@ -2869,128 +3117,84 @@ Packed blob of process location.
 
 Attributes to support event registration and notification.
 
-\adviceuserstart
-The event handler subsystem defined in the \ac{PMIx} \textit{ad hoc} version 1 Standard was completely overhauled in version 2 to resolve design flaws. Deprecated attributes shown below were therefore removed in the version 2 Standard.
-\adviceuserend
-
 %
-\declareDepAttribute{PMIX_ERROR_NAME}{"pmix.errname"}{pmix_status_t}{
-Specific error to be notified
-}
-%
-\declareDepAttribute{PMIX_ERROR_GROUP_COMM}{"pmix.errgroup.comm"}{bool}{
-Set true to get comm errors notification
-}
-%
-\declareDepAttribute{PMIX_ERROR_GROUP_ABORT}{"pmix.errgroup.abort"}{bool}{
-Set true to get abort errors notification
-}
-%
-\declareDepAttribute{PMIX_ERROR_GROUP_MIGRATE}{"pmix.errgroup.migrate"}{bool}{
-Set true to get migrate errors notification
-}
-%
-\declareDepAttribute{PMIX_ERROR_GROUP_RESOURCE}{"pmix.errgroup.resource"}{bool}{
-Set true to get resource errors notification
-}
-%
-\declareDepAttribute{PMIX_ERROR_GROUP_SPAWN}{"pmix.errgroup.spawn"}{bool}{
-Set true to get spawn errors notification
-}
-%
-\declareDepAttribute{PMIX_ERROR_GROUP_NODE}{"pmix.errgroup.node"}{bool}{
-Set true to get node status notification
-}
-%
-\declareDepAttribute{PMIX_ERROR_GROUP_LOCAL}{"pmix.errgroup.local"}{bool}{
-Set true to get local errors notification
-}
-%
-\declareDepAttribute{PMIX_ERROR_GROUP_GENERAL}{"pmix.errgroup.gen"}{bool}{
-Set true to get notified of generic errors
-}
-%
-\declareDepAttribute{PMIX_ERROR_HANDLER_ID}{"pmix.errhandler.id"}{int}{
-Errhandler reference id of notification being reported
-}
-%
-\declareNewAttribute{PMIX_EVENT_HDLR_NAME}{"pmix.evname"}{char*}{
+\declareAttribute{PMIX_EVENT_HDLR_NAME}{"pmix.evname"}{char*}{
 String name identifying this handler.
 }
 
 %
-\declareNewAttribute{PMIX_EVENT_HDLR_FIRST}{"pmix.evfirst"}{bool}{
+\declareAttribute{PMIX_EVENT_HDLR_FIRST}{"pmix.evfirst"}{bool}{
 Invoke this event handler before any other handlers.
 }
 
 %
-\declareNewAttribute{PMIX_EVENT_HDLR_LAST}{"pmix.evlast"}{bool}{
+\declareAttribute{PMIX_EVENT_HDLR_LAST}{"pmix.evlast"}{bool}{
 Invoke this event handler after all other handlers have been called.
 }
 
 %
-\declareNewAttribute{PMIX_EVENT_HDLR_FIRST_IN_CATEGORY}{"pmix.evfirstcat"}{bool}{
+\declareAttribute{PMIX_EVENT_HDLR_FIRST_IN_CATEGORY}{"pmix.evfirstcat"}{bool}{
 Invoke this event handler before any other handlers in this category.
 }
 
 %
-\declareNewAttribute{PMIX_EVENT_HDLR_LAST_IN_CATEGORY}{"pmix.evlastcat"}{bool}{
+\declareAttribute{PMIX_EVENT_HDLR_LAST_IN_CATEGORY}{"pmix.evlastcat"}{bool}{
 Invoke this event handler after all other handlers in this category have been called.
 }
 
 %
-\declareNewAttribute{PMIX_EVENT_HDLR_BEFORE}{"pmix.evbefore"}{char*}{
+\declareAttribute{PMIX_EVENT_HDLR_BEFORE}{"pmix.evbefore"}{char*}{
 Put this event handler immediately before the one specified in the \code{(char*)} value.
 }
 
 %
-\declareNewAttribute{PMIX_EVENT_HDLR_AFTER}{"pmix.evafter"}{char*}{
+\declareAttribute{PMIX_EVENT_HDLR_AFTER}{"pmix.evafter"}{char*}{
 Put this event handler immediately after the one specified in the \code{(char*)} value.
 }
 
 %
-\declareNewAttribute{PMIX_EVENT_HDLR_PREPEND}{"pmix.evprepend"}{bool}{
+\declareAttribute{PMIX_EVENT_HDLR_PREPEND}{"pmix.evprepend"}{bool}{
 Prepend this handler to the precedence list within its category.
 }
 
 %
-\declareNewAttribute{PMIX_EVENT_HDLR_APPEND}{"pmix.evappend"}{bool}{
+\declareAttribute{PMIX_EVENT_HDLR_APPEND}{"pmix.evappend"}{bool}{
 Append this handler to the precedence list within its category.
 }
 
 %
-\declareNewAttribute{PMIX_EVENT_CUSTOM_RANGE}{"pmix.evrange"}{pmix_data_array_t*}{
+\declareAttribute{PMIX_EVENT_CUSTOM_RANGE}{"pmix.evrange"}{pmix_data_array_t*}{
 Array of \refstruct{pmix_proc_t} defining range of event notification.
 }
 
 %
-\declareNewAttribute{PMIX_EVENT_AFFECTED_PROC}{"pmix.evproc"}{pmix_proc_t}{
+\declareAttribute{PMIX_EVENT_AFFECTED_PROC}{"pmix.evproc"}{pmix_proc_t}{
 The single process that was affected.
 }
 
 %
-\declareNewAttribute{PMIX_EVENT_AFFECTED_PROCS}{"pmix.evaffected"}{pmix_data_array_t*}{
+\declareAttribute{PMIX_EVENT_AFFECTED_PROCS}{"pmix.evaffected"}{pmix_data_array_t*}{
 Array of \refstruct{pmix_proc_t} defining affected processes.
 }
 
 %
-\declareNewAttribute{PMIX_EVENT_NON_DEFAULT}{"pmix.evnondef"}{bool}{
+\declareAttribute{PMIX_EVENT_NON_DEFAULT}{"pmix.evnondef"}{bool}{
 Event is not to be delivered to default event handlers.
 }
 
 %
-\declareNewAttribute{PMIX_EVENT_RETURN_OBJECT}{"pmix.evobject"}{void *}{
+\declareAttribute{PMIX_EVENT_RETURN_OBJECT}{"pmix.evobject"}{void *}{
 Object to be returned whenever the registered callback function \code{cbfunc} is invoked.
 The object will \emph{only} be returned to the process that registered it.
 }
 
 %
-\declareNewAttribute{PMIX_EVENT_DO_NOT_CACHE}{"pmix.evnocache"}{bool}{
+\declareAttribute{PMIX_EVENT_DO_NOT_CACHE}{"pmix.evnocache"}{bool}{
 Instruct the PMIx server not to cache the event.
 }
 
 %
-\declareNewAttribute{PMIX_EVENT_SILENT_TERMINATION}{"pmix.evsilentterm"}{bool}{
+\declareAttribute{PMIX_EVENT_SILENT_TERMINATION}{"pmix.evsilentterm"}{bool}{
 Do not generate an event when this job normally terminates.
 }
 
@@ -3002,37 +3206,37 @@ Do not generate an event when this job normally terminates.
 Attributes to support fault tolerance behaviors.
 
 %
-\declareNewAttribute{PMIX_EVENT_TERMINATE_SESSION}{"pmix.evterm.sess"}{bool}{
+\declareAttribute{PMIX_EVENT_TERMINATE_SESSION}{"pmix.evterm.sess"}{bool}{
 The \ac{RM} intends to terminate this session.
 }
 
 %
-\declareNewAttribute{PMIX_EVENT_TERMINATE_JOB}{"pmix.evterm.job"}{bool}{
+\declareAttribute{PMIX_EVENT_TERMINATE_JOB}{"pmix.evterm.job"}{bool}{
 The \ac{RM} intends to terminate this job.
 }
 
 %
-\declareNewAttribute{PMIX_EVENT_TERMINATE_NODE}{"pmix.evterm.node"}{bool}{
+\declareAttribute{PMIX_EVENT_TERMINATE_NODE}{"pmix.evterm.node"}{bool}{
 The \ac{RM} intends to terminate all processes on this node.
 }
 
 %
-\declareNewAttribute{PMIX_EVENT_TERMINATE_PROC}{"pmix.evterm.proc"}{bool}{
+\declareAttribute{PMIX_EVENT_TERMINATE_PROC}{"pmix.evterm.proc"}{bool}{
 The \ac{RM} intends to terminate just this process.
 }
 
 %
-\declareNewAttribute{PMIX_EVENT_ACTION_TIMEOUT}{"pmix.evtimeout"}{int}{
+\declareAttribute{PMIX_EVENT_ACTION_TIMEOUT}{"pmix.evtimeout"}{int}{
 The time in seconds before the \ac{RM} will execute error response.
 }
 
 %
-\declareNewAttribute{PMIX_EVENT_NO_TERMINATION}{"pmix.evnoterm"}{bool}{
+\declareAttribute{PMIX_EVENT_NO_TERMINATION}{"pmix.evnoterm"}{bool}{
 Indicates that the handler has satisfactorily handled the event and believes termination of the application is not required.
 }
 
 %
-\declareNewAttribute{PMIX_EVENT_WANT_TERMINATION}{"pmix.evterm"}{bool}{
+\declareAttribute{PMIX_EVENT_WANT_TERMINATION}{"pmix.evterm"}{bool}{
 Indicates that the handler has determined that the application should be terminated
 }
 
@@ -3129,98 +3333,103 @@ Spawned process rank that is to receive \code{stdin}.
 }
 
 %
-\declareNewAttribute{PMIX_FWD_STDIN}{"pmix.fwd.stdin"}{bool}{
+\declareAttribute{PMIX_FWD_STDIN}{"pmix.fwd.stdin"}{bool}{
 Forward this process's \code{stdin} to the designated process.
 }
 
 %
-\declareNewAttribute{PMIX_FWD_STDOUT}{"pmix.fwd.stdout"}{bool}{
+\declareAttribute{PMIX_FWD_STDOUT}{"pmix.fwd.stdout"}{bool}{
 Forward \code{stdout} from spawned processes to this process.
 }
 
 %
-\declareNewAttribute{PMIX_FWD_STDERR}{"pmix.fwd.stderr"}{bool}{
+\declareAttribute{PMIX_FWD_STDERR}{"pmix.fwd.stderr"}{bool}{
 Forward \code{stderr} from spawned processes to this process.
 }
 
 %
-\declareNewAttribute{PMIX_DEBUGGER_DAEMONS}{"pmix.debugger"}{bool}{
+\declareNewAttribute{PMIX_FWD_STDDOAG}{"pmix.fwd.stddiag"}{bool}{
+If a diagnostic channel exists, forward any output on it from the spawned processes to this process (typically used by a tool)
+}
+
+%
+\declareAttribute{PMIX_DEBUGGER_DAEMONS}{"pmix.debugger"}{bool}{
 Spawned application consists of debugger daemons.
 }
 
 %
-\declareNewAttribute{PMIX_COSPAWN_APP}{"pmix.cospawn"}{bool}{
+\declareAttribute{PMIX_COSPAWN_APP}{"pmix.cospawn"}{bool}{
 Designated application is to be spawned as a disconnected job.
 Meaning that it is not part of the ``comm_world'' of the parent process.
 }
 
 %
-\declareNewAttribute{PMIX_SET_SESSION_CWD}{"pmix.ssncwd"}{bool}{
+\declareAttribute{PMIX_SET_SESSION_CWD}{"pmix.ssncwd"}{bool}{
 Set the application's current working directory to the session working directory assigned by the \ac{RM}.
 }
 
 %
-\declareNewAttribute{PMIX_TAG_OUTPUT}{"pmix.tagout"}{bool}{
+\declareAttribute{PMIX_TAG_OUTPUT}{"pmix.tagout"}{bool}{
 Tag application output with the identity of the source process.
 }
 
 %
-\declareNewAttribute{PMIX_TIMESTAMP_OUTPUT}{"pmix.tsout"}{bool}{
+\declareAttribute{PMIX_TIMESTAMP_OUTPUT}{"pmix.tsout"}{bool}{
 Timestamp output from applications.
 }
 
 %
-\declareNewAttribute{PMIX_MERGE_STDERR_STDOUT}{"pmix.mergeerrout"}{bool}{
+\declareAttribute{PMIX_MERGE_STDERR_STDOUT}{"pmix.mergeerrout"}{bool}{
 Merge \code{stdout} and \code{stderr} streams from application processes.
 }
 
 %
-\declareNewAttribute{PMIX_OUTPUT_TO_FILE}{"pmix.outfile"}{char*}{
+\declareAttribute{PMIX_OUTPUT_TO_FILE}{"pmix.outfile"}{char*}{
 Output application output to the specified file.
 }
 
 %
-\declareNewAttribute{PMIX_INDEX_ARGV}{"pmix.indxargv"}{bool}{
+\declareAttribute{PMIX_INDEX_ARGV}{"pmix.indxargv"}{bool}{
 Mark the \code{argv} with the rank of the process.
 }
 
 %
-\declareNewAttribute{PMIX_CPUS_PER_PROC}{"pmix.cpuperproc"}{uint32_t}{
+\declareAttribute{PMIX_CPUS_PER_PROC}{"pmix.cpuperproc"}{uint32_t}{
 Number of cpus to assign to each rank.
 }
 
 %
-\declareNewAttribute{PMIX_NO_PROCS_ON_HEAD}{"pmix.nolocal"}{bool}{
+\declareAttribute{PMIX_NO_PROCS_ON_HEAD}{"pmix.nolocal"}{bool}{
 Do not place processes on the head node.
 }
 
 %
-\declareNewAttribute{PMIX_NO_OVERSUBSCRIBE}{"pmix.noover"}{bool}{
+\declareAttribute{PMIX_NO_OVERSUBSCRIBE}{"pmix.noover"}{bool}{
 Do not oversubscribe the cpus.
 }
 
 %
-\declareNewAttribute{PMIX_REPORT_BINDINGS}{"pmix.repbind"}{bool}{
+\declareAttribute{PMIX_REPORT_BINDINGS}{"pmix.repbind"}{bool}{
 Report bindings of the individual processes.
 }
 
 %
-\declareNewAttribute{PMIX_CPU_LIST}{"pmix.cpulist"}{char*}{
+\declareAttribute{PMIX_CPU_LIST}{"pmix.cpulist"}{char*}{
 List of cpus to use for this job.
 }
 
 %
-\declareNewAttribute{PMIX_JOB_RECOVERABLE}{"pmix.recover"}{bool}{
+\declareAttribute{PMIX_JOB_RECOVERABLE}{"pmix.recover"}{bool}{
 Application supports recoverable operations.
 }
 
 %
-\declareNewAttribute{PMIX_JOB_CONTINUOUS}{"pmix.continuous"}{bool}{
+\declareAttribute{PMIX_JOB_CONTINUOUS}{"pmix.continuous"}{bool}{
 Application is continuous, all failed processes should be immediately restarted.
 }
 
 %
-\declareNewAttribute{PMIX_MAX_RESTARTS}{"pmix.maxrestarts"}{uint32_t}{
+\declareAttribute{PMIX_MAX_RESTARTS}{"pmix.maxrestarts"}{uint32_t}{
 Maximum number of times to restart a job.
 }
 
@@ -3232,77 +3441,77 @@ Maximum number of times to restart a job.
 Attributes used to describe \refapi{PMIx_Query_info_nb} behavior.
 
 %
-\declareNewAttribute{PMIX_QUERY_NAMESPACES}{"pmix.qry.ns"}{char*}{
+\declareAttribute{PMIX_QUERY_NAMESPACES}{"pmix.qry.ns"}{char*}{
 Request a comma-delimited list of active namespaces.
 }
 
 %
-\declareNewAttribute{PMIX_QUERY_JOB_STATUS}{"pmix.qry.jst"}{pmix_status_t}{
+\declareAttribute{PMIX_QUERY_JOB_STATUS}{"pmix.qry.jst"}{pmix_status_t}{
 Status of a specified, currently executing job.
 }
 
 %
-\declareNewAttribute{PMIX_QUERY_QUEUE_LIST}{"pmix.qry.qlst"}{char*}{
+\declareAttribute{PMIX_QUERY_QUEUE_LIST}{"pmix.qry.qlst"}{char*}{
 Request a comma-delimited list of scheduler queues.
 }
 
 %
-\declareNewAttribute{PMIX_QUERY_QUEUE_STATUS}{"pmix.qry.qst"}{TBD}{
+\declareAttribute{PMIX_QUERY_QUEUE_STATUS}{"pmix.qry.qst"}{TBD}{
 Status of a specified scheduler queue.
 }
 
 %
-\declareNewAttribute{PMIX_QUERY_PROC_TABLE}{"pmix.qry.ptable"}{char*}{
+\declareAttribute{PMIX_QUERY_PROC_TABLE}{"pmix.qry.ptable"}{char*}{
 Input namespace of the job whose information is being requested returns (\refstruct{pmix_data_array_t}) an array of \refstruct{pmix_proc_info_t}.
 }
 
 %
-\declareNewAttribute{PMIX_QUERY_LOCAL_PROC_TABLE}{"pmix.qry.lptable"}{char*}{
+\declareAttribute{PMIX_QUERY_LOCAL_PROC_TABLE}{"pmix.qry.lptable"}{char*}{
 Input namespace of the job whose information is being requested returns (\refstruct{pmix_data_array_t}) an array of \refstruct{pmix_proc_info_t} for processes in job on same node.
 }
 
 %
-\declareNewAttribute{PMIX_QUERY_AUTHORIZATIONS}{"pmix.qry.auths"}{bool}{
+\declareAttribute{PMIX_QUERY_AUTHORIZATIONS}{"pmix.qry.auths"}{bool}{
 Return operations the PMIx tool is authorized to perform.
 }
 
 %
-\declareNewAttribute{PMIX_QUERY_SPAWN_SUPPORT}{"pmix.qry.spawn"}{bool}{
+\declareAttribute{PMIX_QUERY_SPAWN_SUPPORT}{"pmix.qry.spawn"}{bool}{
 Return a comma-delimited list of supported spawn attributes.
 }
 
 %
-\declareNewAttribute{PMIX_QUERY_DEBUG_SUPPORT}{"pmix.qry.debug"}{bool}{
+\declareAttribute{PMIX_QUERY_DEBUG_SUPPORT}{"pmix.qry.debug"}{bool}{
 Return a comma-delimited list of supported debug attributes.
 }
 
 %
-\declareNewAttribute{PMIX_QUERY_MEMORY_USAGE}{"pmix.qry.mem"}{bool}{
+\declareAttribute{PMIX_QUERY_MEMORY_USAGE}{"pmix.qry.mem"}{bool}{
 Return information on memory usage for the processes indicated in the qualifiers.
 }
 
 %
-\declareNewAttribute{PMIX_QUERY_LOCAL_ONLY}{"pmix.qry.local"}{bool}{
+\declareAttribute{PMIX_QUERY_LOCAL_ONLY}{"pmix.qry.local"}{bool}{
 Constrain the query to local information only.
 }
 
 %
-\declareNewAttribute{PMIX_QUERY_REPORT_AVG}{"pmix.qry.avg"}{bool}{
+\declareAttribute{PMIX_QUERY_REPORT_AVG}{"pmix.qry.avg"}{bool}{
 Report average values.
 }
 
 %
-\declareNewAttribute{PMIX_QUERY_REPORT_MINMAX}{"pmix.qry.minmax"}{bool}{
+\declareAttribute{PMIX_QUERY_REPORT_MINMAX}{"pmix.qry.minmax"}{bool}{
 Report minimum and maximum values.
 }
 
 %
-\declareNewAttribute{PMIX_QUERY_ALLOC_STATUS}{"pmix.query.alloc"}{char*}{
+\declareAttribute{PMIX_QUERY_ALLOC_STATUS}{"pmix.query.alloc"}{char*}{
 String identifier of the allocation whose status is being requested.
 }
 
 %
-\declareNewAttribute{PMIX_TIME_REMAINING}{"pmix.time.remaining"}{char*}{
+\declareAttribute{PMIX_TIME_REMAINING}{"pmix.time.remaining"}{char*}{
 Query number of seconds (\code{uint32_t}) remaining in allocation for the specified namespace.
 }
 
@@ -3314,44 +3523,121 @@ Query number of seconds (\code{uint32_t}) remaining in allocation for the specif
 Attributes used to describe \refapi{PMIx_Log_nb} behavior.
 
 %
-\declareNewAttribute{PMIX_LOG_STDERR}{"pmix.log.stderr"}{char*}{
+\declareNewAttribute{PMIX_LOG_SOURCE}{"pmix.log.source"}{pmix_proc_t*}{
+ID of source of the log request
+}
+
+%
+\declareAttribute{PMIX_LOG_STDERR}{"pmix.log.stderr"}{char*}{
 Log string to \code{stderr}.
 }
 
 %
-\declareNewAttribute{PMIX_LOG_STDOUT}{"pmix.log.stdout"}{char*}{
+\declareAttribute{PMIX_LOG_STDOUT}{"pmix.log.stdout"}{char*}{
 Log string to \code{stdout}.
 }
 
 %
-\declareNewAttribute{PMIX_LOG_SYSLOG}{"pmix.log.syslog"}{char*}{
+\declareAttribute{PMIX_LOG_SYSLOG}{"pmix.log.syslog"}{char*}{
 Log data to syslog.
+Defaults to \code{ERROR} priority.  Will log to global syslog if available, otherwise to local syslog
+}
+
+%
+\declareNewAttribute{PMIX_LOG_LOCAL_SYSLOG}{"pmix.log.lsys"}{char*}{
+Log data to local syslog.
 Defaults to \code{ERROR} priority.
 }
 
 %
-\declareNewAttribute{PMIX_LOG_MSG}{"pmix.log.msg"}{pmix_byte_object_t}{
+\declareNewAttribute{PMIX_LOG_GLOBAL_SYSLOG}{"pmix.log.gsys"}{char*}{
+Forward data to system ``gateway'' and log msg to that syslog
+Defaults to \code{ERROR} priority.
+}
+
+%
+\declareNewAttribute{PMIX_LOG_SYSLOG_PRI}{"pmix.log.syspri"}{int}{
+Syslog priority level
+}
+
+%
+\declareNewAttribute{PMIX_LOG_TIMESTAMP}{"pmix.log.tstmp"}{time_t}{
+Timestamp for log report
+}
+
+%
+\declareNewAttribute{PMIX_LOG_GENERATE_TIMESTAMP}{"pmix.log.gtstmp"}{bool}{
+Generate timestamp for log
+}
+
+%
+\declareNewAttribute{PMIX_LOG_TAG_OUTPUT}{"pmix.log.tag"}{bool}{
+Label the output stream with the channel name (e.g., ``stdout'')
+}
+
+%
+\declareNewAttribute{PMIX_LOG_TIMESTAMP_OUTPUT}{"pmix.log.tsout"}{bool}{
+Print timestamp in output string
+}
+
+%
+\declareNewAttribute{PMIX_LOG_XML_OUTPUT}{"pmix.log.xml"}{bool}{
+Print the output stream in \ac{XML} format
+}
+
+%
+\declareNewAttribute{PMIX_LOG_ONCE}{"pmix.log.once"}{bool}{
+Only log this once with whichever channel can first support it, taking the channels in priority order
+}
+
+%
+\declareAttribute{PMIX_LOG_MSG}{"pmix.log.msg"}{pmix_byte_object_t}{
 Message blob to be sent somewhere.
 }
 
 %
-\declareNewAttribute{PMIX_LOG_EMAIL}{"pmix.log.email"}{pmix_data_array_t}{
+\declareAttribute{PMIX_LOG_EMAIL}{"pmix.log.email"}{pmix_data_array_t}{
 Log via email based on \refstruct{pmix_info_t} containing directives.
 }
 
 %
-\declareNewAttribute{PMIX_LOG_EMAIL_ADDR}{"pmix.log.emaddr"}{char*}{
+\declareAttribute{PMIX_LOG_EMAIL_ADDR}{"pmix.log.emaddr"}{char*}{
 Comma-delimited list of email addresses that are to receive the message.
 }
 
 %
-\declareNewAttribute{PMIX_LOG_EMAIL_SUBJECT}{"pmix.log.emsub"}{char*}{
+\declareNewAttribute{PMIX_LOG_EMAIL_SENDER_ADDR}{"pmix.log.emfaddr"}{char*}{
+Return email address of sender
+}
+
+%
+\declareAttribute{PMIX_LOG_EMAIL_SUBJECT}{"pmix.log.emsub"}{char*}{
 Subject line for email.
 }
 
 %
-\declareNewAttribute{PMIX_LOG_EMAIL_MSG}{"pmix.log.emmsg"}{char*}{
+\declareAttribute{PMIX_LOG_EMAIL_MSG}{"pmix.log.emmsg"}{char*}{
 Message to be included in email.
+}
+
+%
+\declareNewAttribute{PMIX_LOG_EMAIL_SERVER}{"pmix.log.esrvr"}{char*}{
+Hostname (or IP address) of estmp server
+}
+
+%
+\declareNewAttribute{PMIX_LOG_EMAIL_SRVR_PORT}{"pmix.log.esrvrprt"}{int32_t}{
+Port the email server is listening to
+}
+
+%
+\declareNewAttribute{PMIX_LOG_GLOBAL_DATASTORE}{"pmix.log.gstore"}{bool}{
+Store the log data in a global data store (e.g., database)
+}
+
+%
+\declareNewAttribute{PMIX_LOG_JOB_RECORD}{"pmix.log.jrec"}{bool}{
+Log the provided information to the host environment's job record
 }
 
 
@@ -3362,29 +3648,39 @@ Message to be included in email.
 Attributes used to assist debuggers.
 
 %
-\declareNewAttribute{PMIX_DEBUG_STOP_ON_EXEC}{"pmix.dbg.exec"}{bool}{
+\declareAttribute{PMIX_DEBUG_STOP_ON_EXEC}{"pmix.dbg.exec"}{bool}{
 Job is being spawned under debugger.
 The processes are instructed to pause on start.
 }
 
 %
-\declareNewAttribute{PMIX_DEBUG_STOP_IN_INIT}{"pmix.dbg.init"}{bool}{
+\declareAttribute{PMIX_DEBUG_STOP_IN_INIT}{"pmix.dbg.init"}{bool}{
 Instruct job to stop processes during \refapi{PMIx_Init}.
 }
 
 %
-\declareNewAttribute{PMIX_DEBUG_WAIT_FOR_NOTIFY}{"pmix.dbg.notify"}{bool}{
+\declareAttribute{PMIX_DEBUG_WAIT_FOR_NOTIFY}{"pmix.dbg.notify"}{bool}{
 Block at desired point until receiving debugger release notification.
 }
 
 %
-\declareNewAttribute{PMIX_DEBUG_JOB}{"pmix.dbg.job"}{char*}{
+\declareAttribute{PMIX_DEBUG_JOB}{"pmix.dbg.job"}{char*}{
 Namespace of the job to be debugged.
 }
 
 %
-\declareNewAttribute{PMIX_DEBUG_WAITING_FOR_NOTIFY}{"pmix.dbg.waiting"}{bool}{
+\declareAttribute{PMIX_DEBUG_WAITING_FOR_NOTIFY}{"pmix.dbg.waiting"}{bool}{
 Job to be debugged is waiting for a release.
+}
+
+%
+\declareNewAttribute{PMIX_DEBUG_JOB_DIRECTIVES}{"pmix.dbg.jdirs"}{pmix_data_array_t*}{
+Array of job-level directives
+}
+
+%
+\declareNewAttribute{PMIX_DEBUG_APP_DIRECTIVES}{"pmix.dbg.adirs"}{pmix_data_array_t*}{
+Array of app-level directives
 }
 
 
@@ -3395,12 +3691,12 @@ Job to be debugged is waiting for a release.
 Attributes used to describe the \ac{RM}.
 
 %
-\declareNewAttribute{PMIX_RM_NAME}{"pmix.rm.name"}{char*}{
+\declareAttribute{PMIX_RM_NAME}{"pmix.rm.name"}{char*}{
 String name of the \ac{RM}.
 }
 
 %
-\declareNewAttribute{PMIX_RM_VERSION}{"pmix.rm.version"}{char*}{
+\declareAttribute{PMIX_RM_VERSION}{"pmix.rm.version"}{char*}{
 \ac{RM} version string.
 }
 
@@ -3412,13 +3708,28 @@ String name of the \ac{RM}.
 Attributes used to adjust environment variables.
 
 %
-\declareNewAttribute{PMIX_SET_ENVAR}{"pmix.set.envar"}{char*}{
-String ``\code{key=value}'' value shall be put into the environment.
+\declareNewAttribute{PMIX_SET_ENVAR}{"pmix.envar.set"}{pmix_envar_t*}{
+Set the envar to the given value, overwriting any pre-existing one
 }
 
 %
-\declareNewAttribute{PMIX_UNSET_ENVAR}{"pmix.unset.envar"}{char*}{
+\declareAttribute{PMIX_UNSET_ENVAR}{"pmix.envar.unset"}{char*}{
 Unset the environment variable specified in the string.
+}
+
+%
+\declareNewAttribute{PMIX_ADD_ENVAR}{"pmix.envar.add"}{pmix_envar_t*}{
+Add the environment variable, but do not overwrite any pre-existing one
+}
+
+%
+\declareNewAttribute{PMIX_PREPEND_ENVAR}{"pmix.envar.prepnd"}{pmix_envar_t*}{
+Prepend the given value to the specified environmental value using the given separator character, creating the variable if it doesn't already exist
+}
+
+%
+\declareNewAttribute{PMIX_APPEND_ENVAR}{"pmix.envar.appnd"}{pmix_envar_t*}{
+Append the given value to the specified environmental value using the given separator character, creating the variable if it doesn't already exist
 }
 
 
@@ -3429,64 +3740,90 @@ Unset the environment variable specified in the string.
 Attributes used to describe the job allocation.
 
 %
-\declareNewAttribute{PMIX_ALLOC_ID}{"pmix.alloc.id"}{char*}{
+\declareAttribute{PMIX_ALLOC_ID}{"pmix.alloc.id"}{char*}{
 Provide a string identifier for this allocation request which can later be used to query status of the request.
 }
 
 %
-\declareNewAttribute{PMIX_ALLOC_NUM_NODES}{"pmix.alloc.nnodes"}{uint64_t}{
+\declareAttribute{PMIX_ALLOC_NUM_NODES}{"pmix.alloc.nnodes"}{uint64_t}{
 The number of nodes.
 }
 
 %
-\declareNewAttribute{PMIX_ALLOC_NODE_LIST}{"pmix.alloc.nlist"}{char*}{
+\declareAttribute{PMIX_ALLOC_NODE_LIST}{"pmix.alloc.nlist"}{char*}{
 Regular expression of the specific nodes.
 }
 
 %
-\declareNewAttribute{PMIX_ALLOC_NUM_CPUS}{"pmix.alloc.ncpus"}{uint64_t}{
+\declareAttribute{PMIX_ALLOC_NUM_CPUS}{"pmix.alloc.ncpus"}{uint64_t}{
 Number of cpus.
 }
 
 %
-\declareNewAttribute{PMIX_ALLOC_NUM_CPU_LIST}{"pmix.alloc.ncpulist"}{char*}{
+\declareAttribute{PMIX_ALLOC_NUM_CPU_LIST}{"pmix.alloc.ncpulist"}{char*}{
 Regular expression of the number of cpus for each node.
 }
 
 %
-\declareNewAttribute{PMIX_ALLOC_CPU_LIST}{"pmix.alloc.cpulist"}{char*}{
+\declareAttribute{PMIX_ALLOC_CPU_LIST}{"pmix.alloc.cpulist"}{char*}{
 Regular expression of the specific cpus indicating the cpus involved.
 }
 
 %
-\declareNewAttribute{PMIX_ALLOC_MEM_SIZE}{"pmix.alloc.msize"}{float}{
+\declareAttribute{PMIX_ALLOC_MEM_SIZE}{"pmix.alloc.msize"}{float}{
 Number of Megabytes.
 }
 
 %
 \declareNewAttribute{PMIX_ALLOC_NETWORK}{"pmix.alloc.net"}{array}{
-Array of \refstruct{pmix_info_t} describing requested network resources.
-If not given as part of an \refstruct{pmix_info_t} struct that identifies the involved nodes, then the description will be applied across all nodes in the requestor's allocation.
+Array of \refstruct{pmix_info_t} describing requested network resources. This must include at least: PMIX_ALLOC_NETWORK_ID, PMIX_ALLOC_NETWORK_TYPE, and PMIX_ALLOC_NETWORK_ENDPTS, plus whatever other descriptors are desired
 }
 
 %
 \declareNewAttribute{PMIX_ALLOC_NETWORK_ID}{"pmix.alloc.netid"}{char*}{
-Name of the network.
+key to be used when accessing this requested network allocation. The allocation will be returned/stored as a \refstruct{pmix_data_array_t} of
+\refstruct{pmix_info_t} indexed by this key and containing at least one entry with the same key and the allocated resource description.
+The type of the included value depends upon the network support. For example, a TCP allocation might consist of a comma-delimited string of socket ranges such as "32000-32100,33005,38123-38146". Additional entries will consist of any provided resource request directives, along with their assigned values. Examples include: PMIX_ALLOC_NETWORK_TYPE - the type of resources provided; PMIX_ALLOC_NETWORK_PLANE - if applicable, what plane the resources were assigned from; PMIX_ALLOC_NETWORK_QOS - the assigned QoS; PMIX_ALLOC_BANDWIDTH - the allocated bandwidth; PMIX_ALLOC_NETWORK_SEC_KEY - a security key for the requested network allocation. NOTE: the assigned values may differ from those requested, especially if \refstruct{PMIX_INFO_REQD} was not set in the request
 }
 
 %
-\declareNewAttribute{PMIX_ALLOC_BANDWIDTH}{"pmix.alloc.bw"}{float}{
+\declareAttribute{PMIX_ALLOC_BANDWIDTH}{"pmix.alloc.bw"}{float}{
 Mbits/sec.
 }
 
 %
-\declareNewAttribute{PMIX_ALLOC_NETWORK_QOS}{"pmix.alloc.netqos"}{char*}{
+\declareAttribute{PMIX_ALLOC_NETWORK_QOS}{"pmix.alloc.netqos"}{char*}{
 Quality of service level.
 }
 
 %
-\declareNewAttribute{PMIX_ALLOC_TIME}{"pmix.alloc.time"}{uint32_t}{
+\declareAttribute{PMIX_ALLOC_TIME}{"pmix.alloc.time"}{uint32_t}{
 Time in seconds.
+}
+
+%
+\declareNewAttribute{PMIX_ALLOC_NETWORK_TYPE}{"pmix.alloc.nettype"}{char*}{
+Type of desired transport (e.g., ``tcp'', ``udp'')
+}
+
+%
+\declareNewAttribute{PMIX_ALLOC_NETWORK_PLANE}{"pmix.alloc.netplane"}{char*}{
+ID string for the NIC (aka \textit{plane}) to be used for this allocation (e.g., CIDR for Ethernet)
+}
+
+%
+\declareNewAttribute{PMIX_ALLOC_NETWORK_ENDPTS}{"pmix.alloc.endpts"}{size_t}{
+Number of endpoints to allocate per process
+}
+
+%
+\declareNewAttribute{PMIX_ALLOC_NETWORK_ENDPTS_NODE}{"pmix.alloc.endpts.nd"}{size_t}{
+Number of endpoints to allocate per node
+}
+
+%
+\declareNewAttribute{PMIX_ALLOC_NETWORK_SEC_KEY}{"pmix.alloc.nsec"}{pmix_byte_object_t}{
+Network security key
 }
 
 
@@ -3497,83 +3834,113 @@ Time in seconds.
 Attributes used to request control operations on an executing application.
 
 %
-\declareNewAttribute{PMIX_JOB_CTRL_ID}{"pmix.jctrl.id"}{char*}{
+\declareAttribute{PMIX_JOB_CTRL_ID}{"pmix.jctrl.id"}{char*}{
 Provide a string identifier for this request.
 }
 
 %
-\declareNewAttribute{PMIX_JOB_CTRL_PAUSE}{"pmix.jctrl.pause"}{bool}{
+\declareAttribute{PMIX_JOB_CTRL_PAUSE}{"pmix.jctrl.pause"}{bool}{
 Pause the specified processes.
 }
 
 %
-\declareNewAttribute{PMIX_JOB_CTRL_RESUME}{"pmix.jctrl.resume"}{bool}{
+\declareAttribute{PMIX_JOB_CTRL_RESUME}{"pmix.jctrl.resume"}{bool}{
 Resume (``un-pause'') the specified processes.
 }
 
 %
-\declareNewAttribute{PMIX_JOB_CTRL_CANCEL}{"pmix.jctrl.cancel"}{char*}{
+\declareAttribute{PMIX_JOB_CTRL_CANCEL}{"pmix.jctrl.cancel"}{char*}{
 Cancel the specified request (\code{NULL} implies cancel all requests from this requestor).
 }
 
 %
-\declareNewAttribute{PMIX_JOB_CTRL_KILL}{"pmix.jctrl.kill"}{bool}{
+\declareAttribute{PMIX_JOB_CTRL_KILL}{"pmix.jctrl.kill"}{bool}{
 Forcibly terminate the specified processes and cleanup.
 }
 
 %
-\declareNewAttribute{PMIX_JOB_CTRL_RESTART}{"pmix.jctrl.restart"}{char*}{
+\declareAttribute{PMIX_JOB_CTRL_RESTART}{"pmix.jctrl.restart"}{char*}{
 Restart the specified processes using the given checkpoint ID.
 }
 
 %
-\declareNewAttribute{PMIX_JOB_CTRL_CHECKPOINT}{"pmix.jctrl.ckpt"}{char*}{
+\declareAttribute{PMIX_JOB_CTRL_CHECKPOINT}{"pmix.jctrl.ckpt"}{char*}{
 Checkpoint the specified processes and assign the given ID to it.
 }
 
 %
-\declareNewAttribute{PMIX_JOB_CTRL_CHECKPOINT_EVENT}{"pmix.jctrl.ckptev"}{bool}{
+\declareAttribute{PMIX_JOB_CTRL_CHECKPOINT_EVENT}{"pmix.jctrl.ckptev"}{bool}{
 Use event notification to trigger a process checkpoint.
 }
 
 %
-\declareNewAttribute{PMIX_JOB_CTRL_CHECKPOINT_SIGNAL}{"pmix.jctrl.ckptsig"}{int}{
+\declareAttribute{PMIX_JOB_CTRL_CHECKPOINT_SIGNAL}{"pmix.jctrl.ckptsig"}{int}{
 Use the given signal to trigger a process checkpoint.
 }
 
 %
-\declareNewAttribute{PMIX_JOB_CTRL_CHECKPOINT_TIMEOUT}{"pmix.jctrl.ckptsig"}{int}{
+\declareAttribute{PMIX_JOB_CTRL_CHECKPOINT_TIMEOUT}{"pmix.jctrl.ckptsig"}{int}{
 Time in seconds to wait for a checkpoint to complete.
 }
 
 %
-\declareNewAttribute{PMIX_JOB_CTRL_CHECKPOINT_METHOD}{"pmix.jctrl.ckmethod"}{pmix_data_array_t}{
+\declareAttribute{PMIX_JOB_CTRL_CHECKPOINT_METHOD}{"pmix.jctrl.ckmethod"}{pmix_data_array_t}{
 Array of \refstruct{pmix_info_t} declaring each method and value supported by this application.
 }
 
 %
-\declareNewAttribute{PMIX_JOB_CTRL_SIGNAL}{"pmix.jctrl.sig"}{int}{
+\declareAttribute{PMIX_JOB_CTRL_SIGNAL}{"pmix.jctrl.sig"}{int}{
 Send given signal to specified processes.
 }
 
 %
-\declareNewAttribute{PMIX_JOB_CTRL_PROVISION}{"pmix.jctrl.pvn"}{char*}{
+\declareAttribute{PMIX_JOB_CTRL_PROVISION}{"pmix.jctrl.pvn"}{char*}{
 Regular expression identifying nodes that are to be provisioned.
 }
 
 %
-\declareNewAttribute{PMIX_JOB_CTRL_PROVISION_IMAGE}{"pmix.jctrl.pvnimg"}{char*}{
+\declareAttribute{PMIX_JOB_CTRL_PROVISION_IMAGE}{"pmix.jctrl.pvnimg"}{char*}{
 Name of the image that is to be provisioned.
 }
 
 %
-\declareNewAttribute{PMIX_JOB_CTRL_PREEMPTIBLE}{"pmix.jctrl.preempt"}{bool}{
+\declareAttribute{PMIX_JOB_CTRL_PREEMPTIBLE}{"pmix.jctrl.preempt"}{bool}{
 Indicate that the job can be pre-empted.
 }
 
 %
-\declareNewAttribute{PMIX_JOB_CTRL_TERMINATE}{"pmix.jctrl.term"}{bool}{
+\declareAttribute{PMIX_JOB_CTRL_TERMINATE}{"pmix.jctrl.term"}{bool}{
 Politely terminate the specified processes.
+}
+
+%
+\declareNewAttribute{PMIX_REGISTER_CLEANUP}{"pmix.reg.cleanup"}{char*}{
+Comma-delimited list of files to be removed upon process termination
+}
+
+%
+\declareNewAttribute{PMIX_REGISTER_CLEANUP_DIR}{"pmix.reg.cleanupdir"}{char*}{
+Comma-delimited list of directories to be removed upon process termination
+}
+
+%
+\declareNewAttribute{PMIX_CLEANUP_RECURSIVE}{"pmix.clnup.recurse"}{bool}{
+Recursively cleanup all subdirectories under the specified one(s)
+}
+
+%
+\declareNewAttribute{PMIX_CLEANUP_EMPTY}{"pmix.clnup.empty"}{bool}{
+Only remove empty subdirectories
+}
+
+%
+\declareNewAttribute{PMIX_CLEANUP_IGNORE}{"pmix.clnup.ignore"}{char*}{
+Comma-delimited list of filenames that are not to be removed
+}
+
+%
+\declareNewAttribute{PMIX_CLEANUP_LEAVE_TOPDIR}{"pmix.clnup.lvtop"}{bool}{
+When recursively cleaning subdirs, do not remove the top-level directory (the one given in the cleanup request)
 }
 
 
@@ -3584,70 +3951,161 @@ Politely terminate the specified processes.
 Attributes used to control monitoring of an executing application.
 
 %
-\declareNewAttribute{PMIX_MONITOR_ID}{"pmix.monitor.id"}{char*}{
+\declareAttribute{PMIX_MONITOR_ID}{"pmix.monitor.id"}{char*}{
 Provide a string identifier for this request.
 }
 
 %
-\declareNewAttribute{PMIX_MONITOR_CANCEL}{"pmix.monitor.cancel"}{char*}{
+\declareAttribute{PMIX_MONITOR_CANCEL}{"pmix.monitor.cancel"}{char*}{
 Identifier to be canceled (\code{NULL} means cancel all monitoring for this process).
 }
 
 %
-\declareNewAttribute{PMIX_MONITOR_APP_CONTROL}{"pmix.monitor.appctrl"}{bool}{
+\declareAttribute{PMIX_MONITOR_APP_CONTROL}{"pmix.monitor.appctrl"}{bool}{
 The application desires to control the response to a monitoring event.
 }
 
 %
-\declareNewAttribute{PMIX_MONITOR_HEARTBEAT}{"pmix.monitor.mbeat"}{void}{
+\declareAttribute{PMIX_MONITOR_HEARTBEAT}{"pmix.monitor.mbeat"}{void}{
 Register to have the PMIx server monitor the requestor for heartbeats.
 }
 
 %
-\declareNewAttribute{PMIX_SEND_HEARTBEAT}{"pmix.monitor.beat"}{void}{
+\declareAttribute{PMIX_SEND_HEARTBEAT}{"pmix.monitor.beat"}{void}{
 Send heartbeat to local PMIx server.
 }
 
 %
-\declareNewAttribute{PMIX_MONITOR_HEARTBEAT_TIME}{"pmix.monitor.btime"}{uint32_t}{
+\declareAttribute{PMIX_MONITOR_HEARTBEAT_TIME}{"pmix.monitor.btime"}{uint32_t}{
 Time in seconds before declaring heartbeat missed.
 }
 
 %
-\declareNewAttribute{PMIX_MONITOR_HEARTBEAT_DROPS}{"pmix.monitor.bdrop"}{uint32_t}{
+\declareAttribute{PMIX_MONITOR_HEARTBEAT_DROPS}{"pmix.monitor.bdrop"}{uint32_t}{
 Number of heartbeats that can be missed before generating the event.
 }
 
 %
-\declareNewAttribute{PMIX_MONITOR_FILE}{"pmix.monitor.fmon"}{char*}{
+\declareAttribute{PMIX_MONITOR_FILE}{"pmix.monitor.fmon"}{char*}{
 Register to monitor file for signs of life.
 }
 
 %
-\declareNewAttribute{PMIX_MONITOR_FILE_SIZE}{"pmix.monitor.fsize"}{bool}{
+\declareAttribute{PMIX_MONITOR_FILE_SIZE}{"pmix.monitor.fsize"}{bool}{
 Monitor size of given file is growing to determine if the application is running.
 }
 
 %
-\declareNewAttribute{PMIX_MONITOR_FILE_ACCESS}{"pmix.monitor.faccess"}{char*}{
+\declareAttribute{PMIX_MONITOR_FILE_ACCESS}{"pmix.monitor.faccess"}{char*}{
 Monitor time since last access of given file to determine if the application is running.
 }
 
 %
-\declareNewAttribute{PMIX_MONITOR_FILE_MODIFY}{"pmix.monitor.fmod"}{char*}{
+\declareAttribute{PMIX_MONITOR_FILE_MODIFY}{"pmix.monitor.fmod"}{char*}{
 Monitor time since last modified of given file to determine if the application is running.
 }
 
 %
-\declareNewAttribute{PMIX_MONITOR_FILE_CHECK_TIME}{"pmix.monitor.ftime"}{uint32_t}{
+\declareAttribute{PMIX_MONITOR_FILE_CHECK_TIME}{"pmix.monitor.ftime"}{uint32_t}{
 Time in seconds between checking the file.
 }
 
 %
-\declareNewAttribute{PMIX_MONITOR_FILE_DROPS}{"pmix.monitor.fdrop"}{uint32_t}{
+\declareAttribute{PMIX_MONITOR_FILE_DROPS}{"pmix.monitor.fdrop"}{uint32_t}{
 Number of file checks that can be missed before generating the event.
 }
 
+%%%%%%%%%%%
+\subsection{Security attributes}
+\label{api:struct:attributes:security}
+
+Attributes for managing security credentials
+
+%
+\declareNewAttribute{PMIX_CRED_TYPE}{"pmix.sec.ctype"}{char*}{
+When passed in \refapi{PMIx_Get_credential}, a prioritized, comma-delimited list of desired credential types for use
+in environments where multiple authentication mechanisms may be available. When returned in a callback function, a
+string identifier of the credential type
+}
+
+%
+\declareNewAttribute{PMIX_CRYPTO_KEY}{"pmix.sec.key"}{pmix_byte_object_t}{
+Blob containing crypto key
+}
+
+
+%%%%%%%%%%%
+\subsection{IO Forwarding attributes}
+\label{api:struct:attributes:security}
+
+Attributes used to control IO forwarding behaviors
+
+%
+\declareNewAttribute{PMIX_IOF_CACHE_SIZE}{"pmix.iof.csize"}{uint32_t}{
+requested size of the server cache in bytes for each specified channel. By default, the server is allowed (but not required) to drop all bytes received beyond the max size
+}
+
+%
+\declareNewAttribute{PMIX_IOF_DROP_OLDEST}{"pmix.iof.old"}{bool}{
+In an overflow situation, drop the oldest bytes to make room in the cache
+}
+
+%
+\declareNewAttribute{PMIX_IOF_DROP_NEWEST}{"pmix.iof.new"}{bool}{
+In an overflow situation, drop any new bytes received until room becomes available in the cache (default)
+}
+
+%
+\declareNewAttribute{PMIX_IOF_BUFFERING_SIZE}{"pmix.iof.bsize"}{uint32_t}{
+Controls grouping of IO on the specified channel(s) to avoid being called every time a bit of IO arrives. The library will execute the callback whenever the specified number of bytes becomes available. Any remaining buffered data will be ``flushed'' upon call to deregister the respective channel
+}
+
+%
+\declareNewAttribute{PMIX_IOF_BUFFERING_TIME}{"pmix.iof.btime"}{uint32_t}{
+Max time in seconds to buffer IO before delivering it. Used in conjunction with buffering size, this
+prevents IO from being held indefinitely while waiting for another payload to arrive
+}
+
+%
+\declareNewAttribute{PMIX_IOF_COMPLETE}{"pmix.iof.cmp"}{bool}{
+Indicates whether or not the specified IO channel has been closed by the source
+}
+
+%
+\declareNewAttribute{PMIX_IOF_TAG_OUTPUT}{"pmix.iof.tag"}{bool}{
+Tag output with the channel it comes from
+}
+
+%
+\declareNewAttribute{PMIX_IOF_TIMESTAMP_OUTPUT}{"pmix.iof.ts"}{bool}{
+Timestamp output
+}
+
+%
+\declareNewAttribute{PMIX_IOF_XML_OUTPUT}{"pmix.iof.xml"}{bool}{
+Format output in \ac{XML}
+}
+
+%%%%%%%%%%%
+\subsection{Application setup attributes}
+\label{api:struct:attributes:security}
+
+Attributes for controlling contents of application setup data
+
+%
+\declareNewAttribute{PMIX_SETUP_APP_ENVARS}{"pmix.setup.env"}{bool}{
+Harvest and include relevant environmental variables
+}
+
+%
+\declareNewAttribute{PMIX_SETUP_APP_NONENVARS}{""pmix.setup.nenv"}{bool}{
+Include all relevant data other than environmental variables
+}
+
+%
+\declareNewAttribute{PMIX_SETUP_APP_ALL}{"pmix.setup.all"}{bool}{
+Include all relevant data
+}
 
 
 %%%%%%%%%%%
@@ -4109,7 +4567,7 @@ typedef void (*pmix_dmodex_response_fn_t)(pmix_status_t status,
 Define a function to be called by the PMIx server library for return of information posted by a local application process (via \refapi{PMIx_Put} with subsequent \refapi{PMIx_Commit}) in response to a request from the host RM. The returned \refarg{data} blob is owned by the PMIx server library and will be free’d upon return from the function.
 
 %%%%%%%%%%%
-\subsection{\code{pmix_connection_cbfunc_t}}
+\subsection{Tool connection request callback function}
 \declareapi{pmix_connection_cbfunc_t}
 
 %%%%
@@ -4140,7 +4598,7 @@ Callback function for incoming connection requests from local clients - only use
 
 
 %%%%%%%%%%%
-\subsection{\code{pmix_tool_connection_cbfunc_t}}
+\subsection{Tool connection callback function}
 \declareapi{pmix_tool_connection_cbfunc_t}
 
 %%%%
@@ -4177,7 +4635,132 @@ It is assumed that \code{rank=0} will be the normal assignment, but allow for th
 \advicermend
 
 %%%%%%%%%%%
-\subsection{Constant String Functions}
+\subsection{Credential callback function}
+\declareapi{pmix_credential_cbfunc_t}
+
+%%%%
+\summary
+
+Callback function to return a requested security credential
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+typedef void (*pmix_credential_cbfunc_t)(
+                             pmix_status_t status,
+                             pmix_byte_object_t *credential,
+                             pmix_info_t info[], size_t ninfo,
+                             void *cbdata)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{status}{\refstruct{pmix_status_t} value (handle)}
+\argin{credential}{\refstruct{pmix_byte_object_t} structure containing the security credential (handle)}
+\argin{info}{Array of provided by the system to pass any additional information about the credential - e.g., the identity of the issuing agent. (handle)}
+\argin{ninfo}{Number of elements in \refarg{info} (\code{size_t})}
+\argin{cbdata}{Object passed in original request (memory reference)}
+\end{arglist}
+
+%%%%
+\descr
+
+Define a callback function to return a requested security credential. Information provided by the issuing agent can subsequently be used
+by the application for a variety of purposes. Examples include:
+
+\begin{itemize}
+    \item checking identified authorizations to determine what requests/operations are feasible as a means to steering workflows
+    \item compare the credential type to that of the local SMS for compatibility
+\end{itemize}
+
+\adviceuserstart
+The credential is opaque and therefore understandable only by a service compatible with the issuer. The \refarg{info} array is owned by the \ac{PMIx} library and is not to be released or altered by the receiving party.
+\adviceuserend
+
+%%%%%%%%%%%
+\subsection{Credential validation callback function}
+\declareapi{pmix_validation_cbfunc_t}
+
+%%%%
+\summary
+
+Callback function for security credential validation
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+typedef void (*pmix_validation_cbfunc_t)(
+                             pmix_status_t status,
+                             pmix_info_t info[], size_t ninfo,
+                             void *cbdata);
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{status}{\refstruct{pmix_status_t} value (handle)}
+\argin{info}{Array of \refstruct{pmix_info_t} provided by the system to pass any additional information about the authentication - e.g., the effective userid and group id of the certificate holder, and any related authorizations (handle)}
+\argin{ninfo}{Number of elements in \refarg{info} (\code{size_t})}
+\argin{cbdata}{Object passed in original request (memory reference)}
+\end{arglist}
+
+%%%%
+\descr
+
+Define a validation callback function to indicate if a provided credential is valid, and any corresponding information regarding authorizations and other security matters
+
+\adviceuserstart
+The precise contents of the array will depend on the host environment and its associated security system. At the minimum, it is expected (but not required) that the array will contain entries for the \refattr{PMIX_USERID} and \refattr{PMIX_GROUPID} of the client described in the credential. The \refarg{info} array is owned by the \ac{PMIx} library and is not to be released or altered by the receiving party.
+\adviceuserend
+
+%%%%%%%%%%%
+\subsection{IOF delivery function}
+\declareapi{pmix_iof_cbfunc_t}
+
+%%%%
+\summary
+
+Callback function for delivering forwarded \ac{IO} to a process
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+typedef void (*pmix_iof_cbfunc_t)(
+                             size_t iofhdlr, pmix_iof_channel_t channel,
+                             pmix_proc_t *source, char *payload,
+                             pmix_info_t info[], size_t ninfo);
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{iofhdlr}{Registration number of the handler being invoked (\code{size_t})}
+\argin{channel}{bitmask identifying the channel the data arrived on (\refstruct{pmix_iof_channel_t})}
+\argin{source}{Pointer to a \refstruct{pmix_proc_t} identifying the namespace/rank of the process that generated the data (\code{char*})}
+\argin{payload}{Pointer to character array containing the data. Note that }
+\argin{info}{Array of \refstruct{pmix_info_t} provided by the source containing metadata about the payload. This could include \refconst{PMIX_IOF_COMPLETE} (handle)}
+\argin{ninfo}{Number of elements in \refarg{info} (\code{size_t})}
+\end{arglist}
+
+%%%%
+\descr
+
+Define a callback function for delivering forwarded \ac{IO} to a process. This function will be called whenever data becomes available, or a
+specified buffering size and/or time has been met.
+
+\adviceuserstart
+Multiple strings may be included in a given \refarg{payload}, and the \refarg{payload} may \textit{not} be \code{NULL} terminated. The user is responsible for releasing the \refarg{payload} memory. The \refarg{info} array is owned by the \ac{PMIx} library and is not to be released or altered by the receiving party.
+\adviceuserend
+
+%%%%%%%%%%%
+\section{Constant String Functions}
 
 Provide a string representation for several types of values.
 Note that the provided string is statically defined and must NOT be \code{free}'d.
@@ -4293,6 +4876,21 @@ const char*
 PMIx_Alloc_directive_string(pmix_alloc_directive_t directive);
 \end{codepar}
 \cspecificend
+
+%%%%
+\summary
+\declareapi{PMIx_IOF_channel_string}
+
+String representation of a \refstruct{pmix_iof_channel_t}.
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+const char*
+PMIx_IOF_channel_string(pmix_iof_channel_t channel);
+\end{codepar}
+\cspecificend
+
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/Chap_Introduction.tex
+++ b/Chap_Introduction.tex
@@ -157,8 +157,8 @@ Recognizing the burden this places on SMS vendors, the PMIx community has includ
 which the host can request support from local SMS elements. Once the SMS has transferred the request to
 an appropriate location, a PMIx server interface can be used to pass the request between SMS subsystems.
 For example, a request for network traffic statistics can utilize the
-PMIx networking abstractions to retrieve the information from the FM. This reduces the portability and 
-interoperability issues between the individual subsystems by transferring the burden of defining the 
+PMIx networking abstractions to retrieve the information from the FM. This reduces the portability and
+interoperability issues between the individual subsystems by transferring the burden of defining the
 interoperable interfaces from the SMS subsystems to the PMIx community, which continues
 to work with those providers to develop the necessary support.
 
@@ -302,4 +302,36 @@ The following \acp{API} were introduced in v2.0 of the PMIx Standard:
 
 The \refapi{PMIx_Init} \ac{API} was modified in v2.0 of the standard from its \textit{ad hoc} v1.0 signature to include passing of a \refstruct{pmix_info_t} array for flexibility and ``future-proofing'' of the \ac{API}.
 In addition, the \code{PMIx_Notify_error}, \code{PMIx_Register_errhandler}, and \code{PMIx_Deregister_errhandler} \acp{API} were replaced.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%% History: Version 3.0
+\section{Version 3.0: Oct. 2018}
+
+The following \acp{API} were introduced in v3.0 of the PMIx Standard:
+
+\begin{itemize}
+\item Client APIs
+\begin{itemize}
+\item \refapi{Log}, \refapi{PMIx_Job_control}
+\item \refapi{PMIx_Allocation_request}, \refapi{PMIx_Process_monitor}
+\item \refapi{PMIx_Get_credential}, \refapi{PMIx_Validate_credential}
+\end{itemize}
+\item Server APIs
+\begin{itemize}
+\item \refapi{PMIx_IOF_deliver}
+\item \refapi{PMIx_server_collect_inventory}, \refapi{PMIx_server_deliver_inventory}
+\end{itemize}
+\item Tool APIs
+\begin{itemize}
+\item \refapi{PMIx_IOF_pull}, \refapi{PMIx_IOF_push}, \refapi{PMIx_IOF_deregister}
+\item \refapi{PMIx_tool_connect_to_server}
+\end{itemize}
+\item Common APIs
+\begin{itemize}
+\item \refapi{PMIx_IOF_channel_string}
+\end{itemize}
+\end{itemize}
+
+The document added a chapter on security credentials, a new section for \ac{IO} forwarding to the Process Management chapter, and a few blocking forms of previously-existing non-blocking \acp{API}. Attributes supporting the new \acp{API} were introduced, as well as additional attributes for a few existing functions.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Makefile for the PMIx Standard document in LaTex format. 
+# Makefile for the PMIx Standard document in LaTex format.
 # For more information, see the master document, pmix-standard.tex.
 
 version=2.0
@@ -15,6 +15,7 @@ CHAPTERS= \
 	Chap_API_Job_Mgmt.tex \
 	Chap_API_Event.tex \
 	Chap_API_Data_Mgmt.tex \
+	Chap_API_Security.tex \
 	Chap_API_Server.tex \
 	App_Support.tex \
 	Acknowledgements.tex
@@ -23,7 +24,7 @@ SOURCES=
 # SOURCES=sources/*.c \
 # 	sources/*.cpp \
 # 	sources/*.f90 \
-# 	sources/*.f 
+# 	sources/*.f
 
 INTERMEDIATE_FILES=pmix-standard.pdf \
 		pmix-standard.toc \

--- a/pmix-standard.tex
+++ b/pmix-standard.tex
@@ -45,8 +45,8 @@
 \documentclass[10pt,letterpaper,twoside,makeidx,hidelinks]{scrreprt}
 
 % Text to appear in the footer on even-numbered pages:
-\newcommand{\VER}{2.0}
-\newcommand{\VERDATE}{September 2018}
+\newcommand{\VER}{3.0 (draft)}
+\newcommand{\VERDATE}{November 2018}
 \newcommand{\footerText}{PMIx Standard -- Version \VER{} -- \VERDATE}
 
 % Unified style sheet for PMIx documents:
@@ -79,6 +79,7 @@
 \acrodef{PRI}[PRI]{PMIx Reference Implementation}
 \acrodef{ECC}[ECC]{Error Check and Correction}
 \acrodef{FM}[FM]{Fabric Manager}
+\acrodef{IO}[IO]{Input/Output}
 
 %%%%%%%%%%%%%%%%%%%
 
@@ -147,6 +148,9 @@
     % Data Packing & Unpacking
     %  - (un)pack, copy
     \input{Chap_API_Data_Mgmt.tex}
+
+    % Security credentials
+    \input{Chap_API_Security.tex}
 
     % PMIx Server Specific Interfaces
     %  - setup_fork, (de)register_nspace, pmix_server_module_t

--- a/pmix.sty
+++ b/pmix.sty
@@ -215,6 +215,7 @@
 \newcommand{\declareconstitem}[1]{\item[\code{#1}] \index{#1} \hspace{1em}}
 \newcommand{\declareconstitemvalue}[2]{\item[\code{#1}] \index{#1} \hspace{0.25em} \code{#2}  \hspace{1em}}
 \newcommand{\declareconstitemDEP}[2]{\item[\code{#1} (Deprecated in PMIx #2)] \index{#1} \hspace{1em}}
+\newcommand{\declareconstitemNEW}[1]{\item[\color{magenta}\code{#1}] \index{#1} \hspace{1em}}
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Add a Security chapter. Add the few new APIs plus attributes. Show
attributes and error constants that are added in this version in magenta
as a way of highlighting them.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>