### PR TITLE
Add an Attribute declared but not referenced script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,5 +65,9 @@ pmix-standard.pdf: $(CHAPTERS) $(SOURCES) pmix.sty pmix-standard.tex figs/pmix-l
 	@echo "====> Success"
 	@cp pmix-standard.pdf pmix-standard-${version}.pdf
 
+check: pmix-standard.pdf
+	@echo "====> Checking for Attributes Declared, but not referenced"
+	@./bin/check-attr-refs.py
+
 clean:
 	rm -f $(INTERMEDIATE_FILES) pmix-standard-*.pdf

--- a/bin/check-attr-refs.py
+++ b/bin/check-attr-refs.py
@@ -1,0 +1,156 @@
+#!/usr/bin/python -u
+
+import sys
+import os
+import re
+import argparse
+import subprocess
+import shutil
+
+
+if __name__ == "__main__":
+    count_not_used = 0
+    attr_declared = {}
+
+    #
+    # Command line parsing
+    #
+    parser = argparse.ArgumentParser(description="PMIx Standard Attribute Reference Check")
+    parser.add_argument("-v", "--verbose", help="Verbose output", action="store_true")
+
+    parser.parse_args()
+    args = parser.parse_args()
+
+
+    #
+    # Verify that we have the necessary files in the current working directory
+    # * pmix-standard.aux
+    # * pmix-standard.idx
+    #
+    if os.path.exists("pmix-standard.aux") is False or os.path.exists("pmix-standard.idx") is False:
+        print("Error: Cannot find the .aux or .idx files necessary for processing in the current directory.")
+        print("       Please run this script from the base PMIx Standard build directory, and with a recent build.")
+        sys.exit(1)
+
+
+    #
+    # Extract the declared attributes
+    #   grep "newlabel{attr" pmix-standard.aux
+    #
+    if args.verbose is True:
+        print "-"*50
+        print "Extracting declared attributes"
+        print "-"*50
+
+    p = subprocess.Popen("grep \"newlabel{attr\" pmix-standard.aux",
+                         stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True, close_fds=True)
+    p.wait()
+    if p.returncode != 0:
+        print("Error: Failed to extract declared attributes. grep error code "+str(p.returncode)+")");
+        sys.exit(2)
+
+    for line in p.stdout:
+        line = line.rstrip()
+        m = re.match(r'\s*\\newlabel{attr:(\w+)', line)
+        if m is None:
+            print("Error: Failed to extract an attribute on the following line")
+            print(" line: "+line)
+            sys.exit(1)
+        # Count will return to 0 when verified
+        attr_declared[m.group(1)] = -1
+
+    if args.verbose is True:
+        for attr in attr_declared:
+            print("Attribute: " + attr)
+        print("Number of declared attributes: " + str(len(attr_declared)))
+
+
+    #
+    # Verify the list against the index
+    # If any difference then post a warning
+    #  grep "PMIX_SERVER_REMOTE_CONNECTIONS\!Def" pmix-standard.idx
+    #
+    if args.verbose is True:
+        print "-"*50
+        print "Verifying list against the index"
+        print "-"*50
+
+    p = subprocess.Popen("grep \"\\!Definition\" pmix-standard.idx",
+                         stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True, close_fds=True)
+    p.wait()
+    if p.returncode != 0:
+        print("Error: Failed to verify declared attribute \""+attr+"\". grep error code "+str(p.returncode)+")");
+        sys.exit(2)
+
+    # List of Definition is larger than attribute list
+    for line in p.stdout:
+        line = line.rstrip()
+        m = re.match(r'\s*\\indexentry{(\w+)', line)
+        if m is None:
+            print("Error: Failed to extract an attribute on the following line")
+            print(" line: "+line)
+            sys.exit(1)
+
+        attr_to_find = m.group(1)
+        if attr_to_find in attr_declared:
+            attr_declared[attr_to_find] = attr_declared[attr_to_find] + 1
+
+    # Sanity check. Should never trigger, but check just in case
+    err_out = False
+    for attr in attr_declared:
+        if attr_declared[attr] < 0:
+            print("Error: Attribute \""+attr+"\" declared, but not in the index")
+            err_out = True
+    if err_out is True:
+        sys.exit(1)
+
+    if args.verbose is True:
+        print("Verified all "+str(len(attr_declared))+" attributes are present in the index")
+
+
+    #
+    # Look for usage references for each attribute
+    #   grep "\|hyperpage" pmix-standard.idx
+    #
+    if args.verbose is True:
+        print "-"*50
+        print "Count the usage of each attribute in the document"
+        print "-"*50
+
+    # Result set was too big for Python to handle, so use an intermediate file
+    output_file = "pmix-standard.idx-grep"
+    with open(output_file, 'w') as logfile:
+        ret = subprocess.call(['grep', '\|hyperpage', 'pmix-standard.idx'],
+                              stdout=logfile, stderr=logfile, shell=False)
+        if ret != 0:
+            print("Error: Failed to verify declared attribute \""+attr+"\". grep error code "+str(ret)+")");
+            sys.exit(2)
+
+    # List of references is much larger than attribute list
+    with open(output_file, 'r') as logfile:
+        for line in logfile:
+            line = line.rstrip()
+            m = re.match(r'\s*\\indexentry{(\w+)', line)
+            if m is None:
+                print("Error: Failed to extract an attribute on the following line")
+                print(" line: "+line)
+                sys.exit(1)
+
+            attr_to_find = m.group(1)
+            if attr_to_find in attr_declared:
+                attr_declared[attr_to_find] = attr_declared[attr_to_find] + 1
+
+    if os.path.isfile(output_file):
+        os.remove(output_file)
+
+
+    #
+    # Display a list of attributes that are declared but not used
+    #
+    for attr in attr_declared:
+        if attr_declared[attr] <= 0:
+            print("Attribute Missing Reference: "+attr)
+            count_not_used += 1
+
+    print("%3d of %3d Attributes are missing reference" % (count_not_used, len(attr_declared)))
+    sys.exit(count_not_used)

