### PR TITLE
Clarify regular expression generator output

### DIFF
--- a/Chap_API_Data_Mgmt.tex
+++ b/Chap_API_Data_Mgmt.tex
@@ -6,16 +6,48 @@
 
 \ac{PMIx} intentionally does not include support for internode communications in the standard, instead relying on its host \ac{SMS} environment to transfer any needed data and/or requests between nodes. These operations frequently involve PMIx-defined public data structures that include binary data. Many \ac{HPC} clusters are homogeneous, and so transferring the structures can be done rather simply. However, greater effort is required in heterogeneous environments to ensure binary data is correctly transferred. \ac{PMIx} buffer manipulation functions are provided for this purpose via standardized interfaces to ease adoption.
 
+%%%%%%%%%%%
+\section{Data Buffer Type}
+\declarestruct{pmix_data_buffer_t}
+
+The \refstruct{pmix_data_buffer_t} structure describes a data buffer used for packing and unpacking.
+
+\versionMarker{2.0}
+\cspecificstart
+\begin{codepar}
+typedef struct pmix_data_buffer \{
+    /** Start of my memory */
+    char *base_ptr;
+    /** Where the next data will be packed to
+        (within the allocated memory starting
+        at base_ptr) */
+    char *pack_ptr;
+    /** Where the next data will be unpacked
+        from (within the allocated memory
+        starting as base_ptr) */
+    char *unpack_ptr;
+    /** Number of bytes allocated (starting
+        at base_ptr) */
+    size_t bytes_allocated;
+    /** Number of bytes used by the buffer
+        (i.e., amount of data -- including
+        overhead -- packed in the buffer) */
+    size_t bytes_used;
+\} pmix_data_buffer_t;
+\end{codepar}
+\cspecificend
+
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Support Macros}
-\label{chap:api_init:macros}
+\label{chap:datamgt:macros}
 
 \ac{PMIx} provides a set of convenience macros for creating, initiating, and releasing data buffers.
 
 %%%%%%%%%%%
 \subsection{\code{PMIX_DATA_BUFFER_CREATE}}
-\declareapi{PMIX_DATA_BUFFER_CREATE}
+\declaremacro{PMIX_DATA_BUFFER_CREATE}
 
 %%%%
 \summary
@@ -44,7 +76,7 @@ This macro uses \textit{calloc} to allocate memory for the buffer and initialize
 
 %%%%%%%%%%%
 \subsection{\code{PMIX_DATA_BUFFER_RELEASE}}
-\declareapi{PMIX_DATA_BUFFER_RELEASE}
+\declaremacro{PMIX_DATA_BUFFER_RELEASE}
 
 %%%%
 \summary
@@ -73,7 +105,7 @@ Free's the data contained in the buffer, and then free's the buffer itself
 
 %%%%%%%%%%%
 \subsection{\code{PMIX_DATA_BUFFER_CONSTRUCT}}
-\declareapi{PMIX_DATA_BUFFER_CONSTRUCT}
+\declaremacro{PMIX_DATA_BUFFER_CONSTRUCT}
 
 %%%%
 \summary
@@ -102,7 +134,7 @@ Initialize a pre-allocated buffer object
 
 %%%%%%%%%%%
 \subsection{\code{PMIX_DATA_BUFFER_DESTRUCT}}
-\declareapi{PMIX_DATA_BUFFER_DESTRUCT}
+\declaremacro{PMIX_DATA_BUFFER_DESTRUCT}
 
 %%%%
 \summary
@@ -131,7 +163,7 @@ Free's the data contained in a \refstruct{pmix_data_buffer_t} object
 
 %%%%%%%%%%%
 \subsection{\code{PMIX_DATA_BUFFER_LOAD}}
-\declareapi{PMIX_DATA_BUFFER_LOAD}
+\declaremacro{PMIX_DATA_BUFFER_LOAD}
 
 %%%%
 \summary
