### PR TITLE
Editing Pass for v3.0

### DIFF
--- a/Chap_API_Event.tex
+++ b/Chap_API_Event.tex
@@ -79,7 +79,7 @@ PMIx_Register_event_handler(pmix_status_t codes[], size_t ncodes,
 \cspecificend
 
 \begin{arglist}
-\argin{codes}{Array of status codes (array of \refattr{pmix_status_t})}
+\argin{codes}{Array of status codes (array of \refstruct{pmix_status_t})}
 \argin{ncodes}{Number of elements in the \refarg{codes} array (\code{size_t})}
 \argin{info}{Array of info structures (array of handles)}
 \argin{ninfo}{Number of elements in the \refarg{info} array (\code{size_t})}
@@ -211,10 +211,10 @@ PMIx_Notify_event(pmix_status_t status,
 \cspecificend
 
 \begin{arglist}
-\argin{status}{Status code of the event (\refattr{pmix_status_t})}
-\argin{source}{Pointer to a \refapi{pmix_proc_t} identifying the original reporter of the event (handle)}
-\argin{range}{Range across which this notification shall be delivered (\refattr{pmix_data_range_t})}
-\argin{info}{Array of \refapi{pmix_info_t} structures containing any further info provided by the originator of the event (array of handles)}
+\argin{status}{Status code of the event (\refstruct{pmix_status_t})}
+\argin{source}{Pointer to a \refstruct{pmix_proc_t} identifying the original reporter of the event (handle)}
+\argin{range}{Range across which this notification shall be delivered (\refstruct{pmix_data_range_t})}
+\argin{info}{Array of \refstruct{pmix_info_t} structures containing any further info provided by the originator of the event (array of handles)}
 \argin{ninfo}{Number of elements in the \refarg{info} array (\code{size_t})}
 \argin{cbfunc}{Callback function to be executed upon completion of operation \refapi{pmix_op_cbfunc_t} (function reference)}
 \argin{cbdata}{Data to be passed to the cbfunc callback function (memory reference)}

--- a/Chap_API_Init.tex
+++ b/Chap_API_Init.tex
@@ -112,7 +112,7 @@ PMIx_Init(pmix_proc_t *proc,
 
 \begin{arglist}
 \arginout{proc}{proc structure (handle)}
-\argin{info}{Array of \refattr{pmix_info_t} structures (array of handles)}
+\argin{info}{Array of \refstruct{pmix_info_t} structures (array of handles)}
 \argin{ninfo}{Number of element in the \refarg{info} array (\code{size_t})}
 \end{arglist}
 
@@ -189,7 +189,7 @@ PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
 \cspecificend
 
 \begin{arglist}
-\argin{info}{Array of \refattr{pmix_info_t} structures (array of handles)}
+\argin{info}{Array of \refstruct{pmix_info_t} structures (array of handles)}
 \argin{ninfo}{Number of element in the \refarg{info} array (\code{size_t})}
 \end{arglist}
 
@@ -238,7 +238,7 @@ PMIx_tool_init(pmix_proc_t *proc,
 
 \begin{arglist}
 \arginout{proc}{\refstruct{pmix_proc_t} structure (handle)}
-\argin{info}{Array of \refattr{pmix_info_t} structures (array of handles)}
+\argin{info}{Array of \refstruct{pmix_info_t} structures (array of handles)}
 \argin{ninfo}{Number of element in the \refarg{info} array (\code{size_t})}
 \end{arglist}
 
@@ -418,8 +418,8 @@ PMIx_server_init(pmix_server_module_t *module,
 \cspecificend
 
 \begin{arglist}
-\arginout{module}{\refstruct{pmix_server_module_t} structure (handle)}
-\argin{info}{Array of \refattr{pmix_info_t} structures (array of handles)}
+\arginout{module}{\refapi{pmix_server_module_t} structure (handle)}
+\argin{info}{Array of \refstruct{pmix_info_t} structures (array of handles)}
 \argin{ninfo}{Number of elements in the \refarg{info} array (\code{size_t})}
 \end{arglist}
 

--- a/Chap_API_Job_Mgmt.tex
+++ b/Chap_API_Job_Mgmt.tex
@@ -689,7 +689,7 @@ Log data to a data service.
 \begin{codepar}
 pmix_status_t
 PMIx_Log(const pmix_info_t data[], size_t ndata,
-            const pmix_info_t directives[], size_t ndirs)
+         const pmix_info_t directives[], size_t ndirs)
 \end{codepar}
 \cspecificend
 

--- a/Chap_API_Proc_Mgmt.tex
+++ b/Chap_API_Proc_Mgmt.tex
@@ -562,7 +562,7 @@ The forwarding of \ac{IO} via \ac{PMIx} requires that both the host environment 
 %%%%
 \summary
 
-Register to receive output forwarded from a remote process.
+Register to receive output forwarded from a set of remote processes.
 
 %%%%
 \format
@@ -584,12 +584,12 @@ PMIx_IOF_pull(const pmix_proc_t procs[], size_t nprocs,
 \argin{directives}{Array of \refstruct{pmix_info_t} structures (array of handles)}
 \argin{ndirs}{Number of elements in the \refarg{directives} array (integer)}
 \argin{channel}{Bitmask of IO channels included in the request (\refstruct{pmix_iof_channel_t})}
-\argin{cbfunc}{Callback function for delivering relevant output (function reference)}
-\argin{regcbfunc}{Function to be called when registration is completed (function reference)}
+\argin{cbfunc}{Callback function for delivering relevant output (\refapi{pmix_iof_cbfunc_t} function reference)}
+\argin{regcbfunc}{Function to be called when registration is completed (\refapi{pmix_hdlr_reg_cbfunc_t} function reference)}
 \argin{regcbdata}{Data to be passed to the \refarg{regcbfunc} callback function (memory reference)}
 \end{arglist}
 
-Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{regcbfunc} will \textit{not} be called
+Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{regcbfunc} will \textit{not} be called.
 
 \reqattrstart
 The following attributes are required for \ac{PMIx} libraries that support \ac{IO} forwarding:
@@ -614,7 +614,7 @@ The following attributes are optional for \ac{PMIx} libraries that support \ac{I
 %%%%
 \descr
 
-Register to receive output forwarded from a remote process.
+Register to receive output forwarded from a set of remote processes.
 
 \adviceuserstart
 Providing a \code{NULL} function pointer for the \refarg{cbfunc} parameter will cause output for the indicated channels to be written to their corresponding stdout/stderr file descriptors. Use of \refconst{PMIX_RANK_WILDCARD} to specify all processes in a given namespace is supported but should be used carefully due to bandwidth considerations.
@@ -627,7 +627,7 @@ Providing a \code{NULL} function pointer for the \refarg{cbfunc} parameter will 
 %%%%
 \summary
 
-Deregister from output forwarded from a remote process.
+Deregister from output forwarded from a set of remote processes.
 
 %%%%
 \format
@@ -643,19 +643,19 @@ PMIx_IOF_deregister(size_t iofhdlr,
 \cspecificend
 
 \begin{arglist}
-\argin{iofhdlr}{Registration number returned from the call to PMIx_IOF_pull (\code{size_t})}
+\argin{iofhdlr}{Registration number returned from the \refapi{pmix_hdlr_reg_cbfunc_t} callback from the call to \refapi{PMIx_IOF_pull} (\code{size_t})}
 \argin{directives}{Array of \refstruct{pmix_info_t} structures (array of handles)}
 \argin{ndirs}{Number of elements in the \refarg{directives} array (integer)}
 \argin{cbfunc}{Callback function to be called when deregistration has been completed. (function reference)}
 \argin{cbdata}{Data to be passed to the \refarg{cbfunc} callback function (memory reference)}
 \end{arglist}
 
-Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{cbfunc} will \textit{not} be called
+Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{cbfunc} will \textit{not} be called.
 
 %%%%
 \descr
 
-Deregister from output forwarded from a remote process
+Deregister from output forwarded from a set of remote processes.
 
 \adviceimplstart
 Any currently buffered \ac{IO} should be flushed upon receipt of a deregistration request. All received \ac{IO} after receipt of the request shall be discarded.
@@ -692,11 +692,11 @@ PMIx_IOF_push(const pmix_proc_t targets[], size_t ntargets,
 \argin{directives}{Array of \refstruct{pmix_info_t} structures (array of handles)}
 \argin{ndirs}{Number of elements in the \refarg{directives} array (integer)}
 \argin{directives}{Array of \refstruct{pmix_info_t} structures (array of handles)}
-\argin{cbfunc}{Callback function to be called when operation has been completed. (function reference)}
+\argin{cbfunc}{Callback function to be called when operation has been completed. (\refapi{pmix_op_cbfunc_t} function reference)}
 \argin{cbdata}{Data to be passed to the \refarg{cbfunc} callback function (memory reference)}
 \end{arglist}
 
-Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{cbfunc} will \textit{not} be called
+Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{cbfunc} will \textit{not} be called.
 
 \reqattrstart
 The following attributes are required for \ac{PMIx} libraries that support \ac{IO} forwarding:

--- a/Chap_API_Security.tex
+++ b/Chap_API_Security.tex
@@ -38,7 +38,7 @@ PMIx_Get_credential(const pmix_info_t info[], size_t ninfo,
 \cspecificend
 
 \begin{arglist}
-\argin{info}{Array of \refattr{pmix_info_t} structures (array of handles)}
+\argin{info}{Array of \refstruct{pmix_info_t} structures (array of handles)}
 \argin{ninfo}{Number of elements in the \refarg{info} array (\code{size_t})}
 \argin{cbfunc}{Callback function to return credential (\refapi{pmix_credential_cbfunc_t} function reference)}
 \argin{cbdata}{Data to be passed to the callback function (memory reference)}

--- a/Chap_API_Security.tex
+++ b/Chap_API_Security.tex
@@ -31,15 +31,16 @@ Request a credential from the \ac{PMIx} server library or the host environment
 \versionMarker{3.0}
 \cspecificstart
 \begin{codepar}
-pmix_status_t PMIx_Get_credential(const pmix_info_t info[], size_t ninfo,
-                             pmix_credential_cbfunc_t cbfunc, void *cbdata)
+pmix_status_t
+PMIx_Get_credential(const pmix_info_t info[], size_t ninfo,
+                    pmix_credential_cbfunc_t cbfunc, void *cbdata)
 \end{codepar}
 \cspecificend
 
 \begin{arglist}
 \argin{info}{Array of \refattr{pmix_info_t} structures (array of handles)}
 \argin{ninfo}{Number of elements in the \refarg{info} array (\code{size_t})}
-\argin{cbfunc}{Callback function to return credential (function reference)}
+\argin{cbfunc}{Callback function to return credential (\refapi{pmix_credential_cbfunc_t} function reference)}
 \argin{cbdata}{Data to be passed to the callback function (memory reference)}
 \end{arglist}
 
@@ -98,17 +99,19 @@ Request validation of a credential by the \ac{PMIx} server library or the host e
 \versionMarker{3.0}
 \cspecificstart
 \begin{codepar}
-pmix_status_t PMIx_Validate_credential(const pmix_byte_object_t *cred,
-                             const pmix_info_t info[], size_t ninfo,
-                             pmix_validation_cbfunc_t cbfunc, void *cbdata)
+pmix_status_t
+PMIx_Validate_credential(const pmix_byte_object_t *cred,
+                         const pmix_info_t info[], size_t ninfo,
+                         pmix_validation_cbfunc_t cbfunc,
+                         void *cbdata)
 \end{codepar}
 \cspecificend
 
 \begin{arglist}
 \argin{cred}{Pointer to \refstruct{pmix_byte_object_t} containing the credential (handle)}
-\argin{info}{Array of \refattr{pmix_info_t} structures (array of handles)}
+\argin{info}{Array of \refstruct{pmix_info_t} structures (array of handles)}
 \argin{ninfo}{Number of elements in the \refarg{info} array (\code{size_t})}
-\argin{cbfunc}{Callback function to return result (function reference)}
+\argin{cbfunc}{Callback function to return result (\refapi{pmix_validation_cbfunc_t} function reference)}
 \argin{cbdata}{Data to be passed to the callback function (memory reference)}
 \end{arglist}
 
@@ -144,7 +147,7 @@ We recommend that implementation of the \refattr{PMIX_TIMEOUT} attribute be left
 %%%%
 \descr
 
-Request validation of a credential by the \ac{PMIx} server library or the host environment
+Request validation of a credential by the \ac{PMIx} server library or the host environment.
 
 
 

--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -787,12 +787,12 @@ the client.
 The server_object parameter will be the value of the server_object parameter passed to
 \refapi{PMIx_server_register_client} by the host server when registering the connecting client.  If provided, an implementation of \refapi{pmix_server_client_connected_fn_t}
 is only required to
-call the callback function designated.  A host server can choose to not be notified when clients connect by setting \refapi{client_connected} to \code{NULL}.
+call the callback function designated.  A host server can choose to not be notified when clients connect by setting \refapi{pmix_server_client_connected_fn_t} to \code{NULL}.
 
-It is possible that only a subset of the clients in a namespace call \refapi{PMIx_init}.   The server's \refapi{pmix_server_client_connected_fn_t} implementation
+It is possible that only a subset of the clients in a namespace call \refapi{PMIx_Init}.   The server's \refapi{pmix_server_client_connected_fn_t} implementation
 should not depend on being called once per rank in a namespace or delay calling the callback function until all ranks have connected.
 However, if a rank makes any \ac{PMIx} calls, it must first call \refapi{PMIx_Init} and
-therefore the server's \refapi{mpix_server_client_connected_fn_t} will be called before any other server functions specific to the rank.
+therefore the server's \refapi{pmix_server_client_connected_fn_t} will be called before any other server functions specific to the rank.
 
 \advicermstart
  This operation is an opportunity for a host environment
@@ -840,10 +840,10 @@ Note that the client will be in a blocked state until the host server executes t
 The server_object parameter will be the value of the server_object parameter passed to
 \refapi{PMIx_server_register_client} by the host server when registering the connecting client.  If provided, an implementation of \refapi{pmix_server_client_finalized_fn_t}
 is only required to
-call the callback function designated.  A host server can choose to not be notified when clients finalize by setting \refapi{client_finalized} to \code{NULL}.
+call the callback function designated.  A host server can choose to not be notified when clients finalize by setting \refapi{pmix_server_client_finalized_fn_t} to \code{NULL}.
 
 Note that the host server is only being informed that the client has called \refapi{PMIx_Finalize}.  The client might not have exited.  If a client
-exits without calling \refapi{PMIx_Finalize}, the server support library will not call the \refapi{PMIx_server_client_finalized_fn_t} implementation.
+exits without calling \refapi{PMIx_Finalize}, the server support library will not call the \refapi{pmix_server_client_finalized_fn_t} implementation.
 
 \advicermstart
 This operation is an opportunity for a host server

--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -588,7 +588,7 @@ PMIx_server_IOF_deliver(const pmix_proc_t *source,
 \argin{cbdata}{Data to be passed to the callback function (memory reference)}
 \end{arglist}
 
-Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{cbfunc} will \textit{not} be called
+Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{cbfunc} will \textit{not} be called.
 
 %%%%
 \descr
@@ -611,19 +611,21 @@ Collect inventory of resources on a node
 \cspecificstart
 \begin{codepar}
 pmix_status_t
-PMIx_server_collect_inventory(const pmix_info_t directives[], size_t ndirs,
-                              pmix_info_cbfunc_t cbfunc, void *cbdata);
+PMIx_server_collect_inventory(const pmix_info_t directives[],
+                              size_t ndirs,
+                              pmix_info_cbfunc_t cbfunc,
+                              void *cbdata);
 \end{codepar}
 \cspecificend
 
 \begin{arglist}
 \argin{directives}{Array of \refstruct{pmix_info_t} directing the request (array of handles)}
 \argin{ndirs}{Number of elements in the \refarg{directives} array (\code{size_t})}
-\argin{cbfunc}{Callback function to return collected data (function reference)}
+\argin{cbfunc}{Callback function to return collected data (\refapi{pmix_info_cbfunc_t} function reference)}
 \argin{cbdata}{Data to be passed to the callback function (memory reference)}
 \end{arglist}
 
-Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{cbfunc} will \textit{not} be called
+Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{cbfunc} will \textit{not} be called.
 
 %%%%
 \descr
@@ -650,9 +652,12 @@ Pass collected inventory to the \ac{PMIx} server library for storage
 \cspecificstart
 \begin{codepar}
 pmix_status_t
-PMIx_server_deliver_inventory(const pmix_info_t info[], size_t ninfo,
-                              const pmix_info_t directives[], size_t ndirs,
-                              pmix_op_cbfunc_t cbfunc, void *cbdata);
+PMIx_server_deliver_inventory(const pmix_info_t info[],
+                              size_t ninfo,
+                              const pmix_info_t directives[],
+                              size_t ndirs,
+                              pmix_op_cbfunc_t cbfunc,
+                              void *cbdata);
 \end{codepar}
 \cspecificend
 
@@ -665,12 +670,12 @@ PMIx_server_deliver_inventory(const pmix_info_t info[], size_t ninfo,
 \argin{cbdata}{Data to be passed to the callback function (memory reference)}
 \end{arglist}
 
-Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{cbfunc} will \textit{not} be called
+Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{cbfunc} will \textit{not} be called.
 
 %%%%
 \descr
 
-Provide a function by which the host environment can pass inventory information obtained from a node to the \ac{PMIx} server library for storage. Inventory data is subsequently used by the \ac{PMIx} server library for allocations in response to \refapi{PMIx_server_setup_application}, and may be available to the library's host via the \ac{PMIx_Get} \ac{API} (depending upon \ac{PMIx} implementation). The \refarg{cbfunc} callback function will be called once the \ac{PMIx} server library no longer requires access to the provided data.
+Provide a function by which the host environment can pass inventory information obtained from a node to the \ac{PMIx} server library for storage. Inventory data is subsequently used by the \ac{PMIx} server library for allocations in response to \refapi{PMIx_server_setup_application}, and may be available to the library's host via the \refapi{PMIx_Get} \ac{API} (depending upon \ac{PMIx} implementation). The \refarg{cbfunc} callback function will be called once the \ac{PMIx} server library no longer requires access to the provided data.
 
 %%%%%%%%%%%
 \section{Server Function Pointers}
@@ -2119,8 +2124,10 @@ Request a credential from the host environment
 \begin{codepar}
 typedef pmix_status_t (*pmix_server_get_cred_fn_t)(
                              const pmix_proc_t *proc,
-                             const pmix_info_t directives[], size_t ndirs,
-                             pmix_credential_cbfunc_t cbfunc, void *cbdata);
+                             const pmix_info_t directives[],
+                             size_t ndirs,
+                             pmix_credential_cbfunc_t cbfunc,
+                             void *cbdata);
 \end{codepar}
 \cspecificend
 
@@ -2128,11 +2135,11 @@ typedef pmix_status_t (*pmix_server_get_cred_fn_t)(
 \argin{proc}{\refstruct{pmix_proc_t} structure of requesting process (handle)}
 \argin{directives}{Array of info structures (array of handles)}
 \argin{ndirs}{Number of elements in the \refarg{info} array (integer)}
-\argin{cbfunc}{Callback function to return the credential (function reference)}
+\argin{cbfunc}{Callback function to return the credential (\refapi{pmix_credential_cbfunc_t} function reference)}
 \argin{cbdata}{Data to be passed to the callback function (memory reference)}
 \end{arglist}
 
-Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{cbfunc} will \textit{not} be called
+Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{cbfunc} will \textit{not} be called.
 
 \reqattrstart
 If the \ac{PMIx} library does not itself provide the requested credential, then it is required to pass any attributes provided by the client to the host environment for processing. In addition, it must include the following attributes in the passed \refarg{info} array:
@@ -2182,8 +2189,10 @@ Request validation of a credential
 typedef pmix_status_t (*pmix_server_validate_cred_fn_t)(
                              const pmix_proc_t *proc,
                              const pmix_byte_object_t *cred,
-                             const pmix_info_t directives[], size_t ndirs,
-                             pmix_validation_cbfunc_t cbfunc, void *cbdata);
+                             const pmix_info_t directives[],
+                             size_t ndirs,
+                             pmix_validation_cbfunc_t cbfunc,
+                             void *cbdata);
 \end{codepar}
 \cspecificend
 
@@ -2192,7 +2201,7 @@ typedef pmix_status_t (*pmix_server_validate_cred_fn_t)(
 \argin{cred}{Pointer to \refstruct{pmix_byte_object_t} containing the credential (handle)}
 \argin{directives}{Array of info structures (array of handles)}
 \argin{ndirs}{Number of elements in the \refarg{info} array (integer)}
-\argin{cbfunc}{Callback function to return the result (function reference)}
+\argin{cbfunc}{Callback function to return the result (\refapi{pmix_validation_cbfunc_t} function reference)}
 \argin{cbdata}{Data to be passed to the callback function (memory reference)}
 \end{arglist}
 
@@ -2238,7 +2247,7 @@ Request validation of a credential obtained from the host environment via a prio
 %%%%
 \summary
 
-Request the specified IO channels be forwarded from the given array of procs.
+Request the specified IO channels be forwarded from the given array of processes.
 
 %%%%
 \format
@@ -2247,10 +2256,10 @@ Request the specified IO channels be forwarded from the given array of procs.
 \cspecificstart
 \begin{codepar}
 typedef pmix_status_t (*pmix_server_iof_fn_t)(
-                             const pmix_proc_t procs[], size_t nprocs,
-                             const pmix_info_t directives[], size_t ndirs,
-                             pmix_iof_channel_t channels,
-                             pmix_op_cbfunc_t cbfunc, void *cbdata);
+                        const pmix_proc_t procs[], size_t nprocs,
+                        const pmix_info_t directives[], size_t ndirs,
+                        pmix_iof_channel_t channels,
+                        pmix_op_cbfunc_t cbfunc, void *cbdata);
 \end{codepar}
 \cspecificend
 
@@ -2296,10 +2305,10 @@ The following attributes may be supported by a host environment.
 %%%%
 \descr
 
-Request the specified IO channels be forwarded from the given array of procs. An error shall be returned in the callback function if the requested service from \textit{any} of the requested procs cannot be provided.
+Request the specified IO channels be forwarded from the given array of processes. An error shall be returned in the callback function if the requested service from \textit{any} of the requested processes cannot be provided.
 
 \adviceimplstart
-The forwarding of stdin is a \textit{push} process - procs cannot request that it be \textit{pulled} from some other source. Requests including the \refconst{PMIX_FWD_STDIN_CHANNEL} channel will return a \refconst{PMIX_ERR_NOT_SUPPORTED} error.
+The forwarding of stdin is a \textit{push} process - processes cannot request that it be \textit{pulled} from some other source. Requests including the \refconst{PMIX_FWD_STDIN_CHANNEL} channel will return a \refconst{PMIX_ERR_NOT_SUPPORTED} error.
 \adviceimplend
 
 
@@ -2310,7 +2319,7 @@ The forwarding of stdin is a \textit{push} process - procs cannot request that i
 %%%%
 \summary
 
-Pass stdin data to the host environment for transmission to specified recipients.
+Pass standard input data to the host environment for transmission to specified recipients.
 
 %%%%
 \format
@@ -2319,11 +2328,13 @@ Pass stdin data to the host environment for transmission to specified recipients
 \cspecificstart
 \begin{codepar}
 typedef pmix_status_t (*pmix_server_stdin_fn_t)(
-                             const pmix_proc_t *source,
-                             const pmix_proc_t targets[], size_t ntargets,
-                             const pmix_info_t directives[], size_t ndirs,
-                             const pmix_byte_object_t *bo,
-                             pmix_op_cbfunc_t cbfunc, void *cbdata);
+                           const pmix_proc_t *source,
+                           const pmix_proc_t targets[],
+                           size_t ntargets,
+                           const pmix_info_t directives[],
+                           size_t ndirs,
+                           const pmix_byte_object_t *bo,
+                           pmix_op_cbfunc_t cbfunc, void *cbdata);
 \end{codepar}
 \cspecificend
 

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -285,6 +285,7 @@ The \ac{GDS} action has completed
 \declareconstitem{PMIX_ERR_INVALID_OPERATION}
 The requested operation is supported by the implementation and host environment, but fails to meet a requirement (e.g., requesting to \textit{disconnect} from processes without first \textit{connecting} to them).
 
+\versionMarker{3.0}
 \declareconstitemNEW{PMIX_PROC_HAS_CONNECTED}
 A tool or client has connected to the \ac{PMIx} server
 %
@@ -1332,7 +1333,7 @@ PMIX_INFO_REQUIRED(info);
 \argin{info}{Pointer to the \refstruct{pmix_info_t} (pointer to \refstruct{pmix_info_t})}
 \end{arglist}
 
-This macro simplifies the setting of the \refstruct{PMIX_INFO_REQD} flag in \refstruct{pmix_info_t} structures.
+This macro simplifies the setting of the \refconst{PMIX_INFO_REQD} flag in \refstruct{pmix_info_t} structures.
 
 %%%%
 \subsubsection{Mark an info structure as optional}
@@ -1431,11 +1432,11 @@ A value boundary above which implementers are free to define their own directive
 
 
 %%%%%%%%%%%
-\subsection{IOF Channels}
+\subsection{IO Forwarding Channels}
 \declarestruct{pmix_iof_channel_t}
 
 \versionMarker{3.0}
-The \refstruct{pmix_iof_channel_t} structure is a \code{uint16_t} type that defines a set of bit-mask flags for specifying IO forwarding channels. These can be OR'd together to reference multiple channels
+The \refstruct{pmix_iof_channel_t} structure is a \code{uint16_t} type that defines a set of bit-mask flags for specifying IO forwarding channels. These can be bitwise OR'd together to reference multiple channels.
 
 \begin{constantdesc}
 %
@@ -1466,12 +1467,12 @@ Forward all available channels
 
 \versionMarker{3.0}
 Define a structure for specifying environment variable modifications.
-Standard environment variables (e.g., PATH, LD_LIBRARY_PATH, and LD_PRELOAD)
+Standard environment variables (e.g., \code{PATH}, \code{LD_LIBRARY_PATH}, and \code{LD_PRELOAD})
 take multiple arguments separated by delimiters. Unfortunately, the delimiters
 depend upon the variable itself - some use semi-colons, some colons, etc. Thus,
 the operation requires not only the name of the variable to be modified and
 the value to be inserted, but also the separator to be used when composing
-the aggregate value
+the aggregate value.
 
 \cspecificstart
 \begin{codepar}
@@ -3766,14 +3767,13 @@ Number of Megabytes.
 
 %
 \declareNewAttribute{PMIX_ALLOC_NETWORK}{"pmix.alloc.net"}{array}{
-Array of \refstruct{pmix_info_t} describing requested network resources. This must include at least: PMIX_ALLOC_NETWORK_ID, PMIX_ALLOC_NETWORK_TYPE, and PMIX_ALLOC_NETWORK_ENDPTS, plus whatever other descriptors are desired
+Array of \refstruct{pmix_info_t} describing requested network resources. This must include at least: \refattr{PMIX_ALLOC_NETWORK_ID}, \refattr{PMIX_ALLOC_NETWORK_TYPE}, and \refattr{PMIX_ALLOC_NETWORK_ENDPTS}, plus whatever other descriptors are desired.
 }
 
 %
 \declareNewAttribute{PMIX_ALLOC_NETWORK_ID}{"pmix.alloc.netid"}{char*}{
-key to be used when accessing this requested network allocation. The allocation will be returned/stored as a \refstruct{pmix_data_array_t} of
-\refstruct{pmix_info_t} indexed by this key and containing at least one entry with the same key and the allocated resource description.
-The type of the included value depends upon the network support. For example, a TCP allocation might consist of a comma-delimited string of socket ranges such as "32000-32100,33005,38123-38146". Additional entries will consist of any provided resource request directives, along with their assigned values. Examples include: PMIX_ALLOC_NETWORK_TYPE - the type of resources provided; PMIX_ALLOC_NETWORK_PLANE - if applicable, what plane the resources were assigned from; PMIX_ALLOC_NETWORK_QOS - the assigned QoS; PMIX_ALLOC_BANDWIDTH - the allocated bandwidth; PMIX_ALLOC_NETWORK_SEC_KEY - a security key for the requested network allocation. NOTE: the assigned values may differ from those requested, especially if \refstruct{PMIX_INFO_REQD} was not set in the request
+The key to be used when accessing this requested network allocation. The allocation will be returned/stored as a \refstruct{pmix_data_array_t} of \refstruct{pmix_info_t} indexed by this key and containing at least one entry with the same key and the allocated resource description.
+The type of the included value depends upon the network support. For example, a TCP allocation might consist of a comma-delimited string of socket ranges such as \var{"32000-32100,33005,38123-38146"}. Additional entries will consist of any provided resource request directives, along with their assigned values. Examples include: \refattr{PMIX_ALLOC_NETWORK_TYPE} - the type of resources provided; \refattr{PMIX_ALLOC_NETWORK_PLANE} - if applicable, what plane the resources were assigned from; \refattr{PMIX_ALLOC_NETWORK_QOS} - the assigned QoS; \refattr{PMIX_ALLOC_BANDWIDTH} - the allocated bandwidth; \refattr{PMIX_ALLOC_NETWORK_SEC_KEY} - a security key for the requested network allocation. NOTE: the assigned values may differ from those requested, especially if \refconst{PMIX_INFO_REQD} was not set in the request.
 }
 
 %
@@ -3793,7 +3793,7 @@ Time in seconds.
 
 %
 \declareNewAttribute{PMIX_ALLOC_NETWORK_TYPE}{"pmix.alloc.nettype"}{char*}{
-Type of desired transport (e.g., ``tcp'', ``udp'')
+Type of desired transport (e.g., \var{``tcp''}, \var{``udp''})
 }
 
 %
@@ -3930,7 +3930,7 @@ Comma-delimited list of filenames that are not to be removed
 
 %
 \declareNewAttribute{PMIX_CLEANUP_LEAVE_TOPDIR}{"pmix.clnup.lvtop"}{bool}{
-When recursively cleaning subdirs, do not remove the top-level directory (the one given in the cleanup request)
+When recursively cleaning subdirectories, do not remove the top-level directory (the one given in the cleanup request)
 }
 
 
@@ -4009,13 +4009,14 @@ Number of file checks that can be missed before generating the event.
 \subsection{Security attributes}
 \label{api:struct:attributes:security}
 
+\versionMarker{3.0}
 Attributes for managing security credentials
 
 %
 \declareNewAttribute{PMIX_CRED_TYPE}{"pmix.sec.ctype"}{char*}{
 When passed in \refapi{PMIx_Get_credential}, a prioritized, comma-delimited list of desired credential types for use
 in environments where multiple authentication mechanisms may be available. When returned in a callback function, a
-string identifier of the credential type
+string identifier of the credential type.
 }
 
 %
@@ -4028,42 +4029,43 @@ Blob containing crypto key
 \subsection{IO Forwarding attributes}
 \label{api:struct:attributes:security}
 
-Attributes used to control IO forwarding behaviors
+\versionMarker{3.0}
+Attributes used to control IO forwarding behavior
 
 %
 \declareNewAttribute{PMIX_IOF_CACHE_SIZE}{"pmix.iof.csize"}{uint32_t}{
-requested size of the server cache in bytes for each specified channel. By default, the server is allowed (but not required) to drop all bytes received beyond the max size
+The requested size of the server cache in bytes for each specified channel. By default, the server is allowed (but not required) to drop all bytes received beyond the max size.
 }
 
 %
 \declareNewAttribute{PMIX_IOF_DROP_OLDEST}{"pmix.iof.old"}{bool}{
-In an overflow situation, drop the oldest bytes to make room in the cache
+In an overflow situation, drop the oldest bytes to make room in the cache.
 }
 
 %
 \declareNewAttribute{PMIX_IOF_DROP_NEWEST}{"pmix.iof.new"}{bool}{
-In an overflow situation, drop any new bytes received until room becomes available in the cache (default)
+In an overflow situation, drop any new bytes received until room becomes available in the cache (default).
 }
 
 %
 \declareNewAttribute{PMIX_IOF_BUFFERING_SIZE}{"pmix.iof.bsize"}{uint32_t}{
-Controls grouping of IO on the specified channel(s) to avoid being called every time a bit of IO arrives. The library will execute the callback whenever the specified number of bytes becomes available. Any remaining buffered data will be ``flushed'' upon call to deregister the respective channel
+Controls grouping of IO on the specified channel(s) to avoid being called every time a bit of IO arrives. The library will execute the callback whenever the specified number of bytes becomes available. Any remaining buffered data will be ``flushed'' upon call to deregister the respective channel.
 }
 
 %
 \declareNewAttribute{PMIX_IOF_BUFFERING_TIME}{"pmix.iof.btime"}{uint32_t}{
 Max time in seconds to buffer IO before delivering it. Used in conjunction with buffering size, this
-prevents IO from being held indefinitely while waiting for another payload to arrive
+prevents IO from being held indefinitely while waiting for another payload to arrive.
 }
 
 %
 \declareNewAttribute{PMIX_IOF_COMPLETE}{"pmix.iof.cmp"}{bool}{
-Indicates whether or not the specified IO channel has been closed by the source
+Indicates whether or not the specified IO channel has been closed by the source.
 }
 
 %
 \declareNewAttribute{PMIX_IOF_TAG_OUTPUT}{"pmix.iof.tag"}{bool}{
-Tag output with the channel it comes from
+Tag output with the channel it comes from.
 }
 
 %
@@ -4080,6 +4082,7 @@ Format output in \ac{XML}
 \subsection{Application setup attributes}
 \label{api:struct:attributes:security}
 
+\versionMarker{3.0}
 Attributes for controlling contents of application setup data
 
 %
@@ -4702,10 +4705,10 @@ typedef void (*pmix_validation_cbfunc_t)(
 %%%%
 \descr
 
-Define a validation callback function to indicate if a provided credential is valid, and any corresponding information regarding authorizations and other security matters
+Define a validation callback function to indicate if a provided credential is valid, and any corresponding information regarding authorizations and other security matters.
 
 \adviceuserstart
-The precise contents of the array will depend on the host environment and its associated security system. At the minimum, it is expected (but not required) that the array will contain entries for the \refattr{PMIX_USERID} and \refattr{PMIX_GROUPID} of the client described in the credential. The \refarg{info} array is owned by the \ac{PMIx} library and is not to be released or altered by the receiving party.
+The precise contents of the array will depend on the host environment and its associated security system. At the minimum, it is expected (but not required) that the array will contain entries for the \refattr{PMIX_USERID} and \refattr{PMIX_GRPID} of the client described in the credential. The \refarg{info} array is owned by the \ac{PMIx} library and is not to be released or altered by the receiving party.
 \adviceuserend
 
 %%%%%%%%%%%
@@ -4734,7 +4737,7 @@ typedef void (*pmix_iof_cbfunc_t)(
 \argin{iofhdlr}{Registration number of the handler being invoked (\code{size_t})}
 \argin{channel}{bitmask identifying the channel the data arrived on (\refstruct{pmix_iof_channel_t})}
 \argin{source}{Pointer to a \refstruct{pmix_proc_t} identifying the namespace/rank of the process that generated the data (\code{char*})}
-\argin{payload}{Pointer to character array containing the data. Note that }
+\argin{payload}{Pointer to character array containing the data.}
 \argin{info}{Array of \refstruct{pmix_info_t} provided by the source containing metadata about the payload. This could include \refconst{PMIX_IOF_COMPLETE} (handle)}
 \argin{ninfo}{Number of elements in \refarg{info} (\code{size_t})}
 \end{arglist}
@@ -4748,6 +4751,40 @@ specified buffering size and/or time has been met.
 \adviceuserstart
 Multiple strings may be included in a given \refarg{payload}, and the \refarg{payload} may \textit{not} be \code{NULL} terminated. The user is responsible for releasing the \refarg{payload} memory. The \refarg{info} array is owned by the \ac{PMIx} library and is not to be released or altered by the receiving party.
 \adviceuserend
+
+
+%%%%%%%%%%%
+\subsection{IOF and Event registration function}
+\declareapi{pmix_hdlr_reg_cbfunc_t}
+
+%%%%
+\summary
+
+Callback function for calls to register handlers, e.g., event notification and IOF requests.
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+typedef void (*pmix_hdlr_reg_cbfunc_t)(pmix_status_t status,
+                                       size_t refid,
+                                       void *cbdata);
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{status}{\refconst{PMIX_SUCCESS} or an appropriate error constant (\refstruct{pmix_status_t})}
+\argin{refid}{reference identifier assigned to the handler by PMIx, used to deregister the handler (\code{size_t})}
+\argin{cbdata}{object provided to the registration call (pointer)}
+\end{arglist}
+
+%%%%
+\descr
+
+Callback function for calls to register handlers, e.g., event notification and IOF requests.
+
 
 %%%%%%%%%%%
 \section{Constant String Functions}

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -384,7 +384,7 @@ Characters in the key must be standard alphanumeric values supported by common u
 \adviceuserstart
 References to keys in \ac{PMIx} v1 rwere defined simply as an array of characters of size \code{PMIX_MAX_KEYLEN+1}. The \refstruct{pmix_key_t} type definition was introduced in version 2 of the standard. The two definitions are code-compatible and thus do not represent a break in backward compatibility.
 
-Passing a \refstruct{pmix_key_t} value to the standard \textit{sizeof} utility can result in compiler warnings of incorrect returned value. Users are advised to avoid using \textit{sizeof(pmix_key_t)} and instead rely on the \refstruct{PMIX_MAX_KEYLEN} constant.
+Passing a \refstruct{pmix_key_t} value to the standard \textit{sizeof} utility can result in compiler warnings of incorrect returned value. Users are advised to avoid using \textit{sizeof(pmix_key_t)} and instead rely on the \refconst{PMIX_MAX_KEYLEN} constant.
 \adviceuserend
 
 \subsubsection{Key support macro}
@@ -424,7 +424,7 @@ Characters in the namespace must be standard alphanumeric values supported by co
 \adviceuserstart
 References to namespace values in \ac{PMIx} v1 rwere defined simply as an array of characters of size \code{PMIX_MAX_NSLEN+1}. The \refstruct{pmix_nspace_t} type definition was introduced in version 2 of the standard. The two definitions are code-compatible and thus do not represent a break in backward compatibility.
 
-Passing a \refstruct{pmix_nspace_t} value to the standard \textit{sizeof} utility can result in compiler warnings of incorrect returned value. Users are advised to avoid using \textit{sizeof(pmix_nspace_t)} and instead rely on the \refstruct{PMIX_MAX_NSLEN} constant.
+Passing a \refstruct{pmix_nspace_t} value to the standard \textit{sizeof} utility can result in compiler warnings of incorrect returned value. Users are advised to avoid using \textit{sizeof(pmix_nspace_t)} and instead rely on the \refconst{PMIX_MAX_NSLEN} constant.
 \adviceuserend
 
 \subsubsection{Namespace support macro}
@@ -4335,7 +4335,7 @@ typedef void (*pmix_info_cbfunc_t)
 \cspecificend
 
 \begin{arglist}
-\argin{status}{Status associated with the operation (\refattr{pmix_status_t})}
+\argin{status}{Status associated with the operation (\refstruct{pmix_status_t})}
 \argin{info}{Array of \refstruct{pmix_info_t} returned by the operation (pointer)}
 \argin{ninfo}{Number of elements in the \argref{info} array (\code{size_t})}
 \argin{cbdata}{Callback data passed to original API call (memory reference)}
@@ -4372,7 +4372,7 @@ typedef void (*pmix_evhdlr_reg_cbfunc_t)
 \cspecificend
 
 \begin{arglist}
-\argin{status}{Status indicates if the request was successful or not (\refattr{pmix_status_t})}
+\argin{status}{Status indicates if the request was successful or not (\refstruct{pmix_status_t})}
 \argin{evhdlr_ref}{Reference assigned to the event handler by \ac{PMIx} --- this reference
  * must be used to deregister the err handler (\code{size_t})}
 \argin{cbdata}{Callback data passed to original API call (memory reference)}
@@ -4406,7 +4406,7 @@ typedef void (*pmix_event_notification_cbfunc_fn_t)
 \cspecificend
 
 \begin{arglist}
-\argin{status}{Status returned by the event handler's operation (\refattr{pmix_status_t})}
+\argin{status}{Status returned by the event handler's operation (\refstruct{pmix_status_t})}
 \argin{results}{Results from this event handler's operation on the event (\refstruct{pmix_info_t})}
 \argin{nresults}{Number of elements in the results array (\code{size_t})}
 \argin{cbfunc}{\refapi{pmix_op_cbfunc_t} function to be executed when \ac{PMIx} completes processing the callback (function reference)}
@@ -4452,7 +4452,7 @@ typedef void (*pmix_notification_fn_t)
 
 \begin{arglist}
 \argin{evhdlr_registration_id}{Registration number of the handler being called (\code{size_t})}
-\argin{status}{Status associated with the operation (\refattr{pmix_status_t})}
+\argin{status}{Status associated with the operation (\refstruct{pmix_status_t})}
 \argin{source}{Identifier of the process that generated the event (\refstruct{pmix_proc_t})}. If the source is the \ac{SMS}, then the nspace will be empty and the rank will be PMIX_RANK_UNDEF
 \argin{info}{Information describing the event (\refstruct{pmix_info_t})}. This argument will be NULL if no additional information was provided by the event generator.
 \argin{ninfo}{Number of elements in the info array (\code{size_t})}

--- a/Chap_Introduction.tex
+++ b/Chap_Introduction.tex
@@ -82,7 +82,7 @@ This also applies to the host environments. Resource managers and other system m
 
 One area where this can become more complicated is regarding the attributes that provide information to the client process and/or control the behavior of a \ac{PMIx} standard \ac{API}. For example, the \refattr{PMIX_TIMEOUT} attribute can be used to specify the time (in seconds) before the requested operation should time out. The intent of this attribute is to allow the client to avoid ``hanging'' in a request that takes longer than the client wishes to wait, or may never return (e.g., a \refapi{PMIx_Fence} that a blocked participant never enters).
 
-If an application (for example) truly relies on the \refattr{PMIX_TIMEOUT} attribute in a call to \refapi{PMIx_Fence}, it should set the required flag in the \refattr{pmix_info_t} for that attribute. This informs the library and its \ac{SMS} host that it must return an immediate error if this attribute is not supported. By not setting the flag, the library and \ac{SMS} host are allowed to treat the attribute as optional, ignoring it if support is not available.
+If an application (for example) truly relies on the \refattr{PMIX_TIMEOUT} attribute in a call to \refapi{PMIx_Fence}, it should set the required flag in the \refstruct{pmix_info_t} for that attribute. This informs the library and its \ac{SMS} host that it must return an immediate error if this attribute is not supported. By not setting the flag, the library and \ac{SMS} host are allowed to treat the attribute as optional, ignoring it if support is not available.
 
 It is therefore critical that users and application implementers:
 
@@ -261,7 +261,7 @@ Below are a summary listing of the interfaces defined in the 1.0 headers.
 \item Common APIs
 \begin{itemize}
 \item \refapi{PMIx_Get_version}, \refapi{PMIx_Store_internal}, \refapi{PMIx_Error_string}
-\item \refapi{PMIx_Register_errhandler}, \refapi{PMIx_Deregister_errhandler}, \refapi{PMIx_Notify_error}
+\item PMIx_Register_errhandler, PMIx_Deregister_errhandler, PMIx_Notify_error
 \end{itemize}
 \end{itemize}
 
@@ -301,7 +301,7 @@ The following \acp{API} were introduced in v2.0 of the PMIx Standard:
 \end{itemize}
 
 The \refapi{PMIx_Init} \ac{API} was modified in v2.0 of the standard from its \textit{ad hoc} v1.0 signature to include passing of a \refstruct{pmix_info_t} array for flexibility and ``future-proofing'' of the \ac{API}.
-In addition, the \code{PMIx_Notify_error}, \code{PMIx_Register_errhandler}, and \code{PMIx_Deregister_errhandler} \acp{API} were replaced.
+In addition, the PMIx_Notify_error, PMIx_Register_errhandler, and PMIx_Deregister_errhandler \acp{API} were replaced.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/Chap_Tool_Support.tex
+++ b/Chap_Tool_Support.tex
@@ -37,7 +37,7 @@ pmix_status_t PMIx_Get_credential(const pmix_info_t info[], size_t ninfo,
 \cspecificend
 
 \begin{arglist}
-\argin{info}{Array of \refattr{pmix_info_t} structures (array of handles)}
+\argin{info}{Array of \refstruct{pmix_info_t} structures (array of handles)}
 \argin{ninfo}{Number of elements in the \refarg{info} array (\code{size_t})}
 \argin{cbfunc}{Callback function to return credential (function reference)}
 \argin{cbdata}{Data to be passed to the callback function (memory reference)}
@@ -100,7 +100,7 @@ pmix_status_t PMIx_Validate_credential(const pmix_byte_object_t *cred,
 
 \begin{arglist}
 \argin{cred}{Pointer to \refstruct{pmix_byte_object_t} containing the credential (handle)}
-\argin{info}{Array of \refattr{pmix_info_t} structures (array of handles)}
+\argin{info}{Array of \refstruct{pmix_info_t} structures (array of handles)}
 \argin{ninfo}{Number of elements in the \refarg{info} array (\code{size_t})}
 \argin{cbfunc}{Callback function to return result (function reference)}
 \argin{cbdata}{Data to be passed to the callback function (memory reference)}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for the PMIx Standard document in LaTex format.
 # For more information, see the master document, pmix-standard.tex.
 
-version=2.0
+version=3.0
 default: pmix-standard.pdf
 
 CHAPTERS= \

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,10 @@ pmix-standard.pdf: $(CHAPTERS) $(SOURCES) pmix.sty pmix-standard.tex figs/pmix-l
 	pdflatex -interaction=batchmode -file-line-error pmix-standard.tex || \
 		pdflatex -interaction=errorstopmode -file-line-error pmix-standard.tex  < /dev/null
 	pdflatex -interaction=batchmode -file-line-error pmix-standard.tex
-	@echo "====> Success"
+	@echo "====> Checking References (pmix-standard.log)"
+	@grep "Hyper reference" pmix-standard.log | grep Warning && \
+	echo "====> Error check references (above)" || \
+	echo "====> Success"
 	cp pmix-standard.pdf pmix-standard-${version}.pdf
 
 clean:


### PR DESCRIPTION
 * Found a missing funciton.
 * Minor text edits
 * Added a feature to the `Makefile` that will show the undefined references, if any, at the end of the build:
```
====> Checking References (pmix-standard.log)
LaTeX Warning: Hyper reference `api:pmix_status_t' on page 176 undefined on inp
====> Error check references (above)
```