### PR TITLE
Cleanup constant references

### DIFF
--- a/Chap_API_Init.tex
+++ b/Chap_API_Init.tex
@@ -473,7 +473,7 @@ The following attributes are optional for implementers of \ac{PMIx} libraries:
 
 Initialize the \ac{PMIx} server support library, and provide a pointer to a \refapi{pmix_server_module_t} structure containing the caller's callback functions.
 The array of \refstruct{pmix_info_t} structs is used to pass additional info that may be required by the server when initializing.
-For example, it may include the \refconst{PMIX_SERVER_TOOL_SUPPORT} key, thereby indicating that the daemon is willing to accept connection requests from tools.
+For example, it may include the \refattr{PMIX_SERVER_TOOL_SUPPORT} attribute, thereby indicating that the daemon is willing to accept connection requests from tools.
 
 \advicermstart
 Providing a value of \code{NULL} for the \refarg{module} argument is permitted, as is passing an empty \refarg{module} structure. Doing so indicates that the host environment will not provide support for multi-node operations such as \refapi{PMIx_Fence}, but does intend to support local clients access to information.

--- a/Chap_API_Job_Mgmt.tex
+++ b/Chap_API_Job_Mgmt.tex
@@ -539,7 +539,7 @@ The following attributes are optional for host environments that support this op
 Request a job control action.
 The \refarg{targets} array identifies the processes to which the requested job control action is to be applied.
 A \code{NULL} value can be used to indicate all processes in the caller's namespace.
-The use of \refconst{PMIX_RANK_WILDARD} can also be used to indicate that all processes in the given namespace are to be included.
+The use of \refconst{PMIX_RANK_WILDCARD} can also be used to indicate that all processes in the given namespace are to be included.
 
 The directives are provided as \refstruct{pmix_info_t} structures in the \refarg{directives} array.
 The callback function provides a \refarg{status} to indicate whether or not the request was granted, and to provide some information as to the reason for any denial in the \refapi{pmix_info_cbfunc_t} array of \refstruct{pmix_info_t} structures.
@@ -627,7 +627,7 @@ The following attributes are optional for host environments that support this op
 Non-blocking form of the \refapi{PMIx_Job_control} \ac{API}.
 The \refarg{targets} array identifies the processes to which the requested job control action is to be applied.
 A \code{NULL} value can be used to indicate all processes in the caller's namespace.
-The use of \refconst{PMIX_RANK_WILDARD} can also be used to indicate that all processes in the given namespace are to be included.
+The use of \refconst{PMIX_RANK_WILDCARD} can also be used to indicate that all processes in the given namespace are to be included.
 
 The directives are provided as \refstruct{pmix_info_t} structures in the \refarg{directives} array.
 The callback function provides a \refarg{status} to indicate whether or not the request was granted, and to provide some information as to the reason for any denial in the \refapi{pmix_info_cbfunc_t} array of \refstruct{pmix_info_t} structures.
@@ -713,7 +713,7 @@ For example, \refattr{PMIX_MONITOR_FILE} to indicate that the requestor is askin
 
 The \refarg{error} argument is the status code to be used when generating an event notification alerting that the monitor has been triggered.
 The range of the notification defaults to \refconst{PMIX_RANGE_NAMESPACE}.
-This can be changed by providing a \refconst{PMIX_RANGE} directive.
+This can be changed by providing a \refattr{PMIX_RANGE} directive.
 
 The \refarg{directives} argument characterizes the monitoring request (e.g., monitor file size) and frequency of checking to be done
 

--- a/Chap_API_Key_Value_Mgmt.tex
+++ b/Chap_API_Key_Value_Mgmt.tex
@@ -691,7 +691,7 @@ We recommend that implementation of the \refattr{PMIX_TIMEOUT} attribute be left
 \descr
 
 Publish the data in the \refarg{info} array for subsequent lookup.
-By default, the data will be published into the \refconst{PMIX_SESSION} range and with \refconst{PMIX_PERSIST_APP} persistence.
+By default, the data will be published into the \refconst{PMIX_RANGE_SESSION} range and with \refconst{PMIX_PERSIST_APP} persistence.
 Changes to those values, and any additional directives, can be included in the \refstruct{pmix_info_t} array. Attempts to access the data by processes outside of the provided data range will be rejected. The persistence parameter instructs the server as to how long the data is to be retained.
 
 The blocking form will block until the server confirms that the data has been sent to the \ac{PMIx} server and that it has obtained confirmation from its host \ac{SMS} daemon that the data is ready to be looked up. Data is copied into the backing key-value data store, and therefore the \refarg{info} array can be released upon return from the blocking function call.