@@ -162,7 +194,7 @@ Load the given data into the provided \refstruct{pmix_data_buffer_t} object, usu
 
 %%%%%%%%%%%
 \subsection{\code{PMIX_DATA_BUFFER_UNLOAD}}
-\declareapi{PMIX_DATA_BUFFER_UNLOAD}
+\declaremacro{PMIX_DATA_BUFFER_UNLOAD}
 
 %%%%
 \summary
@@ -243,7 +275,7 @@ Returns one of the following:
 \descr
 
 The pack function packs one or more values of a specified type into the specified buffer.  The buffer must have already been
-initialized via the \refapi{PMIX_DATA_BUFFER_CREATE} or \refapi{PMIX_DATA_BUFFER_CONSTRUCT}
+initialized via the \refmacro{PMIX_DATA_BUFFER_CREATE} or \refmacro{PMIX_DATA_BUFFER_CONSTRUCT}
 macros --- otherwise, \refapi{PMIx_Data_pack} will return an error.
 Providing an unsupported type flag will likewise be reported as an error.
 
@@ -311,7 +343,7 @@ Returns one of the following:
 %%%%
 \descr
 
-The unpack function unpacks the next value (or values) of a specified type from the given buffer. The buffer must have already been initialized via an \refapi{PMIX_DATA_BUFFER_CREATE} or \refapi{PMIX_DATA_BUFFER_CONSTRUCT} call (and assumedly filled with some data) --- otherwise, the unpack_value function will return an error. Providing an unsupported type flag will likewise be reported as an error, as will specifying a data type that \textit{does not} match the type of the next item in the buffer. An attempt to read beyond the end of the stored data held in the buffer will also return an error.
+The unpack function unpacks the next value (or values) of a specified type from the given buffer. The buffer must have already been initialized via an \refmacro{PMIX_DATA_BUFFER_CREATE} or \refmacro{PMIX_DATA_BUFFER_CONSTRUCT} call (and assumedly filled with some data) --- otherwise, the unpack_value function will return an error. Providing an unsupported type flag will likewise be reported as an error, as will specifying a data type that \textit{does not} match the type of the next item in the buffer. An attempt to read beyond the end of the stored data held in the buffer will also return an error.
 
 NOTE: it is possible for the buffer to be corrupted and that \ac{PMIx} will \textit{think} there is a proper variable type at the beginning of an unpack region --- but that the value is bogus (e.g., just a byte field in a string array that so happens to have a value that matches the specified data type flag). Therefore, the data type error check is \textit{not} completely safe.
 

--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -20,7 +20,7 @@ The following \acp{API} allow the \ac{RM} daemon that hosts the \ac{PMIx} server
 %%%%
 \summary
 
-Generate a regular expression representation of the input string.
+Generate a compressed representation of the input string.
 
 %%%%
 \format
@@ -29,13 +29,13 @@ Generate a regular expression representation of the input string.
 \cspecificstart
 \begin{codepar}
 pmix_status_t
-PMIx_generate_regex(const char *input, char **regex)
+PMIx_generate_regex(const char *input, char **output)
 \end{codepar}
 \cspecificend
 
 \begin{arglist}
 \argin{input}{String to process (string)}
-\argout{regex}{Regular expression representation of \refarg{input} (string)}
+\argout{output}{Compressed representation of \refarg{input} (array of bytes)}
 \end{arglist}
 
 Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant.
@@ -43,14 +43,10 @@ Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx erro
 %%%%
 \descr
 
-Given a comma-separated list of \refarg{input} values, generate a regular expression that can be passed down to the \ac{PMIx} client for parsing.
-The order of the individual values in the \refarg{input} string is preserved in the resulting \refarg{regex} string.
-The caller is responsible for free'ing the resulting string.
-
-If values have leading zero's, then that is preserved, as are prefix and suffix strings. For example, an input string of ``\code{odin009.org,odin010.org,odin011.org,odin012.org,odin[102-107].org}'' will return a regular expression of ``\code{pmix:odin[009-012,102-107].org}''
+Given a comma-separated list of \refarg{input} values, generate a reduced size representation of the input that can be passed down to the \ac{PMIx} server library's \refapi{PMIx_server_register_nspace} \ac{API} for parsing. The order of the individual values in the \refarg{input} string is preserved across the operation. The caller is responsible for releasing the returned data.
 
 \adviceuserstart
