### PR TITLE
Clarify that fence may not involve server

### DIFF
--- a/Chap_API_Key_Value_Mgmt.tex
+++ b/Chap_API_Key_Value_Mgmt.tex
@@ -612,7 +612,9 @@ The following attributes are optional for host environments that support this op
 \adviceimplstart
 We recommend that implementation of the \refattr{PMIX_TIMEOUT} attribute be left to the host environment due to race condition considerations between completion of the operation versus internal timeout in the \ac{PMIx} server library. Implementers that choose to support \refattr{PMIX_TIMEOUT} directly in the \ac{PMIx} server library must take care to resolve the race condition and should avoid passing \refattr{PMIX_TIMEOUT} to the host environment so that multiple competing timeouts are not created.
 
-Note that \ac{PMIx} libraries may choose to implement an optimization for the case where only the calling process is involved in the fence operation by immediately returning \refconst{PMIX_OPERATION_SUCCEEDED} from the client's call in lieu of passing the fence operation to a \ac{PMIx} server.
+Note that \ac{PMIx} libraries may choose to implement an optimization for the case where only the calling process is involved in the fence operation by immediately returning \refconst{PMIX_OPERATION_SUCCEEDED} from the client's call in lieu of passing the fence operation to a \ac{PMIx} server. Fence operations involving more than just the calling process must be communicated to the \ac{PMIx} server for proper execution of the included barrier behavior.
+
+Similarly, fence operations that involve only processes that are clients of the same \ac{PMIx} server may be resolved by that server without referral to its host environment as no inter-node coordination is required.
 \adviceimplend
 
 %%%%

--- a/Chap_API_Key_Value_Mgmt.tex
+++ b/Chap_API_Key_Value_Mgmt.tex
@@ -611,6 +611,8 @@ The following attributes are optional for host environments that support this op
 
 \adviceimplstart
 We recommend that implementation of the \refattr{PMIX_TIMEOUT} attribute be left to the host environment due to race condition considerations between completion of the operation versus internal timeout in the \ac{PMIx} server library. Implementers that choose to support \refattr{PMIX_TIMEOUT} directly in the \ac{PMIx} server library must take care to resolve the race condition and should avoid passing \refattr{PMIX_TIMEOUT} to the host environment so that multiple competing timeouts are not created.
+
+Note that \ac{PMIx} libraries may choose to implement an optimization for the case where only the calling process is involved in the fence operation by immediately returning \refconst{PMIX_OPERATION_SUCCEEDED} from the client's call in lieu of passing the fence operation to a \ac{PMIx} server.
 \adviceimplend
 
 %%%%

--- a/Chap_Introduction.tex
+++ b/Chap_Introduction.tex
@@ -403,6 +403,7 @@ The v3.1 update includes clarifications and corrections from the v3.0 document:
 The following changes were introduced in v4.0 of the PMIx Standard:
 
 \begin{itemize}
+    \item Clarified that the \refapi{PMIx_Fence_nb} operation can immediately return \refconst{PMIX_OPERATION_SUCCEEDED} in lieu of passing the request to a \ac{PMIx} server if only the calling process is involved in the operation
     \item Added the \refapi{PMIx_Register_attributes} \ac{API} by which a host environment can register the attributes it supports for each server-to-host operation
     \item Added the ability to query supported attributes from the \ac{PMIx} tool, client and server libraries, as well as the host environment via the new \refstruct{pmix_regattr_t} structure. Both human-readable and machine-parsable output is supported. New attributes to support this operation include:
     \begin{itemize}


### PR DESCRIPTION
Note that PMIx libraries may choose to implement an
optimization for the case where only the calling process
is involved in the fence operation by immediately
returning PMIX_OPERATION_SUCCEEDED from the client's
call in lieu of passing the fence operation to a PMIx server.

Signed-off-by: Ralph Castain <rhc@pmix.org>