### PR TITLE
Cleanup some blocking functions

### DIFF
--- a/Chap_API_Event.tex
+++ b/Chap_API_Event.tex
@@ -69,7 +69,7 @@ Register an event handler
 \versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
-void
+pmix_status_t
 PMIx_Register_event_handler(pmix_status_t codes[], size_t ncodes,
                             pmix_info_t info[], size_t ninfo,
                             pmix_notification_fn_t evhdlr,
@@ -88,12 +88,14 @@ PMIx_Register_event_handler(pmix_status_t codes[], size_t ncodes,
 \argin{cbdata}{Data to be passed to the cbfunc callback function (memory reference)}
 \end{arglist}
 
-Upon completion, the callback will receive a status based on the following table:
+
+If \refarg{cbfunc} is \code{NULL}, the function call will be treated as a \emph{blocking} call. In this case, the returned status will be either (a) the event handler reference identifier if the value is greater than or equal to zero, or (b) a negative error code indicative of the reason for the failure.
+
+If the \refarg{cbfunc} is non-\code{NULL}, the function call will be treated as a \emph{non-blocking} call and will return the following:
 
 \begin{constantdesc}
-\item \refconst{PMIX_SUCCESS} The event handler was successfully registered - the event handler identifier is returned in the callback.
-\item \refconst{PMIX_ERR_BAD_PARAM} One or more of the directives provided in the \textit{info} array was unrecognized.
-\item \refconst{PMIX_ERR_NOT_SUPPORTED} The \ac{PMIx} implementation does not support event notification, or the host \ac{SMS} does not support notification of the specified event code.
+\item \refconst{PMIX_SUCCESS} indicating that the request has been accepted for processing and the provided callback function will be executed upon completion of the operation. Note that the library must not invoke the callback function prior to returning from the \ac{API}. The event handler identifier will be returned in the callback
+\item a non-zero \ac{PMIx} error constant indicating a reason for the request to have been rejected. In this case, the provided callback function will not be executed.
 \end{constantdesc}
 
 The callback function must not be executed prior to returning from the \ac{API}, and no events corresponding to this registration may be delivered prior to the completion of the registration callback function (\refarg{cbfunc}).
@@ -164,7 +166,7 @@ Deregister an event handler.
 \versionMarker{2.0}
 \cspecificstart
 \begin{codepar}
-void
+pmix_status_t
 PMIx_Deregister_event_handler(size_t evhdlr_ref,
                               pmix_op_cbfunc_t cbfunc,
                               void *cbdata);
@@ -177,14 +179,17 @@ PMIx_Deregister_event_handler(size_t evhdlr_ref,
 \argin{cbdata}{Data to be passed to the cbfunc callback function (memory reference)}
 \end{arglist}
 
-Returns one of the following:
+If \refarg{cbfunc} is \code{NULL}, the function will be treated as a \emph{blocking} call and the result of the operation returned in the status code.
+
+If \refarg{cbfunc} is non-\code{NULL}, the function will be treated as a \emph{non-blocking} call and return one of the following:
+
 \begin{itemize}
 \item \refconst{PMIX_SUCCESS}, indicating that the request is being processed - result will be returned in the provided \refarg{cbfunc}. Note that the library must not invoke the callback function prior to returning from the \ac{API}.
 \item \refconst{PMIX_OPERATION_SUCCEEDED}, indicating that the request was immediately processed and returned \textit{success} - the \refarg{cbfunc} will \textit{not} be called
 \item a PMIx error constant indicating either an error in the input or that the request was immediately processed and failed - the \refarg{cbfunc} will \textit{not} be called
 \end{itemize}
 
-If the provided cbfunc is called to confirm removal of the designated handler, the returned status code will be one of the following:
+The returned status code will be one of the following:
 
 \begin{constantdesc}
 \item \refconst{PMIX_SUCCESS} The event handler was successfully deregistered.
@@ -232,7 +237,10 @@ PMIx_Notify_event(pmix_status_t status,
 \argin{cbdata}{Data to be passed to the cbfunc callback function (memory reference)}
 \end{arglist}
 
-Returns one of the following:
+If \refarg{cbfunc} is \code{NULL}, the function will be treated as a \emph{blocking} call and the result of the operation returned in the status code.
+
+If \refarg{cbfunc} is non-\code{NULL}, the function will be treated as a \emph{non-blocking} call and return one of the following:
+
 \begin{constantdesc}
 \item \refconst{PMIX_SUCCESS} The notification request is valid and is being processed. The callback function will be called when the process-local operation is complete and will provide the resulting status of that operation. Note that this does \textit{not} reflect the success or failure of delivering the event to any recipients. The callback function must not be executed prior to returning from the \ac{API}.
 \item \refconst{PMIX_OPERATION_SUCCEEDED}, indicating that the request was immediately processed and returned \textit{success} - the \refarg{cbfunc} will \textit{not} be called

--- a/Chap_API_Job_Mgmt.tex
+++ b/Chap_API_Job_Mgmt.tex
@@ -584,7 +584,8 @@ Request a job control action.
 \begin{codepar}
 pmix_status_t
 PMIx_Job_control(const pmix_proc_t targets[], size_t ntargets,
-                 const pmix_info_t directives[], size_t ndirs)
+                 const pmix_info_t directives[], size_t ndirs,
+                 pmix_info_t *results[], size_t *nresults)
 \end{codepar}
 \cspecificend
 
@@ -593,14 +594,14 @@ PMIx_Job_control(const pmix_proc_t targets[], size_t ntargets,
 \argin{ntargets}{Number of element in the \refarg{targets} array (integer)}
 \argin{directives}{Array of info structures (array of handles)}
 \argin{ndirs}{Number of element in the \refarg{directives} array (integer)}
-\argin{cbfunc}{Callback function \refapi{pmix_info_cbfunc_t} (function reference)}
-\argin{cbdata}{Data to be passed to the callback function (memory reference)}
+\arginout{results}{Address where a pointer to an array of \refstruct{pmix_info_t} containing the results of the request can be returned (memory reference)}
+\arginout{nresults}{Address where the number of elements in \refarg{results} can be returned (handle)}
 \end{arglist}
 
 Returns one of the following:
 
 \begin{itemize}
-    \item \refconst{PMIX_SUCCESS}, indicating that the request was processed by the host environment and returned \textit{success}
+    \item \refconst{PMIX_SUCCESS}, indicating that the request was processed by the host environment and returned \textit{success}. Details of the result will be returned in the \refarg{results} array
     \item a \ac{PMIx} error constant indicating either an error in the input or that the request was refused
 \end{itemize}
 
@@ -773,7 +774,8 @@ Request that application processes be monitored.
 \begin{codepar}
 pmix_status_t
 PMIx_Process_monitor(const pmix_info_t *monitor, pmix_status_t error,
-                     const pmix_info_t directives[], size_t ndirs)
+                     const pmix_info_t directives[], size_t ndirs,
+                     pmix_info_t *results[], size_t *nresults)
 \end{codepar}
 \cspecificend
 
@@ -782,12 +784,14 @@ PMIx_Process_monitor(const pmix_info_t *monitor, pmix_status_t error,
 \argin{error}{status (integer)}
 \argin{directives}{Array of info structures (array of handles)}
 \argin{ndirs}{Number of elements in the \refarg{directives} array (integer)}
+\arginout{results}{Address where a pointer to an array of \refstruct{pmix_info_t} containing the results of the request can be returned (memory reference)}
+\arginout{nresults}{Address where the number of elements in \refarg{results} can be returned (handle)}
 \end{arglist}
 
 Returns one of the following:
 
 \begin{itemize}
-    \item \refconst{PMIX_SUCCESS}, indicating that the request was processed and returned \textit{success}
+    \item \refconst{PMIX_SUCCESS}, indicating that the request was processed and returned \textit{success}. Details of the result will be returned in the \refarg{results} array
     \item a PMIx error constant indicating either an error in the input or that the request was refused
 \end{itemize}
 

--- a/Chap_API_Proc_Mgmt.tex
+++ b/Chap_API_Proc_Mgmt.tex
@@ -626,7 +626,14 @@ PMIx_IOF_pull(const pmix_proc_t procs[], size_t nprocs,
 \argin{regcbdata}{Data to be passed to the \refarg{regcbfunc} callback function (memory reference)}
 \end{arglist}
 
-Returns \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant. In the event the function returns an error, the \refarg{regcbfunc} will \textit{not} be called.
+If \refarg{regcbfunc} is \code{NULL}, the function call will be treated as a \emph{blocking} call. In this case, the returned status will be either (a) the IOF handler reference identifier if the value is greater than or equal to zero, or (b) a negative error code indicative of the reason for the failure.
+
+If the \refarg{regcbfunc} is non-\code{NULL}, the function call will be treated as a \emph{non-blocking} call and will return the following:
+
+\begin{constantdesc}
+\item \refconst{PMIX_SUCCESS} indicating that the request has been accepted for processing and the provided callback function will be executed upon completion of the operation. Note that the library must not invoke the callback function prior to returning from the \ac{API}. The IOF handler identifier will be returned in the callback
+\item a non-zero \ac{PMIx} error constant indicating a reason for the request to have been rejected. In this case, the provided callback function will not be executed.
+\end{constantdesc}
 
 \reqattrstart
 The following attributes are required for \ac{PMIx} libraries that support \ac{IO} forwarding:
@@ -687,13 +694,23 @@ PMIx_IOF_deregister(size_t iofhdlr,
 \argin{cbdata}{Data to be passed to the \refarg{cbfunc} callback function (memory reference)}
 \end{arglist}
 
-Returns one of the following:
+If \refarg{cbfunc} is \code{NULL}, the function will be treated as a \emph{blocking} call and the result of the operation returned in the status code.
+
+If \refarg{cbfunc} is non-\code{NULL}, the function will be treated as a \emph{non-blocking} call and return one of the following:
 
 \begin{itemize}
-    \item \refconst{PMIX_SUCCESS}, indicating that the request is being processed by the host environment - result will be returned in the provided \refarg{cbfunc}. Note that the library must not invoke the callback function prior to returning from the \ac{API}.
-    \item \refconst{PMIX_OPERATION_SUCCEEDED}, indicating that the request was immediately processed and returned \textit{success} - the \refarg{cbfunc} will \textit{not} be called
-    \item a PMIx error constant indicating either an error in the input or that the request was immediately processed and failed - the \refarg{cbfunc} will \textit{not} be called
+\item \refconst{PMIX_SUCCESS}, indicating that the request is being processed - result will be returned in the provided \refarg{cbfunc}. Note that the library must not invoke the callback function prior to returning from the \ac{API}.
+\item \refconst{PMIX_OPERATION_SUCCEEDED}, indicating that the request was immediately processed and returned \textit{success} - the \refarg{cbfunc} will \textit{not} be called
+\item a PMIx error constant indicating either an error in the input or that the request was immediately processed and failed - the \refarg{cbfunc} will \textit{not} be called
 \end{itemize}
+
+The returned status code will be one of the following:
+
+\begin{constantdesc}
+\item \refconst{PMIX_SUCCESS} The IOF handler was successfully deregistered.
+\item \refconst{PMIX_ERR_BAD_PARAM} The provided \refarg{iofhdlr} was unrecognized.
+\item \refconst{PMIX_ERR_NOT_SUPPORTED} The \ac{PMIx} implementation does not support this function.
+\end{constantdesc}
 
 %%%%
 \descr
@@ -739,13 +756,23 @@ PMIx_IOF_push(const pmix_proc_t targets[], size_t ntargets,
 \argin{cbdata}{Data to be passed to the \refarg{cbfunc} callback function (memory reference)}
 \end{arglist}
 
-Returns one of the following:
+If \refarg{cbfunc} is \code{NULL}, the function will be treated as a \emph{blocking} call and the result of the operation returned in the status code.
+
+If \refarg{cbfunc} is non-\code{NULL}, the function will be treated as a \emph{non-blocking} call and return one of the following:
 
 \begin{itemize}
-    \item \refconst{PMIX_SUCCESS}, indicating that the request is being processed by the host environment - result will be returned in the provided \refarg{cbfunc}. Note that the library must not invoke the callback function prior to returning from the \ac{API}.
-    \item \refconst{PMIX_OPERATION_SUCCEEDED}, indicating that the request was immediately processed and returned \textit{success} - the \refarg{cbfunc} will \textit{not} be called
-    \item a PMIx error constant indicating either an error in the input or that the request was immediately processed and failed - the \refarg{cbfunc} will \textit{not} be called
+\item \refconst{PMIX_SUCCESS}, indicating that the request is being processed - result will be returned in the provided \refarg{cbfunc}. Note that the library must not invoke the callback function prior to returning from the \ac{API}.
+\item \refconst{PMIX_OPERATION_SUCCEEDED}, indicating that the request was immediately processed and returned \textit{success} - the \refarg{cbfunc} will \textit{not} be called
+\item a PMIx error constant indicating either an error in the input or that the request was immediately processed and failed - the \refarg{cbfunc} will \textit{not} be called
 \end{itemize}
+
+The returned status code will be one of the following:
+
+\begin{constantdesc}
+\item \refconst{PMIX_SUCCESS} The provided data has been accepted for transmission - it is not indicative of the payload being delivered to any member of the provided \refarg{targets}
+\item \refconst{PMIX_ERR_NOT_SUPPORTED} The \ac{PMIx} implementation does not support this function.
+\item a PMIx error constant indicating the nature of the error
+\end{constantdesc}
 
 \reqattrstart
 The following attributes are required for \ac{PMIx} libraries that support \ac{IO} forwarding:

--- a/Chap_API_Security.tex
+++ b/Chap_API_Security.tex
@@ -41,7 +41,71 @@ Request a credential from the \ac{PMIx} server library or the host environment
 \begin{codepar}
 pmix_status_t
 PMIx_Get_credential(const pmix_info_t info[], size_t ninfo,
-                    pmix_credential_cbfunc_t cbfunc, void *cbdata)
+                    pmix_byte_object_t *credential)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{info}{Array of \refstruct{pmix_info_t} structures (array of handles)}
+\argin{ninfo}{Number of elements in the \refarg{info} array (\code{size_t})}
+\argin{credential}{Address of a \refstruct{pmix_byte_object_t} within which to return credential (handle)}
+\end{arglist}
+
+Returns one of the following:
+
+\begin{itemize}
+    \item \refconst{PMIX_SUCCESS}, indicating that the credential has been returned in the provided \refstruct{pmix_byte_object_t}
+    \item a \ac{PMIx} error constant indicating either an error in the input or that the request is unsupported
+\end{itemize}
+
+\reqattrstart
+\ac{PMIx} libraries that choose not to support this operation \textit{must} return \refconst{PMIX_ERR_NOT_SUPPORTED} when the function is called.
+
+There are no required attributes for this \ac{API}. Note that implementations may choose to internally
+execute integration for some security environments (e.g., directly
+contacting a \textit{munge} server).
+
+Implementations that support the operation but cannot directly process the client's request must pass any attributes that are provided by the client to the host environment for processing. In addition, the following attributes are required to be included in the \refarg{info} array passed from the \ac{PMIx} library to the host environment:
+
+\pastePRIAttributeItem{PMIX_USERID}
+\pastePRIAttributeItem{PMIX_GRPID}
+
+\reqattrend
+
+\optattrstart
+The following attributes are optional for host environments that support this operation:
+
+\pasteAttributeItem{PMIX_TIMEOUT}
+
+\optattrend
+
+\adviceimplstart
+We recommend that implementation of the \refattr{PMIX_TIMEOUT} attribute be left to the host environment due to race condition considerations between completion of the operation versus internal timeout in the \ac{PMIx} server library. Implementers that choose to support \refattr{PMIX_TIMEOUT} directly in the \ac{PMIx} server library must take care to resolve the race condition and should avoid passing \refattr{PMIX_TIMEOUT} to the host environment so that multiple competing timeouts are not created.
+\adviceimplend
+
+%%%%
+\descr
+
+Request a credential from the \ac{PMIx} server library or the host environment
+
+%%%%%%%%%%%
+\subsection{\code{PMIx_Get_credential_nb}}
+\declareapi{PMIx_Get_credential_nb}
+
+%%%%
+\summary
+
+Request a credential from the \ac{PMIx} server library or the host environment
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+pmix_status_t
+PMIx_Get_credential_nb(const pmix_info_t info[], size_t ninfo,
+                       pmix_credential_cbfunc_t cbfunc, void *cbdata)
 \end{codepar}
 \cspecificend
 
@@ -114,8 +178,77 @@ Request validation of a credential by the \ac{PMIx} server library or the host e
 pmix_status_t
 PMIx_Validate_credential(const pmix_byte_object_t *cred,
                          const pmix_info_t info[], size_t ninfo,
-                         pmix_validation_cbfunc_t cbfunc,
-                         void *cbdata)
+                         pmix_info_t **results, size_t *nresults)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{cred}{Pointer to \refstruct{pmix_byte_object_t} containing the credential (handle)}
+\argin{info}{Array of \refstruct{pmix_info_t} structures (array of handles)}
+\argin{ninfo}{Number of elements in the \refarg{info} array (\code{size_t})}
+\arginout{results}{Address where a pointer to an array of \refstruct{pmix_info_t} containing the results of the request can be returned (memory reference)}
+\arginout{nresults}{Address where the number of elements in \refarg{results} can be returned (handle)}
+\end{arglist}
+
+Returns one of the following:
+
+\begin{itemize}
+    \item \refconst{PMIX_SUCCESS}, indicating that the request was processed and returned \textit{success}. Details of the result will be returned in the \refarg{results} array
+    \item a PMIx error constant indicating either an error in the input or that the request was refused
+\end{itemize}
+
+\reqattrstart
+\ac{PMIx} libraries that choose not to support this operation \textit{must} return \refconst{PMIX_ERR_NOT_SUPPORTED} when the function is called.
+
+There are no required attributes for this \ac{API}. Note that implementations may choose to internally
+execute integration for some security environments (e.g., directly
+contacting a \textit{munge} server).
+
+Implementations that support the operation but cannot directly process the client's request must pass any attributes that are provided by the client to the host environment for processing. In addition, the following attributes are required to be included in the \refarg{info} array passed from the \ac{PMIx} library to the host environment:
+
+\pastePRIAttributeItem{PMIX_USERID}
+\pastePRIAttributeItem{PMIX_GRPID}
+
+\reqattrend
+
+\optattrstart
+The following attributes are optional for host environments that support this operation:
+
+\pasteAttributeItem{PMIX_TIMEOUT}
+
+\optattrend
+
+\adviceimplstart
+We recommend that implementation of the \refattr{PMIX_TIMEOUT} attribute be left to the host environment due to race condition considerations between completion of the operation versus internal timeout in the \ac{PMIx} server library. Implementers that choose to support \refattr{PMIX_TIMEOUT} directly in the \ac{PMIx} server library must take care to resolve the race condition and should avoid passing \refattr{PMIX_TIMEOUT} to the host environment so that multiple competing timeouts are not created.
+\adviceimplend
+
+
+%%%%
+\descr
+
+Request validation of a credential by the \ac{PMIx} server library or the host environment.
+
+
+%%%%%%%%%%%
+\subsection{\code{PMIx_Validate_credential_nb}}
+\declareapi{PMIx_Validate_credential_nb}
+
+%%%%
+\summary
+
+Request validation of a credential by the \ac{PMIx} server library or the host environment
+
+%%%%
+\format
+
+\versionMarker{3.0}
+\cspecificstart
+\begin{codepar}
+pmix_status_t
+PMIx_Validate_credential_nb(const pmix_byte_object_t *cred,
+                            const pmix_info_t info[], size_t ninfo,
+                            pmix_validation_cbfunc_t cbfunc,
+                            void *cbdata)
 \end{codepar}
 \cspecificend
 

--- a/Chap_Introduction.tex
+++ b/Chap_Introduction.tex
@@ -423,6 +423,7 @@ The following changes were introduced in v4.0 of the PMIx Standard:
         \item \refattr{PMIX_CLIENT_ATTRIBUTES}, \refattr{PMIX_SERVER_ATTRIBUTES}, \refattr{PMIX_TOOL_ATTRIBUTES}, and \refattr{PMIX_HOST_ATTRIBUTES} to identify which library supports the attribute; and
         \item \refattr{PMIX_MAX_VALUE}, \refattr{PMIX_MIN_VALUE}, and \refattr{PMIX_ENUM_VALUE} to provide machine-parsable description of accepted values
     \end{itemize}
+    \item Add \refconst{PMIX_APP_WILDCARD} to reference all applications within a given job
     \item Fix signature of blocking APIs \refapi{PMIx_Allocation_request}, \refapi{PMIx_Job_control}, \refapi{PMIx_Process_monitor}, \refapi{PMIx_Get_credential}, and \refapi{PMIx_Validate_credential} to allow return of results
     \item Update description to provide an option for blocking behavior of the \refapi{PMIx_Register_event_handler}, \refapi{PMIx_Deregister_event_handler}, \refapi{PMIx_Notify_event}, \refapi{PMIx_IOF_pull}, \refapi{PMIx_IOF_deregister}, and \refapi{PMIx_IOF_push} APIs. The need for blocking forms of these functions was not initially anticipated but has emerged over time. For these functions, the return value is sufficient to provide the caller with information otherwise returned via callback. Thus, use of a \code{NULL} value as the callback function parameter was deemed a minimal disruption method for providing the desired capability
     \item

--- a/Chap_Introduction.tex
+++ b/Chap_Introduction.tex
@@ -423,4 +423,7 @@ The following changes were introduced in v4.0 of the PMIx Standard:
         \item \refattr{PMIX_CLIENT_ATTRIBUTES}, \refattr{PMIX_SERVER_ATTRIBUTES}, \refattr{PMIX_TOOL_ATTRIBUTES}, and \refattr{PMIX_HOST_ATTRIBUTES} to identify which library supports the attribute; and
         \item \refattr{PMIX_MAX_VALUE}, \refattr{PMIX_MIN_VALUE}, and \refattr{PMIX_ENUM_VALUE} to provide machine-parsable description of accepted values
     \end{itemize}
+    \item Fix signature of blocking APIs \refapi{PMIx_Allocation_request}, \refapi{PMIx_Job_control}, \refapi{PMIx_Process_monitor}, \refapi{PMIx_Get_credential}, and \refapi{PMIx_Validate_credential} to allow return of results
+    \item Update description to provide an option for blocking behavior of the \refapi{PMIx_Register_event_handler}, \refapi{PMIx_Deregister_event_handler}, \refapi{PMIx_Notify_event}, \refapi{PMIx_IOF_pull}, \refapi{PMIx_IOF_deregister}, and \refapi{PMIx_IOF_push} APIs. The need for blocking forms of these functions was not initially anticipated but has emerged over time. For these functions, the return value is sufficient to provide the caller with information otherwise returned via callback. Thus, use of a \code{NULL} value as the callback function parameter was deemed a minimal disruption method for providing the desired capability
+    \item
 \end{itemize}


### PR DESCRIPTION
Some of the blocking functions were missing necessary parameters to
return the results of their operation. In some casees, no blocking
form of an operation was provided - where possible, we provide a
blocking form by simply looking for a NULL callback function. We
return the result of the operation in the status code.

Need to bring at least some of these back to v3.2 errata

Signed-off-by: Ralph Castain <rhc@pmix.org>