-The returned regular expression will have a ``\code{pmix:}'' at the beginning of the string. This informs the \ac{PMIx} parser that the string was produced using the \ac{PRI}'s regular expression generator, and thus that same plugin should be used for parsing the string
+The returned representation may be an arbitrary array of bytes as opposed to a valid NULL-terminated string. However, the method used to generate the representation shall be identified with a colon-delimited string at the beginning of the output. For example, an output starting with \code{"pmix:"} indicates that the representation is a \ac{PMIx}-defined regular expression. In contrast, an output starting with \code{"blob:"} is a compressed binary array.
 \adviceuserend
 
 
@@ -61,7 +57,7 @@ The returned regular expression will have a ``\code{pmix:}'' at the beginning of
 %%%%
 \summary
 
-Generate a regular expression representation of the input string.
+Generate a compressed representation of the input identifying the processes on each node.
 
 %%%%
 \format
@@ -75,7 +71,7 @@ pmix_status_t PMIx_generate_ppn(const char *input, char **ppn)
 
 \begin{arglist}
 \argin{input}{String to process (string)}
-\argout{regex}{Regular expression representation of \refarg{input} (string)}
+\argout{ppn}{Compressed representation of \refarg{input} (array of bytes)}
 \end{arglist}
 
 Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant.
@@ -83,10 +79,10 @@ Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx erro
 %%%%
 \descr
 
-The input is expected to consist of a semicolon-separated list of ranges representing the ranks of processes on each node of the job. Thus, an input of "1-4;2-5;8,10,11,12;6,7,9" would generate a regex of "pmix:2x(3);8,10-12;6-7,9"
+The input shall consist of a semicolon-separated list of ranges representing the ranks of processes on each node of the job - e.g.,  "1-4;2-5;8,10,11,12;6,7,9". Each field of the input must correspond to the node name provided at that position in the input to \refapi{PMIx_generate_regex}. Thus, in the example, ranks 1-4 would be located on the first node of the comma-separated list of names provided to \refapi{PMIx_generate_regex}, and ranks 2-5 would be on the second name in the list.
 
 \adviceuserstart
-The returned regular expression will have a ``pmix:'' at the beginning of the string. This informs the \ac{PMIx} parser that the string was produced using the \ac{PRI}'s regular expression generator, and thus that same plugin should be used for parsing the string
+The returned representation may be an arbitrary array of bytes as opposed to a valid NULL-terminated string. However, the method used to generate the representation shall be identified with a colon-delimited string at the beginning of the output. For example, an output starting with \code{"pmix:"} indicates that the representation is a \ac{PMIx}-defined regular expression. In contrast, an output starting with \code{"blob:"} is a compressed binary array.
 \adviceuserend
 
 %%%%%%%%%%%

--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -45,9 +45,11 @@ Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx erro
 
 Given a comma-separated list of \refarg{input} values, generate a reduced size representation of the input that can be passed down to the \ac{PMIx} server library's \refapi{PMIx_server_register_nspace} \ac{API} for parsing. The order of the individual values in the \refarg{input} string is preserved across the operation. The caller is responsible for releasing the returned data.
 
