### PR TITLE
Suggested Templates for Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/discussion-topic.md
+++ b/.github/ISSUE_TEMPLATE/discussion-topic.md
@@ -1,0 +1,20 @@
+---
+name: Discussion Topic (RFC)
+about: Propose a general topic for discussion
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Overview
+
+A brief overview of the topic for discussion.
+
+### Motivation
+
+Additional details that may be useful to start the discussion on this topic. Include a list of prior work or other references that are relevant to the discussion.
+
+### Discussion Items
+
+A list of open questions that need to be addressed, or specific subtopics for discussion.

--- a/.github/ISSUE_TEMPLATE/questions---clarifications.md
+++ b/.github/ISSUE_TEMPLATE/questions---clarifications.md
@@ -1,0 +1,18 @@
+---
+name: Questions & Clarifications
+about: Ask a question or suggest clarifications
+title: ''
+labels: Clarification, question
+assignees: ''
+
+---
+
+**Describe your question or clarification request here**
+
+### Suggested Clarification
+
+If you have a suggestion for consideration you can put it here. Otherwise, you can delete this section.
+
+### References
+
+Please list specific chapters/sections in the PMIx Standard related to your query.

--- a/.github/ISSUE_TEMPLATE/use-case.md
+++ b/.github/ISSUE_TEMPLATE/use-case.md
@@ -1,0 +1,21 @@
+---
+name: Use Case
+about: Suggest a new use case
+title: ''
+labels: Use Case
+assignees: ''
+
+---
+
+### Brief Description
+
+A brief description of the use case.
+
+### Use Case Details
+
+A place for a longer description of your use case.
+Please also describe any alternative approaches that you have considered.
+
+### References
+
+List any prototypes, similar projects, papers, etc. that provide background and context for this use case. If the use case requires support from a specific resource.


### PR DESCRIPTION
Three templates proposed (user can always open a non-templated Issue if necessary):
 *  `Discussion Topic (RFC)` for general topics and RFC level discussions. These are the deeper discussions.
 *  `Questions & Clarifications` for questions and clarifications. Meant to be lightweight.
 *  `Use Case` for use case discussions.