### PR TITLE
Clarifications

### DIFF
--- a/Chap_API_Key_Value_Mgmt.tex
+++ b/Chap_API_Key_Value_Mgmt.tex
@@ -4,10 +4,7 @@
 \chapter{Key/Value Management}
 \label{chap:api_kv_mgmt}
 
-Management of key-value pairs in \ac{PMIx} is a distributed responsibility. While the stated objective of the \ac{PMIx} community is to eliminate collective operations, it is recognized that the traditional method of publishing/exchanging data must be supported until that objective can be met. This method relies on processes to discover and publish their local information which is collected by the local PMIx server library.
-Global exchange of the published information is then executed via a collective operation performed by the host \ac{SMS} servers.
-
-Keys are required to be unique within a specific level of informarion as defined in \ref{api:struct:attributes:retrieval}. For example, a value for \refattr{PMIX_NUM_NODES} can be specified for each of the \refterm{session}, \refterm{job}, and \refterm{application} levels. However, subsequently specifying another value for that attribute in the \refterm{session} level will overwrite the prior value.
+Management of key-value pairs in \ac{PMIx} is a distributed responsibility. While the stated objective of the \ac{PMIx} community is to eliminate collective operations, it is recognized that the traditional method of posting/exchanging data must be supported until that objective can be met. This method relies on processes to discover and post their local information which is collected by the local PMIx server library. Global exchange of the posted information is then executed via a collective operation performed by the host \ac{SMS} servers. The \refapi{PMIx_Put} and \refapi{PMIx_Commit} \acp{API}, plus an attribute directing \refapi{PMIx_Fence} to globally collect the data posted by processes, are provided for this purpose.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/Chap_API_Proc_Mgmt.tex
+++ b/Chap_API_Proc_Mgmt.tex
@@ -280,24 +280,20 @@ Behavior of individual resource managers may differ, but it is expected that fai
 \section{Connecting and Disconnecting Processes}
 \label{chap:api_proc_mgmt:connect}
 
-This section defines functions to connect and disconnect processes in two or more separate \ac{PMIx} namespaces. The \ac{PMIx} definition of \textit{connected} solely implies the following:
-
-\begin{itemize}
-    \item job-level information for each namespace involved in the operation is to be made available to all processes in the connected assemblage
-    \item any data posted by a process in the connected assemblage (via calls to \refapi{PMIx_Put} committed via \refapi{PMIx_Commit}) prior to execution of the \refapi{PMIx_Connect} operation is to be made accessible to all processes in the assemblage - any data posted after execution of the \textit{connect} operation must be exchanged via a separate \refapi{PMIx_Fence} operation spanning the connected processes
-    \item the host environment should treat the failure of any process in the assemblage as a reportable event, taking action on the assemblage as if it were a single application. For example, if the environment defaults (in the absence of any application directives) to terminating an application upon failure of any process in that application, then the environment should terminate all processes in the connected assemblage upon failure of any member.
-\end{itemize}
+This section defines functions to connect and disconnect processes in two or more separate \ac{PMIx} namespaces. The \ac{PMIx} definition of \textit{connected} solely implies that the host environment should treat the failure of any process in the assemblage as a reportable event, taking action on the assemblage as if it were a single application. For example, if the environment defaults (in the absence of any application directives) to terminating an application upon failure of any process in that application, then the environment should terminate all processes in the connected assemblage upon failure of any member.
 
 \advicermstart
 The host environment may choose to assign a new namespace to the connected assemblage and/or assign new ranks for its members for its own internal tracking purposes. However, it is not required to communicate such assignments to the participants (e.g., in response to an appropriate call to \refapi{PMIx_Query_info_nb}). The host environment is required to generate a \refconst{PMIX_ERR_INVALID_TERMINATION} event should any process in the assemblage terminate or call \refapi{PMIx_Finalize} without first \textit{disconnecting} from the assemblage.