-\adviceuserstart
-The returned representation may be an arbitrary array of bytes as opposed to a valid NULL-terminated string. However, the method used to generate the representation shall be identified with a colon-delimited string at the beginning of the output. For example, an output starting with \code{"pmix:"} indicates that the representation is a \ac{PMIx}-defined regular expression. In contrast, an output starting with \code{"blob:"} is a compressed binary array.
-\adviceuserend
+\advicermstart
+The returned representation may be an arbitrary array of bytes as opposed to a valid NULL-terminated string. However, the method used to generate the representation shall be identified with a colon-delimited string at the beginning of the output. For example, an output starting with \code{"pmix:"} indicates that the representation is a \ac{PMIx}-defined regular expression represented as a NULL-terminated string. In contrast, an output starting with \code{"blob:\textbackslash0size=1234:"} is a compressed binary array.
+
+Communicating the resulting output should be done by first packing the returned expression using the \refapi{PMIx_Data_pack}, declaring the input to be of type \refconst{PMIX_REGEX}, and then obtaining the blob to be communicated using the \refmacro{PMIX_DATA_BUFFER_UNLOAD} macro. The pack/unpack routines will ensure proper handling of the data based on the regex prefix.
+\advicermend
 
 
 %%%%%%%%%%%
@@ -81,9 +83,11 @@ Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx erro
 
 The input shall consist of a semicolon-separated list of ranges representing the ranks of processes on each node of the job - e.g.,  "1-4;2-5;8,10,11,12;6,7,9". Each field of the input must correspond to the node name provided at that position in the input to \refapi{PMIx_generate_regex}. Thus, in the example, ranks 1-4 would be located on the first node of the comma-separated list of names provided to \refapi{PMIx_generate_regex}, and ranks 2-5 would be on the second name in the list.
 
-\adviceuserstart
-The returned representation may be an arbitrary array of bytes as opposed to a valid NULL-terminated string. However, the method used to generate the representation shall be identified with a colon-delimited string at the beginning of the output. For example, an output starting with \code{"pmix:"} indicates that the representation is a \ac{PMIx}-defined regular expression. In contrast, an output starting with \code{"blob:"} is a compressed binary array.
-\adviceuserend
+\advicermstart
+The returned representation may be an arbitrary array of bytes as opposed to a valid NULL-terminated string. However, the method used to generate the representation shall be identified with a colon-delimited string at the beginning of the output. For example, an output starting with \code{"pmix:"} indicates that the representation is a \ac{PMIx}-defined regular expression represented as a NULL-terminated string. In contrast, an output starting with \code{"blob:\textbackslash0size=1234:"} is a compressed binary array.
+
+Communicating the resulting output should be done by first packing the returned expression using the \refapi{PMIx_Data_pack}, declaring the input to be of type \refconst{PMIX_REGEX}, and then obtaining the blob to be communicated using the \refmacro{PMIX_DATA_BUFFER_UNLOAD} macro. The pack/unpack routines will ensure proper handling of the data based on the regex prefix.
+\advicermend
 
 %%%%%%%%%%%
 \subsection{\code{PMIx_server_register_nspace}}

--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -45,10 +45,12 @@ Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx erro
 
 Given a comma-separated list of \refarg{input} values, generate a reduced size representation of the input that can be passed down to the \ac{PMIx} server library's \refapi{PMIx_server_register_nspace} \ac{API} for parsing. The order of the individual values in the \refarg{input} string is preserved across the operation. The caller is responsible for releasing the returned data.
 
-\advicermstart
-The returned representation may be an arbitrary array of bytes as opposed to a valid NULL-terminated string. However, the method used to generate the representation shall be identified with a colon-delimited string at the beginning of the output. For example, an output starting with \code{"pmix:"} indicates that the representation is a \ac{PMIx}-defined regular expression represented as a NULL-terminated string. In contrast, an output starting with \code{"blob:\textbackslash0size=1234:"} is a compressed binary array.
+The precise compressed representations will be implementation specific. However, all \ac{PMIx} implementations are required to include a \code{NULL}-terminated string in the output representation that can be printed for diagnostic purposes.
 
