### PR TITLE
Support model-dependent customized environments

### DIFF
--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -227,6 +227,14 @@ The following attributes may be provided by host environments:
 
 Attributes not directly provided by the host environment may be derived by the \ac{PMIx} server library from other required information and included in the data made available to the server library's clients.
 
+The following optional attributes may be provided by the host environment to identify the programming model (as specified by the user) being executed within the namespace. The \ac{PMIx} server library may utilize this information to customize the environment to fit that model (e.g., adding environmental variables specified by the corresponding standard for that model):
+
+\begin{itemize}
+    \item \pastePRIAttributeItem{PMIX_PROGRAMMING_MODEL}
+    \item \pastePRIAttributeItem{PMIX_MODEL_LIBRARY_NAME}
+    \item \pastePRIAttributeItem{PMIX_MODEL_LIBRARY_VERSION}
+\end{itemize}
+
 \optattrend
 
 %%%%
@@ -776,6 +784,14 @@ Returns one of the following:
 \pastePRIAttributeItem{PMIX_ALLOC_BANDWIDTH}
 \pastePRIAttributeItem{PMIX_ALLOC_NETWORK_QOS}
 \pastePRIAttributeItem{PMIX_ALLOC_TIME}
+
+The following optional attributes may be provided by the host environment to identify the programming model (as specified by the user) being executed within the application. The \ac{PMIx} server library may utilize this information to harvest/forward model-specific environmental variables, record the programming model associated with the application, etc.
+
+\begin{itemize}
+    \item \pastePRIAttributeItem{PMIX_PROGRAMMING_MODEL}
+    \item \pastePRIAttributeItem{PMIX_MODEL_LIBRARY_NAME}
+    \item \pastePRIAttributeItem{PMIX_MODEL_LIBRARY_VERSION}
+\end{itemize}
 
 \optattrend
 

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -73,6 +73,9 @@ a space of size \refconst{PMIX_MAX_NSLEN}+1 to allow room for the \code{NULL} te
 \declareconstitem{PMIX_MAX_KEYLEN}
 Maximum key string length as an integer.
 %
+\declareconstitemNEW{PMIX_APP_WILDCARD}
+A value to indicate that the user wants the data for the given key from every application that posted that key, or that the given value applies to all applications within the given nspace.
+
 \end{constantdesc}
 
 \adviceimplstart


### PR DESCRIPTION
Programming models often like to provide their applications with custom
environmental variables to help guide their execution. Making every
resource manager wishing to support direct launch of such apps write
their own code to provide those envars is burdensome, which means users
cannot rely on their presence.

Provide a mechanism by which a PMIx-enabled RM can request PMIx to
supply the custom environment without generating their own code, and
can forward model-specific envars from frontend to backend. This is done
by simply passing appropriate attributes to either the "register_nspace"
or "setup_application" interfaces, as documented here.

Signed-off-by: Ralph Castain <rhc@pmix.org>