@@ -819,7 +819,7 @@ We recommend that implementation of the \refattr{PMIX_TIMEOUT} attribute be left
 \descr
 
 Lookup information published by this or another process.
-By default, the search will be conducted across the \refconst{PMIX_SESSION} range.
+By default, the search will be conducted across the \refconst{PMIX_RANGE_SESSION} range.
 Changes to the range, and any additional directives, can be provided in the \refstruct{pmix_info_t} array. Data is returned provided the following conditions are met:
 
 \begin{itemize}
@@ -961,7 +961,7 @@ Unpublish data posted by this process using the given \refarg{keys}.
 The function will block until the data has been removed by the server (i.e., it is safe to publish that key again).
 A value of \code{NULL} for the \refarg{keys} parameter instructs the server to remove all data published by this process.
 
-By default, the range is assumed to be \refconst{PMIX_SESSION}.
+By default, the range is assumed to be \refconst{PMIX_RANGE_SESSION}.
 Changes to the range, and any additional directives, can be provided in the \refarg{info} array.
 
 

--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -1502,7 +1502,7 @@ The following attributes are optional for host environments that support this op
 
 Publish data per the \refapi{PMIx_Publish} specification.
 The callback is to be executed upon completion of the operation.
-The default data range is left to the host environment, but expected to be \refconst{PMIX_SESSION}, and the default persistence \refconst{PMIX_PERSIST_SESSION} or their equivalent.
+The default data range is left to the host environment, but expected to be \refconst{PMIX_RANGE_SESSION}, and the default persistence \refconst{PMIX_PERSIST_SESSION} or their equivalent.
 These values can be specified by including the respective attributed in the \refarg{info} array.
 
 The persistence indicates how long the server should retain the data.
@@ -1585,7 +1585,7 @@ The following attributes are optional for host environments that support this op
 Lookup published data.
 The host server will be passed a \code{NULL}-terminated array of string keys identifying the data being requested.
 
-The array of \refarg{info} structs is used to pass user-requested options to the server. The default data range is left to the host environment, but expected to be \refconst{PMIX_SESSION}.
+The array of \refarg{info} structs is used to pass user-requested options to the server. The default data range is left to the host environment, but expected to be \refconst{PMIX_RANGE_SESSION}.
 This can include a wait flag to indicate that the server should wait for all data to become available before executing the callback function, or should immediately callback with whatever data is available.
 In addition, a timeout can be specified on the wait to preclude an indefinite wait for data that may never be published.
 
@@ -1660,7 +1660,7 @@ The following attributes are optional for host environments that support this op
 \descr
 
 Delete data from the data store.
-The host server will be passed a \code{NULL}-terminated array of string keys, plus potential directives such as the data range within which the keys should be deleted. The default data range is left to the host environment, but expected to be \refconst{PMIX_SESSION}.
+The host server will be passed a \code{NULL}-terminated array of string keys, plus potential directives such as the data range within which the keys should be deleted. The default data range is left to the host environment, but expected to be \refconst{PMIX_RANGE_SESSION}.
 The callback is to be executed upon completion of the delete procedure.
 
 \advicermstart