-Communicating the resulting output should be done by first packing the returned expression using the \refapi{PMIx_Data_pack}, declaring the input to be of type \refconst{PMIX_REGEX}, and then obtaining the blob to be communicated using the \refmacro{PMIX_DATA_BUFFER_UNLOAD} macro. The pack/unpack routines will ensure proper handling of the data based on the regex prefix.
+\advicermstart
+The returned representation may be an arbitrary array of bytes as opposed to a valid NULL-terminated string. However, the method used to generate the representation shall be identified with a colon-delimited string at the beginning of the output. For example, an output starting with \code{"pmix:\textbackslash0"} might indicate that the representation is a \ac{PMIx}-defined regular expression represented as a \code{NULL}-terminated string following the \code{"pmix:\textbackslash0"} prefix. In contrast, an output starting with \code{"blob:\textbackslash0"} might indicate a compressed binary array follows the prefix.
+
+Communicating the resulting output should be done by first packing the returned expression using the \refapi{PMIx_Data_pack}, declaring the input to be of type \refconst{PMIX_REGEX}, and then obtaining the resulting blob to be communicated using the \refmacro{PMIX_DATA_BUFFER_UNLOAD} macro. The reciprocal method can be used on the remote end prior to passing the regex into \refapi{PMIx_server_register_nspace}. The pack/unpack routines will ensure proper handling of the data based on the regex prefix.
 \advicermend
 
 

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -2507,143 +2507,7 @@ PMIX_BYTE_OBJECT_LOAD(b, d, s)
 \end{arglist}
 
 