+
+The \textit{connect} operation does not require the exchange of job-level information nor the inclusion of information posted by  participating processes via \refapi{PMIx_Put}. Indeed, the callback function utilized in \refapi{pmix_server_connect_fn_t} cannot pass information back into the \ac{PMIx} server library. However, host environments are advised that collecting such information at the participating daemons represents an optimization opportunity as participating processes are likely to request such information after the connect operation completes.
 \advicermend
 
 \adviceuserstart
 Attempting to \textit{connect} processes solely within the same namespace is essentially a \textit{no-op} operation. While not explicitly prohibited, users are advised that a \ac{PMIx} implementation or host environment may return an error in such cases.
 
 Neither the \ac{PMIx} implementation nor host environment are required to provide any tracking support for the assemblage. Thus, the application is responsible for maintaining the membership list of the assemblage.
-
 \adviceuserend
+
 
 %%%%%%%%%%%
 \subsection{\code{PMIx_Connect}}

--- a/Chap_API_Proc_Mgmt.tex
+++ b/Chap_API_Proc_Mgmt.tex
@@ -151,6 +151,7 @@ The following attributes are optional for host environments that support this op
 \pastePRRTEAttributeItem{PMIX_JOB_RECOVERABLE}
 \pastePRRTEAttributeItem{PMIX_JOB_CONTINUOUS}
 \pastePRRTEAttributeItem{PMIX_MAX_RESTARTS}
+\pastePRRTEAttributeItem{PMIX_NOTIFY_COMPLETION}
 
 \optattrend
 

--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -204,6 +204,7 @@ The following attributes may be provided by host environments:
             \item \pastePRRTEAttributeItem{PMIX_MAPBY}
             \item \pastePRRTEAttributeItem{PMIX_RANKBY}
             \item \pastePRRTEAttributeItem{PMIX_BINDTO}
+            \item \pasteAttributeItem{PMIX_ANL_MAP}
         \end{itemize}
     \item for its own node:
         \begin{itemize}

--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -1050,7 +1050,7 @@ server, which is free to release it upon return from the callback
 %%%%%%%%%%%
 \subsection{\code{pmix_server_module_t} Module}
 \declareapi{pmix_server_module_t}
-
+\label{server:module_fns}
 %%%%
 \summary
 

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -3699,7 +3699,7 @@ This attribute would direct \refapi{PMIx_Finalize} to execute a barrier as part 
 
 %
 \declareAttribute{PMIX_JOB_TERM_STATUS}{"pmix.job.term.status"}{pmix_status_t}{
-Status returned by job upon its termination.
+Status returned by job upon its termination. The status will be communicated as part of a \ac{PMIx} event payload provided by the host environment upon termination of a job. Note that generation of the \refconst{PMIX_ERR_JOB_TERMINATED} event is optional and host environments may choose to provide it only upon request.
 }
 
 %
@@ -3707,6 +3707,9 @@ Status returned by job upon its termination.
 State of the specified process as of the last report - may not be the actual current state based on update rate.
 }
 
+\declareAttribute{PMIX_PROC_TERM_STATUS}{"pmix.proc.term.status"}{pmix_status_t}{
+Status returned by a process upon its termination. The status will be communicated as part of a \ac{PMIx} event payload provided by the host environment upon termination of a process. Note that generation of the \refconst{PMIX_PROC_TERMINATED} event is optional and host environments may choose to provide it only upon request.
+}
 
 %%%%%%%%%%%
 \subsection{Server-to-PMIx library attributes}
@@ -4541,7 +4544,7 @@ Resume (``un-pause'') the specified processes.
 
 %
 \declareAttribute{PMIX_JOB_CTRL_CANCEL}{"pmix.jctrl.cancel"}{char*}{
-Cancel the specified request (\code{NULL} implies cancel all requests from this requestor).
+Cancel the specified request - the provided request ID must match the \refattr{PMIX_JOB_CTRL_ID} provided to a previous call to \refapi{PMIx_Job_control}. An ID of \code{NULL} implies cancel all requests from this requestor.
 }
 
 %

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -4526,7 +4526,7 @@ Attributes used to request control operations on an executing application - thes
 
 %
 \declareAttribute{PMIX_JOB_CTRL_ID}{"pmix.jctrl.id"}{char*}{
-Provide a string identifier for this request.
+Provide a string identifier for this request. The user can provide an identifier for the requested operation, thus allowing them to later request status of the operation or to terminate it. The host, therefore, shall track it with the request for future reference.
 }
 
 %

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -3699,12 +3699,12 @@ This attribute would direct \refapi{PMIx_Finalize} to execute a barrier as part 
 
 %
 \declareAttribute{PMIX_JOB_TERM_STATUS}{"pmix.job.term.status"}{pmix_status_t}{
-Status to be returned upon job termination.
+Status returned by job upon its termination.
 }
 
 %
 \declareAttribute{PMIX_PROC_STATE_STATUS}{"pmix.proc.state"}{pmix_proc_state_t}{
-Process state
+State of the specified process as of the last report - may not be the actual current state based on update rate.
 }
 
 