@@ -1977,7 +1977,7 @@ Register to receive notifications for the specified status codes. The \refarg{in
 The \ac{PMIx} server library must track all client registrations for subsequent notification. This module function shall only be called when:
 
 \begin{itemize}
-    \item the client has requested notification of an environmental code (i.e., a \ac{PMIx} code in the range between \refconst{PMIX_ERR_SYS_BASE} and \refconst{PMIX_ERR_SYS_OTHER}, inclusive) or a code that lies outside the defined \ac{PMIx} range of constants; and
+    \item the client has requested notification of an environmental code (i.e., a \ac{PMIx} code in the range beyond \refconst{PMIX_ERR_SYS_OTHER}) or a code that lies outside the defined \ac{PMIx} range of constants; and
     \item the \ac{PMIx} server library has not previously requested notification of that code - i.e., the host environment is to be contacted only once a given unique code value
 \end{itemize}
 
@@ -2524,7 +2524,7 @@ The following attributes are optional for host environments that support this op
 
 Execute a job control action on behalf of a client. The \refarg{targets} array identifies the processes to which the requested job control action is to be applied.
 A \code{NULL} value can be used to indicate all processes in the caller's namespace.
-The use of \refconst{PMIX_RANK_WILDARD} can also be used to indicate that all processes in the given namespace are to be included.
+The use of \refconst{PMIX_RANK_WILDCARD} can also be used to indicate that all processes in the given namespace are to be included.
 
 The directives are provided as \refstruct{pmix_info_t} structures in the \refarg{directives} array.
 The callback function provides a \refarg{status} to indicate whether or not the request was granted, and to provide some information as to the reason for any denial in the \refapi{pmix_info_cbfunc_t} array of \refstruct{pmix_info_t} structures.

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -338,6 +338,11 @@ Launcher directives have been received from a PMIx-enabled tool
 %
 \declareconstitemNEW{PMIX_LAUNCHER_READY}
 Application launcher (e.g., mpiexec) is ready to receive directives from a PMIx-enabled tool
+
+%
+\declareconstitemNEW{PMIX_LAUNCH_COMPLETE}
+A job has been launched - the nspace of the launched job will be included in the notification
+
 %
 \declareconstitemNEW{PMIX_OPERATION_IN_PROGRESS}
 A requested operation is already in progress
@@ -345,8 +350,76 @@ A requested operation is already in progress
 \declareconstitem{PMIX_OPERATION_SUCCEEDED}
 The requested operation was performed atomically - no callback function will be executed
 %
+\declareconstitemNEW{PMIX_ERR_PARTIAL_SUCCESS}
+The operation is considered successful but not all elements of the operation were concluded (e.g., some members of a group construct operation chose not to participate)
+
+%
 \declareconstitemNEW{PMIX_ERR_DUPLICATE_KEY}
 The provided key has already been published on a different data range
+
+%
+\declareconstitemNEW{PMIX_ERR_INVALID_OPERATION}
+The requested operation is not valid - this can possibly indicate the inclusion of conflicting directives or a request to perform an operation that conflicts with an ongoing one.
+
+%
+\declareconstitemNEW{PMIX_GROUP_INVITED}
+The process has been invited to join a \ac{PMIx} Group - the identifier of the group and the ID's of other invited (or already joined) members will be included in the notification
+
+%
+\declareconstitemNEW{PMIX_GROUP_LEFT}
+A process has asynchronously left a \ac{PMIx} Group - the process identifier of the departing process will in included in the notification
+
+%
+\declareconstitemNEW{PMIX_GROUP_MEMBER_FAILED}
+A member of a \ac{PMIx} Group has abnormally terminated (i.e., without formally leaving the group prior to termination) - the process identifier of the failed process will in included in the notification
+
+%
+\declareconstitemNEW{PMIX_GROUP_INVITE_ACCEPTED}
+A process has accepted an invitation to join a \ac{PMIx} Group - the identifier of the group being joined will be included in the notification
+
+%
+\declareconstitemNEW{PMIX_GROUP_INVITE_DECLINED}
+A process has declined an invitation to join a \ac{PMIx} Group - the identifier of the declined group will be included in the notification
+
+%
+\declareconstitemNEW{PMIX_GROUP_INVITE_FAILED}
+An invited process failed or terminated prior to responding to the invitation - the identifier of the failed process will be included in the notification.
+
+%
+\declareconstitemNEW{PMIX_GROUP_MEMBERSHIP_UPDATE}
+The membership of a \ac{PMIx} group has changed - the identifiers of the revised membership will be included in the notification.
+
+%
+\declareconstitemNEW{PMIX_GROUP_CONSTRUCT_ABORT}
+Any participant in a \ac{PMIx} group construct operation that returns \refconst{PMIX_GROUP_CONSTRUCT_ABORT} from the \emph{leader failed} event handler will cause all participants to receive an event notifying them of that status. Similarly, the leader may elect to abort the procedure by either returning this error code from the handler assigned to the \refconst{PMIX_GROUP_INVITE_ACCEPTED} or \refconst{PMIX_GROUP_INVITE_DECLINED} codes, or by generating an event for the abort code. Abort events will be sent to all invited or existing members of the group.
+
+%
+\declareconstitemNEW{PMIX_GROUP_CONSTRUCT_COMPLETE}
+The group construct operation has completed - the final membership will be included in the notification.
+
+%
+\declareconstitemNEW{PMIX_GROUP_LEADER_FAILED}
+The current \emph{leader} of a group including this process has abnormally terminated - the group identifier will be included in the notification.
+
+%
+\declareconstitemNEW{PMIX_GROUP_LEADER_SELECTED}
+A new \emph{leader} of a group including this process has been selected - the identifier of the new leader will be included in the notification
+
+%
+\declareconstitemNEW{PMIX_GROUP_CONTEXT_ID_ASSIGNED}
+A new \ac{PGCID} has been assigned by the host environment to a group that includes this process - the group identifier will be included in the notification.
+
+%
+\declareconstitemNEW{PMIX_ERR_REPEAT_ATTR_REGISTRATION}
+The attributes for an identical function have already been registered at the specified level (host, server, or client)
+
+%
+\declareconstitemNEW{PMIX_ERR_IOF_FAILURE}
+An \ac{IO} forwarding operation failed - the affected channel will be included in the notification
+
+%
+\declareconstitemNEW{PMIX_ERR_IOF_COMPLETE}
+\ac{IO} forwarding of the standard input for this process has completed - i.e., the stdin file descriptor has closed
 
 \end{constantdesc}
 
@@ -354,14 +427,17 @@ The provided key has already been published on a different data range
 
 \begin{constantdesc}
 %
+\declareconstitem{PMIX_ERR_SYS_BASE}
+Mark the beginning of a dedicated range of constants for system event reporting.
+%
 \declareconstitem{PMIX_ERR_NODE_DOWN}
-Node down
+A node has gone down - the identifier of the affected node will be included in the notification
 %
 \declareconstitem{PMIX_ERR_NODE_OFFLINE}
-Node is marked as offline
+A node has been marked as \emph{offline} - the identifier of the affected node will be included in the notification
 %
 \declareconstitem{PMIX_ERR_SYS_OTHER}
-Mark the beginning of a dedicated range of constants for system event reporting.
+Mark the end of a dedicated range of constants for system event reporting.
 \end{constantdesc}
 %
 
@@ -386,13 +462,13 @@ Event handler: Action complete
 %%%%%%%%%%%
 \subsubsection{User-Defined Error Constants}
 
-PMIx establishes an error code boundary for constants defined in the PMIx standard. Negative values larger than this (and any positive values greater than zero) are guaranteed not to conflict with PMIx values.
+\ac{PMIx} establishes an error code boundary for constants defined in the \ac{PMIx} standard. Negative values larger than this (and any positive values greater than zero) are guaranteed not to conflict with \ac{PMIx} values.
 
 \begin{constantdesc}
 %
 \declareconstitem{PMIX_EXTERNAL_ERR_BASE}
 A starting point for user-level defined error constants.
-Negative values lower than this are guaranteed not to conflict with PMIx values.
+Negative values lower than this are guaranteed not to conflict with \ac{PMIx} values.
 Definitions should always be based on the \refconst{PMIX_EXTERNAL_ERR_BASE} constant and not a specific value as the value of the constant may change.
 %
 \end{constantdesc}
@@ -3435,12 +3511,7 @@ The size of each dimension in the specified network plane/view, returned in a \r
 }
 
 %