--- a/pmix.sty
+++ b/pmix.sty
@@ -337,7 +337,7 @@
 %
 \newcommand{\declareAttribute}[4]{%
     \code{#1} ~~\code{#2}~~(\code{#3})%
-    \index{#1!Defintion|textbf} \label{attr:#1}%
+    \index{#1!Definition|textbf} \label{attr:#1}%
     \StdCopy{str:#1}{\code{#2}}%
     \StdCopy{attr:#1}{\code{#3}}%
     \vspace{-1.3ex}%
@@ -349,7 +349,7 @@
 
 \newcommand{\declareNewAttribute}[4]{%
    {\color{magenta}\code{#1}} ~~\code{#2}~~(\code{#3})%
-    \index{#1!Defintion|textbf} \label{attr:#1}%
+    \index{#1!Definition|textbf} \label{attr:#1}%
     \StdCopy{str:#1}{\code{#2}}%
     \StdCopy{attr:#1}{\code{#3}}%
     \vspace{-1.3ex}%
@@ -361,7 +361,7 @@
 
 \newcommand{\declareDepAttribute}[4]{%
    {\color{green!80!black}\code{#1}} ~~\code{#2}~~(\code{#3})%
-    \index{#1!Defintion|textbf} \label{attr:#1}%
+    \index{#1!Definition|textbf} \label{attr:#1}%
     \StdCopy{str:#1}{\code{#2}}%
     \StdCopy{attr:#1}{\code{#3}}%
     \vspace{-1.3ex}%
@@ -685,26 +685,26 @@
 
 \newcommand{\refsection}[2]{\hyperref[#1]{#2}}
 
-\newcommand{\declarestruct}[1]{\index{#1!Defintion|textbf} \label{struct:#1}}
+\newcommand{\declarestruct}[1]{\index{#1!Definition|textbf} \label{struct:#1}}
 \newcommand{\refstruct}[1]{\index{#1} \hyperref[struct:#1]{\code{#1} }}
 \newcommand{\structref}[1] {\refstruct{#1}}
 \newcommand{\specrefstruct}[1]{Section~\ref{struct:#1} on page~\pageref{struct:#1}}
 
-\newcommand{\declareapi}[1]{\index{#1!Defintion|textbf} \label{api:#1}}
+\newcommand{\declareapi}[1]{\index{#1!Definition|textbf} \label{api:#1}}
 \newcommand{\refapi}[1]{\index{#1} \hyperref[api:#1]{\code{#1} }}
 \newcommand{\argapi}[1] {\refapi{#1}}
 
 \newcommand{\refconst}[1]{\hyperref[const:#1]{\code{#1} }}
 
-\newcommand{\declareattr}[1]{\index{#1!Defintion|textbf} \label{attr:#1}}
+\newcommand{\declareattr}[1]{\index{#1!Definition|textbf} \label{attr:#1}}
 
 \newcommand{\refarg}[1] {{\textrm{\textmd{\itshape{#1}}}}}
 \newcommand{\argref}[1] {\refarg{#1}}
 
-\newcommand{\declaremacro}[1]{\index{#1!Defintion|textbf} \label{macro:#1}}
+\newcommand{\declaremacro}[1]{\index{#1!Definition|textbf} \label{macro:#1}}
 \newcommand{\refmacro}[1]{\index{#1} \hyperref[macro:#1]{\code{#1} }}
 
-\newcommand{\declareterm}[1]{\index{#1!Defintion|textbf} \label{macro:#1}}
+\newcommand{\declareterm}[1]{\index{#1!Definition|textbf} \label{macro:#1}}
 \newcommand{\refterm}[1]{\index{#1} \hyperref[macro:#1]{\code{#1} }}
 
 % Place in text for in-text questions during review


### PR DESCRIPTION
 * Adds a script to list all of the attributes that have been declared
   but have no reference in the document outside of the declaration.
 * Fixes a typo in the internal cross referencing
 * Add a new make target `make check` that runs this additional check
   and displays the list of attributes missing a reference.
 * Ref Issue #185