--- a/Chap_Terms.tex
+++ b/Chap_Terms.tex
@@ -122,6 +122,12 @@ The call may update the argument but does not use its input value
 The call may both use and update the argument.
 \end{itemize}
 
+Many \ac{PMIx} interfaces, particularly nonblocking interfaces, use a \code{void*}cbdata object passed to the function that is then passed to the associated callback. In a client-side \ac{API}, the cbdata is a client-provided context (opaque object) that the client can pass to the nonblocking call (e.g., \refapi{PMIx_Get_nb}). When the nonblocking call (e.g., \refapi{pmix_value_cbfunc_t}) completes, the cbdata is passed back to the client without modification by the \ac{PMIx} library, thus allowing the client to associate a context with that callback. This is useful if there are many outstanding nonblocking calls.
+
+A similar model is used for the server module functions (see \ref{server:module_fns}). In this case, the \ac{PMIx} library is making an upcall into its host via the \ac{PMIx} server module function and passing a specific cbfunc and cbdata. The \ac{PMIx} library expects the host to call the cbfunc with the necessary arguments and pass back the original cbdata upon completing the operation. This gives the server-side \ac{PMIx} library the ability to associate a context with the call back (since multiple operations may be outstanding). The host has no visibility into the contents of the cbdata object, nor is permitted to alter it in any way.
+
+\ac{PMIx} callback functions typically return \code{void} - i.e., they do not return a value and therefore cannot indicate the result of an operation. Errors encountered by \ac{PMIx} callback functions are to be communicated via the \refapi{PMIx_Notify_event} \ac{API} using a status code appropriate to the error. Implementers and users wishing to receive such notifications must register a corresponding event handler via the \refapi{PMIx_Register_event_handler} \ac{API}.
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Standard vs Reference Implementation}
 

--- a/Chap_Terms.tex
+++ b/Chap_Terms.tex
@@ -126,7 +126,6 @@ Many \ac{PMIx} interfaces, particularly nonblocking interfaces, use a \code{void
 
 A similar model is used for the server module functions (see \ref{server:module_fns}). In this case, the \ac{PMIx} library is making an upcall into its host via the \ac{PMIx} server module function and passing a specific cbfunc and cbdata. The \ac{PMIx} library expects the host to call the cbfunc with the necessary arguments and pass back the original cbdata upon completing the operation. This gives the server-side \ac{PMIx} library the ability to associate a context with the call back (since multiple operations may be outstanding). The host has no visibility into the contents of the cbdata object, nor is permitted to alter it in any way.
 
-\ac{PMIx} callback functions typically return \code{void} - i.e., they do not return a value and therefore cannot indicate the result of an operation. Errors encountered by \ac{PMIx} callback functions are to be communicated via the \refapi{PMIx_Notify_event} \ac{API} using a status code appropriate to the error. Implementers and users wishing to receive such notifications must register a corresponding event handler via the \refapi{PMIx_Register_event_handler} \ac{API}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Standard vs Reference Implementation}


### PR DESCRIPTION
Clarify use of PMIX_JOB_CTRL_ID
Fixes #186

Remove confusing paragraph at start of key-value mgmt
Fixes #208

Clarify intent of cbdata in function signatures
Fixes #184

Clarify language around PMIx_Connect
Fixes #170

 Reference some attributes where they can be used
 Refs #185

Signed-off-by: Ralph Castain <rhc@pmix.org>