-\declareNewAttribute{PMIX_NETWORK_IS_PERIODIC}{"pmix.net.period"}{pmix_data_array_t*}{
-Return a \refstruct{pmix_data_array_t} containing an array of \code{boolean} values indicating whether or not the network topology is periodic in that dimension within the specified view. Default is to provide the periodicity flags in \emph{logical} view.
-}
-
-%
-\declareNewAttribute{PMIX_NETWORK_SHAPE_STRING_ENDPT}{"pmix.net.shapestr"}{char*}{
+\declareNewAttribute{PMIX_NETWORK_SHAPE_STRING}{"pmix.net.shapestr"}{char*}{
 Network shape of the specified plane/view expressed as a string (e.g., "10x12x2"). In the absence of a specified plane, then the shape of each plane in the system will be returned in an array of network shape strings. Default is to provide the shape in \emph{logical} view.
 }
 
@@ -5267,7 +5338,7 @@ typedef void (*pmix_event_notification_cbfunc_fn_t)
 %%%%
 \descr
 
-Define a callback by which an event handler can notify the \ac{PMIx} library that it has completed its response to the notification. The handler is \textit{required} to execute this callback so the library can determine if additional handlers need to be called. The handler shall return \refconst{PMIX_ERR_EVENT_COMPLETE} if no further action is required. The return status of each event handler and any returned \refstruct{pmix_info_t} structures will be added to the \textit{results} array of \refstruct{pmix_info_t} passed to any subsequent event handlers to help guide their operation.
+Define a callback by which an event handler can notify the \ac{PMIx} library that it has completed its response to the notification. The handler is \textit{required} to execute this callback so the library can determine if additional handlers need to be called. The handler shall return \refconst{PMIX_EVENT_ACTION_COMPLETE} if no further action is required. The return status of each event handler and any returned \refstruct{pmix_info_t} structures will be added to the \textit{results} array of \refstruct{pmix_info_t} passed to any subsequent event handlers to help guide their operation.
 
 If non-NULL, the provided callback function will be called to allow the event handler to release the provided info array and execute any other required cleanup operations.
 
@@ -5588,7 +5659,7 @@ typedef void (*pmix_iof_cbfunc_t)(
 \argin{channel}{bitmask identifying the channel the data arrived on (\refstruct{pmix_iof_channel_t})}
 \argin{source}{Pointer to a \refstruct{pmix_proc_t} identifying the namespace/rank of the process that generated the data (\code{char*})}
 \argin{payload}{Pointer to character array containing the data.}
-\argin{info}{Array of \refstruct{pmix_info_t} provided by the source containing metadata about the payload. This could include \refconst{PMIX_IOF_COMPLETE} (handle)}
+\argin{info}{Array of \refstruct{pmix_info_t} provided by the source containing metadata about the payload. This could include \refattr{PMIX_IOF_COMPLETE} (handle)}
 \argin{ninfo}{Number of elements in \refarg{info} (\code{size_t})}
 \end{arglist}
 

--- a/pmix.sty
+++ b/pmix.sty
@@ -213,10 +213,10 @@
 {\begin{description}[itemsep=-1.3ex,itemindent=\dimexpr-17pt-\labelsep\relax]}
 {\end{description}}
 
-\newcommand{\declareconstitem}[1]{\item[\code{#1}] \index{#1} \hspace{1em}}
+\newcommand{\declareconstitem}[1]{\item[\code{#1}] \index{#1} \label{const:#1} \hspace{1em}}
 \newcommand{\declareconstitemvalue}[2]{\item[\code{#1}] \index{#1} \hspace{0.25em} \code{#2}  \hspace{1em}}
-\newcommand{\declareconstitemDEP}[2]{\item[\code{#1} (Deprecated in PMIx #2)] \index{#1} \hspace{1em}}
-\newcommand{\declareconstitemNEW}[1]{\item[\color{magenta}\code{#1}] \index{#1} \hspace{1em}}
+\newcommand{\declareconstitemDEP}[2]{\item[\code{#1} (Deprecated in PMIx #2)] \index{#1} \label{const:#1} \hspace{1em}}
+\newcommand{\declareconstitemNEW}[1]{\item[\color{magenta}\code{#1}] \index{#1} \label{const:#1} \hspace{1em}}
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -689,7 +689,7 @@
 \newcommand{\refapi}[1]{\index{#1} \hyperref[api:#1]{\code{#1} }}
 \newcommand{\argapi}[1] {\refapi{#1}}
 
-\newcommand{\refconst}[1]{\hyperref[chap:struct]{\code{#1} }}
+\newcommand{\refconst}[1]{\hyperref[const:#1]{\code{#1} }}
 
 \newcommand{\declareattr}[1]{\index{#1!Defintion|textbf} \label{attr:#1}}
 


### PR DESCRIPTION
Fix the declare and ref constant macros to correctly label and refer
back to constant definitions. Add missing constants and fix a few typos
that used refconst instead of refattr

Signed-off-by: Ralph Castain <rhc@pmix.org>