### PR TITLE
Clarify cbfunc precedence during event reg/dereg

### DIFF
--- a/Chap_API_Event.tex
+++ b/Chap_API_Event.tex
@@ -96,7 +96,7 @@ Upon completion, the callback will receive a status based on the following table
 \item \refconst{PMIX_ERR_NOT_SUPPORTED} The \ac{PMIx} implementation does not support event notification, or the host \ac{SMS} does not support notification of the specified event code.
 \end{constantdesc}
 
-The callback function must not be executed prior to returning from the \ac{API}, and no events corresponding to this registration may be delivered prior to the registration callback function (\refarg{cbfunc}) being executed.
+The callback function must not be executed prior to returning from the \ac{API}, and no events corresponding to this registration may be delivered prior to the completion of the registration callback function (\refarg{cbfunc}).
 
 \reqattrstart
 The following attributes are required to be supported by all \ac{PMIx} libraries:

--- a/Chap_API_Event.tex
+++ b/Chap_API_Event.tex
@@ -96,7 +96,7 @@ Upon completion, the callback will receive a status based on the following table
 \item \refconst{PMIX_ERR_NOT_SUPPORTED} The \ac{PMIx} implementation does not support event notification, or the host \ac{SMS} does not support notification of the specified event code.
 \end{constantdesc}
 
-The callback function must not be executed prior to returning from the \ac{API}.
+The callback function must not be executed prior to returning from the \ac{API}, and no events corresponding to this registration may be delivered prior to the registration callback function (\refarg{cbfunc}) being executed.
 
 \reqattrstart
 The following attributes are required to be supported by all \ac{PMIx} libraries:
@@ -195,7 +195,7 @@ If the provided cbfunc is called to confirm removal of the designated handler, t
 %%%%
 \descr
 
-Deregister an event handler.
+Deregister an event handler. Note that no events corresponding to the referenced registration may be delivered following completion of the deregistration operation (either return from the \ac{API} with \refconst{PMIX_OPERATION_SUCCEEDED} or execution of the \refarg{cbfunc}).
 
 %%%%%%%%%%%
 \subsection{\code{PMIx_Notify_event}}


### PR DESCRIPTION
No events corresponding to a registration request may be delivered prior
to executing the registration cbfunc. No events may be delivered after
completing dereg of that handler.

Signed-off-by: Ralph Castain <rhc@pmix.org>