### PR TITLE
Support return of static values for PMIx_Get

### DIFF
--- a/Chap_API_Key_Value_Mgmt.tex
+++ b/Chap_API_Key_Value_Mgmt.tex
@@ -111,6 +111,9 @@ The following attributes are required to be supported by all \ac{PMIx} libraries
 \pastePRIAttributeItem{PMIX_JOB_INFO}
 \pastePRIAttributeItem{PMIX_APP_INFO}
 \pastePRIAttributeItem{PMIX_NODE_INFO}
+\pastePRIAttributeItemBegin{PMIX_GET_STATIC_VALUES}
+and indicate that the address provided for the return value points to a statically defined memory location. Returned non-pointer values should therefore be copied directly into the provided memory. Pointers in the returned value should point directly to values in the key-value store. User is responsible for \emph{not} releasing memory on any returned pointer value. Note that a return status of \refconst{PMIX_ERR_GET_MALLOC_REQD} indicates that direct pointers could not be supported - thus, the returned data contains allocated memory that the user must release.
+\pastePRIAttributeItemEnd
 
 \reqattrend
 
@@ -198,6 +201,9 @@ The following attributes are required to be supported by all \ac{PMIx} libraries
 \pastePRIAttributeItem{PMIX_JOB_INFO}
 \pastePRIAttributeItem{PMIX_APP_INFO}
 \pastePRIAttributeItem{PMIX_NODE_INFO}
+\pastePRIAttributeItemBegin{PMIX_GET_STATIC_VALUES}
+and indicate that user takes responsibility for properly releasing memory on the returned value (i.e., free'ing the value structure but not the pointer fields). Note that a return status of \refconst{PMIX_ERR_GET_MALLOC_REQD} indicates that direct pointers could not be supported - thus, the returned data contains allocated memory that the user must release.
+\pastePRIAttributeItemEnd
 
 \reqattrend
 

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -421,6 +421,10 @@ An \ac{IO} forwarding operation failed - the affected channel will be included i
 \declareconstitemNEW{PMIX_ERR_IOF_COMPLETE}
 \ac{IO} forwarding of the standard input for this process has completed - i.e., the stdin file descriptor has closed
 
+%
+\declareconstitemNEW{PMIX_ERR_GET_MALLOC_REQD}
+The data returned by \refapi{PMIx_Get} contains values that required dynamic memory allocations (i.e., "malloc"), despite a request for static pointers to the values in the key-value store. User is responsible for releasing the memory when done with the information.
+
 \end{constantdesc}
 
 \subsubsection{System error constants}
@@ -3689,6 +3693,10 @@ Scope of the data to be found in a \refapi{PMIx_Get} call.
 \declareAttribute{PMIX_OPTIONAL}{"pmix.optional"}{bool}{
 Look only in the client's local data store for the requested value - do not request data from the PMIx server if not found.
 }
+
+%
+\declareNewAttribute{PMIX_GET_STATIC_VALUES}{"pmix.get.static"}{bool}{
+Request that any pointers in the returned value point directly to values in the key-value store}
 
 %
 \declareAttribute{PMIX_EMBED_BARRIER}{"pmix.embed.barrier"}{bool}{


### PR DESCRIPTION
Provide an attribute indicating that the user requests that any
pointers in the returned value point directly to values in the
key-value store. Define a return status of PMIX_ERR_GET_MALLOC_REQD
to indicate that direct pointers could not be supported - thus,
the returned data contains allocated memory that the user must release.

If PMIX_GET_STATIC_VALUES is provided to the blocking PMIx_Get, then
assume that the provided address points to a statically defined memory
location. Returned non-pointer values shall be copied directly into the
provided memory - i.e., do not malloc a pmix_value_t to contain the
returned values. User takes responsibility for not releasing memory
unless the "malloc_reqd" status is returned.

Signed-off-by: Ralph Castain <rhc@pmix.org>