-%%%%%%%%%%%
-\subsection{Data Buffer Type}
-\declarestruct{pmix_data_buffer_t}
-
-The \refstruct{pmix_data_buffer_t} structure describes a data buffer used for packing and unpacking.
-
-\versionMarker{2.0}
-\cspecificstart
-\begin{codepar}
-typedef struct pmix_data_buffer \{
-    /** Start of my memory */
-    char *base_ptr;
-    /** Where the next data will be packed to
-        (within the allocated memory starting
-        at base_ptr) */
-    char *pack_ptr;
-    /** Where the next data will be unpacked
-        from (within the allocated memory
-        starting as base_ptr) */
-    char *unpack_ptr;
-    /** Number of bytes allocated (starting
-        at base_ptr) */
-    size_t bytes_allocated;
-    /** Number of bytes used by the buffer
-        (i.e., amount of data -- including
-        overhead -- packed in the buffer) */
-    size_t bytes_used;
-\} pmix_data_buffer_t;
-\end{codepar}
-\cspecificend
-
-\subsection{Data buffer support macros}
-The following macros support the \refstruct{pmix_data_buffer_t} structure.
-
-\subsubsection{Initialize the \refstruct{pmix_data_buffer_t} structure}
-\declaremacro{PMIX_DATA_BUFFER_CONSTRUCT}
-
-Initialize the \refstruct{pmix_data_buffer_t} fields
-
-\versionMarker{2.0}
-\cspecificstart
-\begin{codepar}
-PMIX_DATA_BUFFER_CONSTRUCT(m)
-\end{codepar}
-\cspecificend
-
-\begin{arglist}
-\argin{m}{Pointer to the structure to be initialized (pointer to \refstruct{pmix_data_buffer_t})}
-\end{arglist}
-
-\subsubsection{Destruct the \refstruct{pmix_data_buffer_t} structure}
-\declaremacro{PMIX_DATA_BUFFER_DESTRUCT}
-
-Clear the \refstruct{pmix_data_buffer_t} fields
-
-\versionMarker{2.0}
-\cspecificstart
-\begin{codepar}
-PMIX_DATA_BUFFER_DESTRUCT(m)
-\end{codepar}
-\cspecificend
-
-\begin{arglist}
-\argin{m}{Pointer to the structure to be destructed (pointer to \refstruct{pmix_data_buffer_t})}
-\end{arglist}
-
-\subsubsection{Create a \refstruct{pmix_data_buffer_t} structure}
-\declaremacro{PMIX_DATA_BUFFER_CREATE}
-
-Allocate and intitialize a \refstruct{pmix_data_buffer_t} structure
-
-\versionMarker{2.0}
-\cspecificstart
-\begin{codepar}
-PMIX_DATA_BUFFER_CREATE(m)
-\end{codepar}
-\cspecificend
-
-\begin{arglist}
-\arginout{m}{Address where the pointer to the \refstruct{pmix_data_buffer_t} structure shall be stored (handle)}
-\end{arglist}
-
-\subsubsection{Free a \refstruct{pmix_data_buffer_t}}
-\declaremacro{PMIX_DATA_BUFFER_RELEASE}
-
-Release a \refstruct{pmix_data_buffer_t} structure
-
-\versionMarker{2.0}
-\cspecificstart
-\begin{codepar}
-PMIX_DATA_BUFFER_RELEASE(m)
-\end{codepar}
-\cspecificend
-
-\begin{arglist}
-\argin{m}{Pointer to the \refstruct{pmix_data_buffer_t} structure to be released (handle)}
-\end{arglist}
-
-\subsubsection{Load a \refstruct{pmix_data_buffer_t}}
-\declaremacro{PMIX_DATA_BUFFER_LOAD}
-
-Load data into a \refstruct{pmix_data_buffer_t} structure
-
-\versionMarker{2.2}
-\cspecificstart
-\begin{codepar}
-PMIX_DATA_BUFFER_LOAD(b, d, s)
-\end{codepar}
-\cspecificend
-
-\begin{arglist}
-\argin{b}{Pointer to the \refstruct{pmix_data_buffer_t} structure to be loaded (handle)}
-\argin{d}{Pointer to the data to be loaded into \refarg{b} (\code{void*})}
-\argin{s}{Number of bytes in \refarg{d} (\code{size_t})}
-\end{arglist}
-
-
-\subsubsection{Unload a \refstruct{pmix_data_buffer_t}}
-\declaremacro{PMIX_DATA_BUFFER_UNLOAD}
-
-Unload the data from a \refstruct{pmix_data_buffer_t} structure
-
-\versionMarker{2.2}
-\cspecificstart
-\begin{codepar}
-PMIX_DATA_BUFFER_UNLOAD(b, d, s)
-\end{codepar}
-\cspecificend
-
-\begin{arglist}
-\argin{b}{Pointer to the \refstruct{pmix_data_buffer_t} structure to be unloaded (handle)}
-\arginout{d}{Pointer to be set to the data region after unloading (\code{void*})}
-\arginout{s}{Variable to be set to the number of bytes in the returned data region (\code{size_t})}
-\end{arglist}
-
-
-%%%%%%%%%%%
+%%%%%%%%%%
 \subsection{Data Array Structure}
 \declarestruct{pmix_data_array_t}
 
@@ -2882,9 +2746,17 @@ Input/output forwarding channel (\refstruct{pmix_iof_channel_t})
 \declareconstitem{PMIX_ENVAR}
 Environmental variable structure (\refstruct{pmix_envar_t})
 %
+\declareconstitemNEW{PMIX_COORD}
+Structure containing network coordinates (\refstruct{pmix_coord_t})
+%
 \declareconstitemNEW{PMIX_REGATTR}
 Structure supporting attribute registrations (\refstruct{pmix_regattr_t})
 %
+%
+\declareconstitemNEW{PMIX_REGEX}
+Regular expressions - can be a valid NULL-terminated string or an arbitrary array of bytes
+%
+
 \end{constantdesc}
 
 %%%%%%%%%%%


### PR DESCRIPTION
The PMIx_generate_regex and PMIx_generate_ppn functions are intended
solely to prepare input for PMIx_server_register_nspace. The rationale
is that someone might need to only run those generators once per nspace,
transmitting the output to remote nodes for input to register_nspace.

This modification simply clarifies that the output from those generator
functions may not be a NULL-terminated string, but instead could be a
byte array of arbitrary binary content.

Signed-off-by: Ralph Castain <rhc@pmix.org>