### PR TITLE
Split index into multiple parts and add automated document check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.xwm
 datetime-defaults.sty
 datetime.sty
+check-openpmix

--- a/App_Python.tex
+++ b/App_Python.tex
@@ -1008,7 +1008,7 @@ The client Python class is by far the richest in terms of \acp{API} as it houses
 
 %%%%%%%%%%%
 \subsection{Client.init}
-\declareapi{PMIxClient.init}
+\declareapibinding{PMIxClient.init}{PMIx_Init}{Python}
 
 \summary Initialize the \ac{PMIx} client library after obtaining a new PMIxClient object
 
@@ -1038,7 +1038,7 @@ See \refapi{PMIx_Init} for description of all relevant attributes and behaviors
 
 %%%%%%%%%%%
 \subsection{Client.initialized}
-\declareapi{PMIxClient.initialized}
+\declareapibinding{PMIxClient.initialized}{PMIx_Initialized}{Python}
 
 \format
 
@@ -1063,7 +1063,7 @@ See \refapi{PMIx_Initialized} for description of all relevant attributes and beh
 
 %%%%%%%%%%%
 \subsection{Client.get_version}
-\declareapi{PMIxClient.get_version}
+\declareapibinding{PMIxClient.get_version}{PMIx_Get_version}{Python}
 
 \format
 
@@ -1088,7 +1088,7 @@ See \refapi{PMIx_Get_version} for description of all relevant attributes and beh
 
 %%%%%%%%%%%
 \subsection{Client.finalize}
-\declareapi{PMIxClient.finalize}
+\declareapibinding{PMIxClient.finalize}{PMIx_Finalize}{Python}
 
 %%%%
 \summary
@@ -1121,7 +1121,7 @@ See \refapi{PMIx_Finalize} for description of all relevant attributes and behavi
 
 %%%%%%%%%%%
 \subsection{Client.abort}
-\declareapi{PMIxClient.abort}
+\declareapibinding{PMIxClient.abort}{PMIx_Abort}{Python}
 
 %%%%
 \summary
@@ -1156,7 +1156,7 @@ See \refapi{PMIx_Abort} for description of all relevant attributes and behaviors
 
 %%%%%%%%%%%
 \subsection{Client.store_internal}
-\declareapi{PMIxClient.store_internal}
+\declareapibinding{PMIxClient.store_internal}{PMIx_Store_internal}{Python}
 
 %%%%
 \summary
@@ -1191,7 +1191,7 @@ See \refapi{PMIx_Store_internal} for details
 
 %%%%%%%%%%%
 \subsection{Client.put}
-\declareapi{PMIxClient.put}
+\declareapibinding{PMIxClient.put}{PMIx_Put}{Python}
 
 %%%%
 \summary
@@ -1226,12 +1226,12 @@ See \refapi{PMIx_Put} for description of all relevant attributes and behaviors
 
 %%%%%%%%%%%
 \subsection{Client.commit}
-\declareapi{PMIxClient.commit}
+\declareapibinding{PMIxClient.commit}{PMIx_Commit}{Python}
 
 %%%%
 \summary
 
-Push all previously \refapi{PMIxClient.put} values to the local PMIx server.
+Push all previously \refapibinding{PMIxClient.put} values to the local PMIx server.
 
 %%%%
 \format
@@ -1255,7 +1255,7 @@ See \refapi{PMIx_Commit} for description of all relevant attributes and behavior
 
 %%%%%%%%%%%
 \subsection{Client.fence}
-\declareapi{PMIxClient.fence}
+\declareapibinding{PMIxClient.fence}{PMIx_Fence}{Python}
 
 %%%%
 \summary
@@ -1289,7 +1289,7 @@ See \refapi{PMIx_Fence} for description of all relevant attributes and behaviors
 
 %%%%%%%%%%%
 \subsection{Client.get}
-\declareapi{PMIxClient.get}
+\declareapibinding{PMIxClient.get}{PMIx_Get}{Python}
 
 %%%%
 \summary
@@ -1325,7 +1325,7 @@ See \refapi{PMIx_Get} for description of all relevant attributes and behaviors
 
 %%%%%%%%%%%
 \subsection{Client.publish}
-\declareapi{PMIxClient.publish}
+\declareapibinding{PMIxClient.publish}{PMIx_Publish}{Python}
 
 %%%%
 \summary
@@ -1359,7 +1359,7 @@ See \refapi{PMIx_Publish} for description of all relevant attributes and behavio
 
 %%%%%%%%%%%
 \subsection{Client.lookup}
-\declareapi{PMIxClient.lookup}
+\declareapibinding{PMIxClient.lookup}{PMIx_Lookup}{Python}
 
 %%%%
 \summary
@@ -1394,7 +1394,7 @@ See \refapi{PMIx_Lookup} for description of all relevant attributes and behavior
 
 %%%%%%%%%%%
 \subsection{Client.unpublish}
-\declareapi{PMIxClient.unpublish}
+\declareapibinding{PMIxClient.unpublish}{PMIx_Unpublish}{Python}
 
 %%%%
 \summary
@@ -1428,7 +1428,7 @@ See \refapi{PMIx_Unpublish} for description of all relevant attributes and behav
 
 %%%%%%%%%%%
 \subsection{Client.spawn}
-\declareapi{PMIxClient.spawn}
+\declareapibinding{PMIxClient.spawn}{PMIx_Spawn}{Python}
 
 %%%%
 \summary
@@ -1463,7 +1463,7 @@ See \refapi{PMIx_Spawn} for description of all relevant attributes and behaviors
 
 %%%%%%%%%%%
 \subsection{Client.connect}
-\declareapi{PMIxClient.connect}
+\declareapibinding{PMIxClient.connect}{PMIx_Connect}{Python}
 
 %%%%
 \summary
@@ -1497,7 +1497,7 @@ See \refapi{PMIx_Connect} for description of all relevant attributes and behavio
 
 %%%%%%%%%%%
 \subsection{Client.disconnect}
-\declareapi{PMIxClient.disconnect}
+\declareapibinding{PMIxClient.disconnect}{PMIx_Disconnect}{Python}
 
 %%%%
 \summary
@@ -1531,7 +1531,7 @@ See \refapi{PMIx_Disconnect} for description of all relevant attributes and beha
 
 %%%%%%%%%%%
 \subsection{Client.resolve_peers}
-\declareapi{PMIxClient.resolve_peers}
+\declareapibinding{PMIxClient.resolve_peers}{PMIx_Resolve_peers}{Python}
 
 %%%%
 \summary
@@ -1566,7 +1566,7 @@ See \refapi{PMIx_Resolve_peers} for description of all relevant attributes and b
 
 %%%%%%%%%%%
 \subsection{Client.resolve_nodes}
-\declareapi{PMIxClient.resolve_nodes}
+\declareapibinding{PMIxClient.resolve_nodes}{PMIx_Resolve_nodes}{Python}
 
 %%%%
 \summary
@@ -1600,7 +1600,7 @@ See \refapi{PMIx_Resolve_nodes} for description of all relevant attributes and b
 
 %%%%%%%%%%%
 \subsection{Client.query}
-\declareapi{PMIxClient.query}
+\declareapibinding{PMIxClient.query}{PMIx_Query_info_nb}{Python}
 
 %%%%
 \summary
@@ -1635,7 +1635,7 @@ See \refapi{PMIx_Query_info_nb} for description of all relevant attributes and b
 
 %%%%%%%%%%%
 \subsection{Client.log}
-\declareapi{PMIxClient.log}
+\declareapibinding{PMIxClient.log}{PMIx_Log}{Python}
 
 %%%%
 \summary
@@ -1669,7 +1669,7 @@ See \refapi{PMIx_Log} for description of all relevant attributes and behaviors
 
 %%%%%%%%%%%
 \subsection{Client.allocate}
-\declareapi{PMIxClient.allocate}
+\declareapibinding{PMIxClient.allocate}{PMIx_Allocation_request_nb}{Python}
 
 %%%%
 \summary
@@ -1704,7 +1704,7 @@ See \refapi{PMIx_Allocation_request_nb} for description of all relevant attribut
 
 %%%%%%%%%%%
 \subsection{Client.job_ctrl}
-\declareapi{PMIxClient.job_ctrl}
+\declareapibinding{PMIxClient.job_ctrl}{PMIx_Job_control_nb}{Python}
 
 %%%%
 \summary
@@ -1739,7 +1739,7 @@ See \refapi{PMIx_Job_control_nb} for description of all relevant attributes and 
 
 %%%%%%%%%%%
 \subsection{Client.monitor}
-\declareapi{PMIxClient.monitor}
+\declareapibinding{PMIxClient.monitor}{PMIx_Process_monitor_nb}{Python}
 
 %%%%
 \summary
@@ -1774,7 +1774,7 @@ See \refapi{PMIx_Process_monitor_nb} for description of all relevant attributes 
 
 %%%%%%%%%%%
 \subsection{Client.get_credential}
-\declareapi{PMIxClient.get_credential}
+\declareapibinding{PMIxClient.get_credential}{PMIx_Get_credential}{Python}
 
 %%%%
 \summary
@@ -1809,7 +1809,7 @@ See \refapi{PMIx_Get_credential} for description of all relevant attributes and 
 
 %%%%%%%%%%%
 \subsection{Client.validate_credential}
-\declareapi{PMIxClient.validate_credential}
+\declareapibinding{PMIxClient.validate_credential}{PMIx_Validate_credential}{Python}
 
 %%%%
 \summary
@@ -1844,7 +1844,7 @@ See \refapi{PMIx_Validate_credential} for description of all relevant attributes
 
 %%%%%%%%%%%
 \subsection{Client.group_construct}
-\declareapi{PMIxClient.group_construct}
+\declareapibinding{PMIxClient.group_construct}{PMIx_Group_construct}{Python}
 
 %%%%
 \summary
@@ -1881,7 +1881,7 @@ See \refapi{PMIx_Group_construct} for description of all relevant attributes and
 
 %%%%%%%%%%%
 \subsection{Client.group_invite}
-\declareapi{PMIxClient.group_invite}
+\declareapibinding{PMIxClient.group_invite}{PMIx_Group_invite}{Python}
 
 %%%%
 \summary
@@ -1917,7 +1917,7 @@ See \refapi{PMIx_Group_invite} for description of all relevant attributes and be
 
 %%%%%%%%%%%
 \subsection{Client.group_join}
-\declareapi{PMIxClient.group_join}
+\declareapibinding{PMIxClient.group_join}{PMIx_Group_join}{Python}
 
 %%%%
 \summary
@@ -1954,7 +1954,7 @@ See \refapi{PMIx_Group_join} for description of all relevant attributes and beha
 
 %%%%%%%%%%%
 \subsection{Client.group_leave}
-\declareapi{PMIxClient.group_leave}
+\declareapibinding{PMIxClient.group_leave}{PMIx_Group_leave}{Python}
 
 %%%%
 \summary
@@ -1988,7 +1988,7 @@ See \refapi{PMIx_Group_leave} for description of all relevant attributes and beh
 
 %%%%%%%%%%%
 \subsection{Client.group_destruct}
-\declareapi{PMIxClient.group_destruct}
+\declareapibinding{PMIxClient.group_destruct}{PMIx_Group_destruct}{Python}
 
 %%%%
 \summary
@@ -2022,7 +2022,7 @@ See \refapi{PMIx_Group_destruct} for description of all relevant attributes and 
 
 %%%%%%%%%%%
 \subsection{Client.register_event_handler}
-\declareapi{PMIxClient.register_event_handler}
+\declareapibinding{PMIxClient.register_event_handler}{PMIx_Register_event_handler}{Python}
 
 %%%%
 \summary
@@ -2058,7 +2058,7 @@ See \refapi{PMIx_Register_event_handler} for description of all relevant attribu
 
 %%%%%%%%%%%
 \subsection{Client.deregister_event_handler}
-\declareapi{PMIxClient.deregister_event_handler}
+\declareapibinding{PMIxClient.deregister_event_handler}{PMIx_Deregister_event_handler}{Python}
 
 %%%%
 \summary
@@ -2086,7 +2086,7 @@ See \refapi{PMIx_Deregister_event_handler} for description of all relevant attri
 
 %%%%%%%%%%%
 \subsection{Client.notify_event}
-\declareapi{PMIxClient.notify_event}
+\declareapibinding{PMIxClient.notify_event}{PMIx_Notify_event}{Python}
 
 %%%%
 \summary
@@ -2121,7 +2121,7 @@ See \refapi{PMIx_Notify_event} for description of all relevant attributes and be
 
 %%%%%%%%%%%
 \subsection{Client.error_string}
-\declareapi{PMIxClient.error_string}
+\declareapibinding{PMIxClient.error_string}{PMIx_Error_string}{Python}
 
 %%%%
 \summary
@@ -2152,7 +2152,7 @@ See \refapi{PMIx_Error_string} for further details
 
 %%%%%%%%%%%
 \subsection{Client.proc_state_string}
-\declareapi{PMIxClient.proc_state_string}
+\declareapibinding{PMIxClient.proc_state_string}{PMIx_Proc_state_string}{Python}
 
 %%%%
 \summary
@@ -2183,7 +2183,7 @@ See \refapi{PMIx_Proc_state_string} for further details
 
 %%%%%%%%%%%
 \subsection{Client.scope_string}
-\declareapi{PMIxClient.scope_string}
+\declareapibinding{PMIxClient.scope_string}{PMIx_Scope_string}{Python}
 
 %%%%
 \summary
@@ -2214,7 +2214,7 @@ See \refapi{PMIx_Scope_string} for further details
 
 %%%%%%%%%%%
 \subsection{Client.persistence_string}
-\declareapi{PMIxClient.persistence_string}
+\declareapibinding{PMIxClient.persistence_string}{PMIx_Persistence_string}{Python}
 
 %%%%
 \summary
@@ -2245,7 +2245,7 @@ See \refapi{PMIx_Persistence_string} for further details
 
 %%%%%%%%%%%
 \subsection{Client.data_range_string}
-\declareapi{PMIxClient.data_range_string}
+\declareapibinding{PMIxClient.data_range_string}{PMIx_Data_range_string}{Python}
 
 %%%%
 \summary
@@ -2276,7 +2276,7 @@ See \refapi{PMIx_Data_range_string} for further details
 
 %%%%%%%%%%%
 \subsection{Client.info_directives_string}
-\declareapi{PMIxClient.info_directives_string}
+\declareapibinding{PMIxClient.info_directives_string}{PMIx_Info_directives_string}{Python}
 
 %%%%
 \summary
@@ -2307,7 +2307,7 @@ See \refapi{PMIx_Info_directives_string} for further details
 
 %%%%%%%%%%%
 \subsection{Client.data_type_string}
-\declareapi{PMIxClient.data_type_string}
+\declareapibinding{PMIxClient.data_type_string}{PMIx_Data_type_string}{Python}
 
 %%%%
 \summary
@@ -2338,7 +2338,7 @@ See \refapi{PMIx_Data_type_string} for further details
 
 %%%%%%%%%%%
 \subsection{Client.alloc_directive_string}
-\declareapi{PMIxClient.alloc_directive_string}
+\declareapibinding{PMIxClient.alloc_directive_string}{PMIx_Alloc_directive_string}{Python}
 
 %%%%
 \summary
@@ -2369,7 +2369,7 @@ See \refapi{PMIx_Alloc_directive_string} for further details
 
 %%%%%%%%%%%
 \subsection{Client.iof_channel_string}
-\declareapi{PMIxClient.iof_channel_string}
+\declareapibinding{PMIxClient.iof_channel_string}{PMIx_IOF_channel_string}{Python}
 
 %%%%
 \summary
@@ -2407,7 +2407,7 @@ The server Python class inherits the Python "client" class as its parent. Thus, 
 
 %%%%%%%%%%%
 \subsection{Server.init}
-\declareapi{PMIxServer.init}
+\declareapibinding{PMIxServer.init}{PMIx_server_init}{Python}
 
 \summary Initialize the \ac{PMIx} server library after obtaining a new PMIxServer object
 
@@ -2438,7 +2438,7 @@ See \refapi{PMIx_server_init} for description of all relevant attributes and beh
 
 %%%%%%%%%%%
 \subsection{Server.finalize}
-\declareapi{PMIxServer.finalize}
+\declareapibinding{PMIxServer.finalize}{PMIx_server_finalize}{Python}
 
 \summary Finalize the \ac{PMIx} server library
 
@@ -2464,7 +2464,7 @@ See \refapi{PMIx_server_finalize} for details
 
 %%%%%%%%%%%
 \subsection{Server.generate_regex}
-\declareapi{PMIxServer.generate_regex}
+\declareapibinding{PMIxServer.generate_regex}{PMIx_generate_regex}{Python}
 
 \summary
 Generate a regular expression representation of the input strings.
@@ -2496,7 +2496,7 @@ See \refapi{PMIx_generate_regex} for details
 
 %%%%%%%%%%%
 \subsection{Server.generate_ppn}
-\declareapi{PMIxServer.generate_ppn}
+\declareapibinding{PMIxServer.generate_ppn}{PMIx_generate_ppn}{Python}
 
 \summary
 Generate a regular expression representation of the input strings.
@@ -2528,7 +2528,7 @@ See \refapi{PMIx_generate_ppn} for details
 
 %%%%%%%%%%%
 \subsection{Server.register_nspace}
-\declareapi{PMIxServer.register_nspace}
+\declareapibinding{PMIxServer.register_nspace}{PMIx_server_register_nspace}{Python}
 
 \summary Setup the data about a particular namespace.
 
@@ -2562,7 +2562,7 @@ See \refapi{PMIx_server_register_nspace} for description of all relevant attribu
 
 %%%%%%%%%%%
 \subsection{Server.deregister_nspace}
-\declareapi{PMIxServer.deregister_nspace}
+\declareapibinding{PMIxServer.deregister_nspace}{PMIx_server_deregister_nspace}{Python}
 
 \summary Deregister a namespace.
 
@@ -2588,7 +2588,7 @@ See \refapi{PMIx_server_deregister_nspace} for details
 
 %%%%%%%%%%%
 \subsection{Server.register_client}
-\declareapi{PMIxServer.register_client}
+\declareapibinding{PMIxServer.register_client}{PMIx_server_register_client}{Python}
 
 \summary
 Register a client process with the PMIx server library.
@@ -2622,7 +2622,7 @@ See \refapi{PMIx_server_register_client} for details
 
 %%%%%%%%%%%
 \subsection{Server.deregister_client}
-\declareapi{PMIxServer.deregister_client}
+\declareapibinding{PMIxServer.deregister_client}{PMIx_server_deregister_client}{Python}
 
 \summary
 Dergister a client process and purge all data relating to it
@@ -2650,7 +2650,7 @@ See \refapi{PMIx_server_deregister_client} for details
 
 %%%%%%%%%%%
 \subsection{Server.setup_fork}
-\declareapi{PMIxServer.setup_fork}
+\declareapibinding{PMIxServer.setup_fork}{PMIx_server_setup_fork}{Python}
 
 \summary
 Setup the environment of a child process that is to be forked
@@ -2683,7 +2683,7 @@ See \refapi{PMIx_server_setup_fork} for details
 
 %%%%%%%%%%%
 \subsection{Server.dmodex_request}
-\declareapi{PMIxServer.dmodex_request}
+\declareapibinding{PMIxServer.dmodex_request}{PMIx_server_dmodex_request}{Python}
 
 \summary
 Function by which the host server can request modex data from the local PMIx server.
@@ -2715,7 +2715,7 @@ See \refapi{PMIx_server_dmodex_request} for details
 
 %%%%%%%%%%%
 \subsection{Server.setup_application}
-\declareapi{PMIxServer.setup_application}
+\declareapibinding{PMIxServer.setup_application}{PMIx_server_setup_application}{Python}
 
 \summary
 Function by which the resource manager can request application-specific setup data prior to launch of a \refterm{job}.
@@ -2748,7 +2748,7 @@ See \refapi{PMIx_server_setup_application} for details
 
 %%%%%%%%%%%
 \subsection{Server.register_attributes}
-\declareapi{PMIxServer.register_attributes}
+\declareapibinding{PMIxServer.register_attributes}{PMIx_Register_attributes}{Python}
 
 \summary
 Register host environment attribute support for a function.
@@ -2780,7 +2780,7 @@ See \refapi{PMIx_Register_attributes} for details
 
 %%%%%%%%%%%
 \subsection{Server.setup_local_support}
-\declareapi{PMIxServer.setup_local_support}
+\declareapibinding{PMIxServer.setup_local_support}{PMIx_server_setup_local_support}{Python}
 
 \summary
 Function by which the local \ac{PMIx} server can perform any application-specific operations prior to spawning local clients of a given application
@@ -2812,7 +2812,7 @@ See \refapi{PMIx_server_setup_local_support} for details
 
 %%%%%%%%%%%
 \subsection{Server.iof_deliver}
-\declareapi{PMIxServer.iof_deliver}
+\declareapibinding{PMIxServer.iof_deliver}{PMIx_server_IOF_deliver}{Python}
 
 \summary
 Function by which the host environment can pass forwarded \ac{IO} to the \ac{PMIx} server library for distribution to its clients.
@@ -2847,7 +2847,7 @@ See \refapi{PMIx_server_IOF_deliver} for details
 
 %%%%%%%%%%%
 \subsection{Server.collect_inventory}
-\declareapi{PMIxServer.collect_inventory}
+\declareapibinding{PMIxServer.collect_inventory}{PMIx_server_collect_inventory}{Python}
 
 \summary
 Collect inventory of resources on a node
@@ -2879,7 +2879,7 @@ See \refapi{PMIx_server_collect_inventory} for details
 
 %%%%%%%%%%%
 \subsection{Server.deliver_inventory}
-\declareapi{PMIxServer.deliver_inventory}
+\declareapibinding{PMIxServer.deliver_inventory}{PMIx_server_deliver_inventory}{Python}
 
 \summary
 Pass collected inventory to the \ac{PMIx} server library for storage
@@ -2918,7 +2918,7 @@ The tool Python class inherits the Python "server" class as its parent. Thus, it
 
 %%%%%%%%%%%
 \subsection{Tool.init}
-\declareapi{PMIxTool.init}
+\declareapibinding{PMIxTool.init}{PMIx_tool_init}{Python}
 
 \summary Initialize the \ac{PMIx} tool library after obtaining a new PMIxTool object
 
@@ -2949,7 +2949,7 @@ See \refapi{PMIx_tool_init} for description of all relevant attributes and behav
 
 %%%%%%%%%%%
 \subsection{Tool.finalize}
-\declareapi{PMIxTool.finalize}
+\declareapibinding{PMIxTool.finalize}{PMIx_tool_finalize}{Python}
 
 \summary Finalize the PMIx tool library, closing the connection to the server.
 
@@ -2975,7 +2975,7 @@ See \refapi{PMIx_tool_finalize} for description of all relevant attributes and b
 
 %%%%%%%%%%%
 \subsection{Tool.connect_to_server}
-\declareapi{PMIxTool.connect_to_server}
+\declareapibinding{PMIxTool.connect_to_server}{PMIx_tool_connect_to_server}{Python}
 
 \summary
 Switch connection from the current \ac{PMIx} server to another one, or initialize a connection to a specified server.
@@ -3008,7 +3008,7 @@ See \refapi{PMIx_tool_connect_to_server} for description of all relevant attribu
 
 %%%%%%%%%%%
 \subsection{Tool.iof_pull}
-\declareapi{PMIxTool.iof_pull}
+\declareapibinding{PMIxTool.iof_pull}{PMIx_IOF_pull}{Python}
 
 %%%%
 \summary
@@ -3045,7 +3045,7 @@ See \refapi{PMIx_IOF_pull} for description of all relevant attributes and behavi
 
 %%%%%%%%%%%
 \subsection{Tool.iof_deregister}
-\declareapi{PMIxTool.iof_deregister}
+\declareapibinding{PMIxTool.iof_deregister}{PMIx_IOF_deregister}{Python}
 
 %%%%
 \summary
@@ -3079,7 +3079,7 @@ See \refapi{PMIx_IOF_deregister} for description of all relevant attributes and 
 
 %%%%%%%%%%%
 \subsection{Tool.iof_push}
-\declareapi{PMIxTool.iof_push}
+\declareapibinding{PMIxTool.iof_push}{PMIx_IOF_push}{Python}
 
 %%%%
 \summary

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -484,7 +484,7 @@ Definitions should always be based on the \refconst{PMIX_EXTERNAL_ERR_BASE} cons
 \subsection{Macros for use with PMIx constants}
 
 \subsubsection{Detect system event constant}
-\declaremacro{pmix_system_event}
+\declaremacro{PMIX_SYSTEM_EVENT}
 
 Test a given error constant to see if it falls within the dedicated range of constants for system event reporting.
 
@@ -529,7 +529,7 @@ Passing a \refstruct{pmix_key_t} value to the standard \textit{sizeof} utility c
 \adviceuserend
 
 \subsubsection{Key support macro}
-\declaremacro{pmix_check_key}
+\declaremacro{PMIX_CHECK_KEY}
 
 Compare the key in a \refstruct{pmix_info_t} to a given value
 
@@ -569,7 +569,7 @@ Passing a \refstruct{pmix_nspace_t} value to the standard \textit{sizeof} utilit
 \adviceuserend
 
 \subsubsection{Namespace support macro}
-\declaremacro{pmix_check_nspace}
+\declaremacro{PMIX_CHECK_NSPACE}
 
 Compare the string in a \refstruct{pmix_nspace_t} to a given value
 
@@ -723,7 +723,7 @@ PMIX_PROC_LOAD(m, n, r)
 \end{arglist}
 
 \subsubsection{Compare identifiers}
-\declaremacro{pmix_check_procid}
+\declaremacro{PMIX_CHECK_PROCID}
 
 Compare two \refstruct{pmix_proc_t} identifiers
 

--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,16 @@ pmix-standard.pdf: $(CHAPTERS) $(SOURCES) pmix.sty pmix-standard.tex figs/pmix-l
 	@echo "====> Success"
 	@cp pmix-standard.pdf pmix-standard-${version}.pdf
 
-check: pmix-standard.pdf
+check: check-attr-ref check-openpmix
+
+check-attr-ref: pmix-standard.pdf
 	@echo "====> Checking for Attributes Declared, but not referenced"
 	@./bin/check-attr-refs.py
+
+check-openpmix: pmix-standard.pdf
+	@echo "====> Checking cross-reference with OpenPMIx"
+	@./bin/check-openpmix.py
+
 
 clean:
 	rm -f $(INTERMEDIATE_FILES) pmix-standard-*.pdf

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,8 @@ INTERMEDIATE_FILES=pmix-standard.pdf \
 		pmix-standard.bbl \
 		pmix-standard.blg \
 		pmix-standard.synctex.gz \
-		pmix-standard.xwm
+		pmix-standard.xwm \
+		*.idx *.ilg *.ind
 
 all: pmix-standard.pdf
 

--- a/bin/check-openpmix.py
+++ b/bin/check-openpmix.py
@@ -1,0 +1,379 @@
+#!/usr/bin/python -u
+
+import sys
+import os
+import re
+import argparse
+import subprocess
+import shutil
+
+def check_missing_pmix_standard(std_all_refs, openpmix_all_refs, verbose=False):
+    """Check for OpenPMIx definitions missing from the PMIx Standard"""
+
+    print "-"*50
+    print "Checking: Defined in OpenPMIx, but not in the PMIx Standard"
+    print "-"*50
+
+    missing_refs = []
+    for openpmix_ref in openpmix_all_refs:
+        found_ref = False
+        for std_ref in std_all_refs:
+            if openpmix_ref == std_ref:
+                found_ref = True
+                break
+        if found_ref is False:
+            # Double check that we didn't miss it earlier when parsing OpenPMIx
+            p = subprocess.Popen("grep -in \"{"+openpmix_ref+"}\" *.tex | grep -i declare",
+                                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True, close_fds=True)
+            p.wait()
+            if p.returncode != 0 and p.returncode != 1:
+                print("Error: Failed to grep and confirm missing item \""+openpmix_ref+"\". grep error code "+str(p.returncode)+")");
+                sys.exit(2)
+            if p.returncode == 0:
+                possible_error = False
+                for line in p.stdout:
+                    line = line.rstrip()
+                    parts = line.split(":", 2)
+
+                    # if this reference is in a comment then ignore it
+                    m = re.match(r"^\s*\*", parts[2])
+                    if m is not None:
+                        print("Warning: Found reference in comment: " + line)
+                        continue
+
+                    print("ERROR: Suspected Missing \""+openpmix_ref+"\" but found on "+parts[0]+"("+parts[1]+"):"+parts[2])
+                    possible_error = True
+
+                if possible_error is True:
+                    sys.exit(1)
+
+
+            missing_refs.append(openpmix_ref)
+
+    return missing_refs
+
+def check_missing_openpmix(std_all_refs, openpmix_all_refs, verbose=False):
+    """Check for PMIx Standard definitions missing from OpenPMIx"""
+
+    print "-"*50
+    print "Checking: Defined in PMIx Standard, but not in the OpenPMIx"
+    print "-"*50
+
+    missing_refs = []
+    for std_ref in std_all_refs:
+        found_ref = False
+        for openpmix_ref in openpmix_all_refs:
+            if openpmix_ref == std_ref:
+                found_ref = True
+                break
+        if found_ref is False:
+            # Double check that we didn't miss it earlier when parsing OpenPMIx
+            p = subprocess.Popen("grep -in \""+std_ref+"\" check-openpmix/include/*",
+                                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True, close_fds=True)
+            p.wait()
+            if p.returncode != 0 and p.returncode != 1:
+                print("Error: Failed to grep and confirm missing item \""+std_ref+"\". grep error code "+str(p.returncode)+")");
+                sys.exit(2)
+            if p.returncode == 0:
+                possible_error = False
+                for line in p.stdout:
+                    line = line.rstrip()
+                    parts = line.split(":", 2)
+
+                    # if this reference is in a comment then ignore it
+                    m = re.match(r"^\s*\*", parts[2])
+                    if m is not None:
+                        print("Warning: Found reference in comment: " + line)
+                        continue
+
+                    print("ERROR: Suspected Missing \""+std_ref+"\" but found on "+parts[0]+"("+parts[1]+"):"+parts[2])
+                    possible_error = True
+
+                if possible_error is True:
+                    sys.exit(1)
+
+            # Ok it's missing so add it to the list
+            missing_refs.append(std_ref)
+
+    return missing_refs
+
+
+if __name__ == "__main__":
+    std_attributes = {}
+    std_macros = {}
+    std_consts = {}
+    std_structs = {}
+    std_apis = {}
+    std_all_refs = {}
+
+    openpmix_defines = {}
+    openpmix_structs = {}
+    openpmix_apis = {}
+    openpmix_cbs = {}
+    openpmix_all_refs = {}
+
+    #
+    # Command line parsing
+    #
+    parser = argparse.ArgumentParser(description="PMIx Standard / OpenPMIx Cross Check")
+    parser.add_argument("-v", "--verbose", help="Verbose output", action="store_true")
+
+    parser.parse_args()
+    args = parser.parse_args()
+
+
+    #
+    # Verify that we have the necessary files in the current working directory
+    # * pmix-standard.aux
+    # * check-openpmix
+    #
+    if os.path.exists("check-openpmix") is False:
+        print("Warning: Missing OpenPMIx checkout. Trying to clone now")
+        os.system("git clone https://github.com/openpmix/openpmix.git check-openpmix")
+        print("")
+
+    if os.path.exists("pmix-standard.aux") is False or os.path.exists("check-openpmix") is False:
+        print("Error: Cannot find the .aux files or OpenPMIx checkout necessary for processing in the current directory.")
+        print("       Please run this script from the base PMIx Standard build directory, and with a recent build.")
+        sys.exit(1)
+
+
+    # --------------------------------------------------
+    # Extract the declared items from the standard
+    # attributes - grep "newlabel{attr" pmix-standard.aux
+    # consts     - grep "newlabel{const" pmix-standard.aux
+    # structs    - grep "newlabel{struct" pmix-standard.aux
+    # macros     - grep "newlabel{macro" pmix-standard.aux
+    # apis       - grep "newlabel{api" pmix-standard.aux
+    # --------------------------------------------------
+    all_ref_strs = ["attr", "const", "struct", "macro", "apifn"]
+    for ref_str in all_ref_strs:
+        if args.verbose is True:
+            print "-"*50
+            print "Extracting Standard: \""+ref_str+"\""
+            print "-"*50
+
+        # subsection.A is Appendix A: Python Bindings
+        p = subprocess.Popen("grep \"newlabel{"+ref_str+"\" pmix-standard.aux | grep -v subsection.A",
+                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True, close_fds=True)
+        p.wait()
+        if p.returncode != 0:
+            print("Error: Failed to extract declared \""+ref_str+"\". grep error code "+str(p.returncode)+")");
+            sys.exit(2)
+
+        for line in p.stdout:
+            line = line.rstrip()
+            m = re.match(r"\s*\\newlabel{"+ re.escape(ref_str) + r":(\w+)", line)
+            if m is None:
+                print("Error: Failed to extract an \""+ref_str+"\" on the following line")
+                print(" line: "+line)
+                sys.exit(1)
+                
+            # Count will return to 0 when verified
+            #print("Found \""+ref_str+"\" : "+m.group(1)+" on line " + line)
+            std_all_refs[m.group(1)] = -1
+            if ref_str == "attr":
+                std_attributes[m.group(1)] = -1
+            elif ref_str == "const":
+                std_consts[m.group(1)] = -1
+            elif ref_str == "struct":
+                std_structs[m.group(1)] = -1
+            elif ref_str == "macro":
+                std_macros[m.group(1)] = -1
+            elif ref_str == "apifn":
+                std_apis[m.group(1)] = -1
+            else:
+                print("Error: Failed to classify the attribute: "+m.group(1))
+                sys.exit(1)
+
+    if args.verbose is True and 0 == 1:
+        print "-"*50
+        for val in std_attributes:
+            print("Std Attribute: " + val)
+        print "-"*50
+        for val in std_consts:
+            print("Std Const    : " + val)
+        print "-"*50
+        for val in std_structs:
+            print("Std Struct   : " + val)
+        print "-"*50
+        for val in std_macros:
+            print("Std Macro    : " + val)
+        print "-"*50
+        for val in std_apis:
+            print("Std API      : " + val)
+        print "-"*50
+
+    print("Number of Standard attributes  : " + str(len(std_attributes)))
+    print("Number of Standard consts      : " + str(len(std_consts)))
+    print("Number of Standard structs     : " + str(len(std_structs)))
+    print("Number of Standard macros      : " + str(len(std_macros)))
+    print("Number of Standard apis        : " + str(len(std_apis)))
+    print("Total Number of Standard items : " + str(len(std_all_refs)))
+    print("")
+
+
+    # --------------------------------------------------
+    # Extract the declared items from OpenPMIx
+    # --------------------------------------------------
+    openpmix_files = ["include/pmix_common.h.in", "include/pmix_tool.h", "include/pmix_server.h", "include/pmix_sched.h", "include/pmix.h"]
+    for openpmix_file in openpmix_files:
+        openpmix_file = "check-openpmix/" + openpmix_file
+        if args.verbose is True:
+            print "-"*50
+            print "Extracting OpenPMIx Definitions from: " + openpmix_file
+            print "-"*50
+
+        parse_active = False
+        parse_enum = False
+        parse_struct = False
+        defs_found = 0
+        with open(openpmix_file) as fp:
+            for line in fp:
+                line = line.rstrip()
+
+                m = re.match(r'extern "C"', line);
+                if m is None and parse_active is False:
+                    continue
+                else:
+                    parse_active = True
+
+                # typedef enum {
+                m = re.match(r'\s*typedef\s+enum\s*', line);
+                if m is not None:
+                    parse_enum = True
+                    continue
+                if parse_enum is True:
+                    m = re.match(r'\s*}\s*(pmi\w*)', line)
+                    if m is not None:
+                        openpmix_structs[m.group(1)] = -1
+                        openpmix_all_refs[m.group(1)] = -1
+                        defs_found = defs_found + 1
+                        parse_enum = False
+                        continue
+                    m = re.match(r'\s+(\w+)', line)
+                    if m is not None:
+                        #print("Define Enum: "+m.group(1))
+                        openpmix_defines[m.group(1)] = -1
+                        openpmix_all_refs[m.group(1)] = -1
+                        defs_found = defs_found + 1
+                        continue
+
+                # typedef struct pmix_data_buffer {
+                m = re.match(r'\s*typedef\s+struct\s*\w+\s+{', line);
+                if m is not None:
+                    parse_struct = True
+                    continue
+                else:
+                    m = re.match(r'\s*typedef\s+struct\s*{', line);
+                    if m is not None:
+                        parse_struct = True
+                        continue
+                if parse_struct is True:
+                    m = re.match(r'\s*}\s*(pmi\w+)', line)
+                    if m is not None:
+                        #print("Define Struct: "+m.group(1))
+                        openpmix_structs[m.group(1)] = -1
+                        openpmix_all_refs[m.group(1)] = -1
+                        defs_found = defs_found + 1
+                        parse_struct = False
+                        continue
+                    else:
+                        continue
+
+                # typedef uint8_t pmix_data_range_t;
+                m = re.match(r'\s*typedef\s*\w*\s*(pmi\w*)[;|\[]', line);
+                if m is not None:
+                    #print("Define Struct1: "+m.group(1))
+                    openpmix_structs[m.group(1)] = -1
+                    openpmix_all_refs[m.group(1)] = -1
+                    defs_found = defs_found + 1
+                    continue
+                
+                # #define PMIX_EVENT_BASE                     "pmix.evbase"
+                m = re.match(r'#define\s+(\w+)\(', line);
+                if m is not None:
+                    openpmix_defines[m.group(1)] = -1
+                    openpmix_all_refs[m.group(1)] = -1
+                    #print("Define FN: "+m.group(1))
+                    defs_found = defs_found + 1
+                    continue
+
+                # #define PMIx_Heartbeat()
+                m = re.match(r'#define\s+(\w+)', line);
+                if m is not None:
+                    openpmix_defines[m.group(1)] = -1
+                    openpmix_all_refs[m.group(1)] = -1
+                    #print("Define: "+m.group(1))
+                    defs_found = defs_found + 1
+                    continue
+
+                # PMIX_EXPORT const char* PMIx_Error_string
+                m = re.match(r'PMIX_EXPORT\s+\w+\s+\w+\*\s+(PMI\w+)', line);
+                if m is not None:
+                    openpmix_apis[m.group(1)] = -1
+                    openpmix_all_refs[m.group(1)] = -1
+                    #print("API1: "+m.group(1))
+                    defs_found = defs_found + 1
+                    continue
+
+                # PMIX_EXPORT pmix_status_t PMIx_Init(
+                m = re.match(r'PMIX_EXPORT\s+\w+\s+(PMI\w+)', line);
+                if m is not None:
+                    openpmix_apis[m.group(1)] = -1
+                    openpmix_all_refs[m.group(1)] = -1
+                    #print("API2: "+m.group(1))
+                    defs_found = defs_found + 1
+                    continue
+
+                # typedef void (*pmix_iof_cbfunc_t)(
+                m = re.match(r'\s*typedef\s+\w+\s+\(\*(\w+)', line);
+                if m is not None:
+                    openpmix_cbs[m.group(1)] = -1
+                    openpmix_all_refs[m.group(1)] = -1
+                    #print("CB: "+m.group(1))
+                    defs_found = defs_found + 1
+                    continue
+
+        if args.verbose is True:
+            print("Found "+str(defs_found)+" items in file "+openpmix_file)
+
+    print("Number of OpenPMIx defines     : " + str(len(openpmix_defines)))
+    print("Number of OpenPMIx structs     : " + str(len(openpmix_structs)))
+    print("Number of OpenPMIx APIs        : " + str(len(openpmix_apis)))
+    print("Number of OpenPMIx callbacks   : " + str(len(openpmix_cbs)))
+    print("Total Number of OpenPMIx items : " + str(len(openpmix_all_refs)))
+    print("")
+
+    # --------------------------------------------------
+    # Check to make sure that all of the items defined in OpenPMIx are in the PMIx Standard
+    # - except for those explicitly excluded
+    # --------------------------------------------------
+    total_missing_refs = 0
+
+    missing_refs = check_missing_pmix_standard(std_all_refs, openpmix_all_refs, args.verbose)
+    total_missing_refs = total_missing_refs + len(missing_refs)
+    if len(missing_refs) > 0:
+        print "-"*50
+        print("Found "+str(len(missing_refs))+" references defined in OpenPMIx, but not in the PMIx Standard")
+        for ref in sorted(missing_refs):
+            print("PMIx Standard Missing: "+ref)
+        print("")
+
+
+    # --------------------------------------------------
+    # Check to make sure that all of the items defined in the PMIx Standard are in OpenPMIx
+    # --------------------------------------------------
+    missing_refs = check_missing_openpmix(std_all_refs, openpmix_all_refs, args.verbose)
+    total_missing_refs = total_missing_refs + len(missing_refs)
+    if len(missing_refs) > 0:
+        print "-"*50
+        print("Found "+str(len(missing_refs))+" references defined in PMIx Standard, but not in OpenPMIx")
+        for ref in sorted(missing_refs):
+            print("OpenPMIx Missing: "+ref)
+        print("")
+
+
+    # Return the total number of missing references
+    sys.exit(total_missing_refs)
+

--- a/pmix-standard.tex
+++ b/pmix-standard.tex
@@ -67,7 +67,6 @@
 
 % Unified style sheet for PMIx documents:
 \input{pmix.sty}
-\makeindex[intoc,columns=2]
 
 % Watermark for the Unofficial Drafts
 % Note: "allpages","evenpages","oddpages" do not work. Likely because of the index.
@@ -75,6 +74,15 @@
   {\usepackage[printwatermark]{xwatermark}
    \newwatermark[firstpage,color=gray!30,angle=45,scale=3,xpos=-5,ypos=0]{Unofficial Draft}
   }{}
+
+%%%%%%%%%%%%%%%%%%% Indices
+\makeindex[intoc,columns=1,columnseprule=true,columnsep=15pt,title=Index]
+\makeindex[intoc,columns=1,columnseprule=true,columnsep=15pt,name=index_api,title=Index of APIs]
+\makeindex[intoc,columns=1,columnseprule=true,columnsep=15pt,name=index_macro,title=Index of Support Macros]
+\makeindex[intoc,columns=1,columnseprule=true,columnsep=15pt,name=index_const,title=Index of Constants] % 1 column because of long names
+\makeindex[intoc,columns=1,columnseprule=true,columnsep=15pt,name=index_attribute,title=Index of Attributes]
+\makeindex[intoc,columns=1,columnseprule=true,columnsep=15pt,name=index_struct,title=Index of Data Structures]
+
 
 %%%%%%%%%%%%%%%%%%%
 \usepackage{acronym}
@@ -114,6 +122,8 @@
 
 
 \begin{document}
+
+
 %
 % Title page
 %
@@ -220,7 +230,25 @@
 % Index
 %
 	\nolinenumbers
+
+	\indexprologue{General terms and other items not induced in the other indices.}
 	\printindex
+
+	%\indexprologue{Functions}
+	\printindex[index_api]
+
+	%\indexprologue{Macros}
+	\printindex[index_macro]
+
+	%\indexprologue{Data structures}
+	\printindex[index_struct]
+
+	%\indexprologue{Constants}
+	\printindex[index_const]
+
+	%\indexprologue{Attributes}
+	\printindex[index_attribute]
+
 
 \end{document}
 

--- a/pmix.sty
+++ b/pmix.sty
@@ -700,6 +700,12 @@
 \newcommand{\refapi}[1]{\index[index_api]{#1} \hyperref[apifn:#1]{\code{#1} }}
 \newcommand{\argapi}[1] {\refapi{#1}}
 
+% API references for language bindings (e.g., Python)
+% {Language specific function}{Primary C PMIx function}{Language Classification}
+\newcommand{\declareapibinding}[3]{\index[index_api]{#2!#1 (#3)} \label{bindingfn:#1}}
+\newcommand{\refapibinding}[1]{\hyperref[bindingfn:#1]{\code{#1} }}
+\newcommand{\argapibinding}[1] {\refapibinding{#1}}
+
 \newcommand{\refconst}[1]{\hyperref[const:#1]{\code{#1} }}
 
 \newcommand{\declareattr}[1]{\index[index_attribute]{#1|indexfmt} \label{attr:#1}}

--- a/pmix.sty
+++ b/pmix.sty
@@ -117,6 +117,28 @@
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Indexing and Table of Contents
+\usepackage{imakeidx}
+\usepackage[nodotinlabels]{titletoc}   % required for its [nodotinlabels] option
+
+% Clickable links in TOC and index:
+\usepackage[hyperindex=true,linktocpage=true]{hyperref}
+\hypersetup{
+  bookmarksnumbered = true,
+  bookmarksopen     = false,
+  colorlinks  = true, % Colors links instead of red boxes
+  urlcolor    = blue, % Color for external links
+  linkcolor   = blue  % Color for internal links
+}
+
+% Formatting for "Definition" items in the index
+\newcommand{\indexfmt}[1]{\textbf{\underline{#1}}}
+
+
+% \url styled in Roman font.
+\urlstyle{rm}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Paragraph formatting
 
 \usepackage{setspace}     % allows use of \singlespacing, \onehalfspacing
@@ -214,10 +236,10 @@
 {\begin{description}[itemsep=-1.3ex,itemindent=\dimexpr-17pt-\labelsep\relax]}
 {\end{description}}
 
-\newcommand{\declareconstitem}[1]{\item[\code{#1}] \index{#1} \label{const:#1} \hspace{1em}}
-\newcommand{\declareconstitemvalue}[2]{\item[\code{#1}] \index{#1} \hspace{0.25em} \code{#2}  \hspace{1em}}
-\newcommand{\declareconstitemDEP}[2]{\item[\code{#1} (Deprecated in PMIx #2)] \index{#1} \label{const:#1} \hspace{1em}}
-\newcommand{\declareconstitemNEW}[1]{\item[\color{magenta}\code{#1}] \index{#1} \label{const:#1} \hspace{1em}}
+\newcommand{\declareconstitem}[1]{\item[\code{#1}] \index[index_const]{#1|indexfmt} \label{const:#1} \hspace{1em}}
+\newcommand{\declareconstitemvalue}[2]{\item[\code{#1}] \index[index_const]{#1|indexfmt} \hspace{0.25em} \code{#2}  \hspace{1em}}
+\newcommand{\declareconstitemDEP}[2]{\item[\code{#1} (Deprecated in PMIx #2)] \index[index_const]{#1|indexfmt} \label{const:#1} \hspace{1em}}
+\newcommand{\declareconstitemNEW}[1]{\item[\color{magenta}\code{#1}] \index[index_const]{#1|indexfmt} \label{const:#1} \hspace{1em}}
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -335,10 +357,11 @@
 %   \declareAttribute       Declare an attribute with a description
 %   \pasteAttributeItem     Paste the attribute description here
 %   \refAttributeItem       Reference the original definition of the attribute
-%
+% 
+
 \newcommand{\declareAttribute}[4]{%
     \code{#1} ~~\code{#2}~~(\code{#3})%
-    \index{#1!Definition|textbf} \label{attr:#1}%
+    \index[index_attribute]{#1|indexfmt} \label{attr:#1}%
     \StdCopy{str:#1}{\code{#2}}%
     \StdCopy{attr:#1}{\code{#3}}%
     \vspace{-1.3ex}%
@@ -350,7 +373,7 @@
 
 \newcommand{\declareNewAttribute}[4]{%
    {\color{magenta}\code{#1}} ~~\code{#2}~~(\code{#3})%
-    \index{#1!Definition|textbf} \label{attr:#1}%
+    \index[index_attribute]{#1|indexfmt} \label{attr:#1}%
     \StdCopy{str:#1}{\code{#2}}%
     \StdCopy{attr:#1}{\code{#3}}%
     \vspace{-1.3ex}%
@@ -362,7 +385,7 @@
 
 \newcommand{\declareDepAttribute}[4]{%
    {\color{green!80!black}\code{#1}} ~~\code{#2}~~(\code{#3})%
-    \index{#1!Definition|textbf} \label{attr:#1}%
+    \index[index_attribute]{#1|indexfmt} \label{attr:#1}%
     \StdCopy{str:#1}{\code{#2}}%
     \StdCopy{attr:#1}{\code{#3}}%
     \vspace{-1.3ex}%
@@ -386,10 +409,10 @@
 	\pasteAttributeItemBegin{#1}
 	\pasteAttributeItemEnd{}
 }
-\newcommand{\refAttributeItem}[1]{\index{#1} \hyperref[attr:#1]{\code{#1}} }
+\newcommand{\refAttributeItem}[1]{\index[index_attribute]{#1} \hyperref[attr:#1]{\code{#1}} }
 \newcommand{\refattr}[1]{\refAttributeItem{#1}}
 
-\newcommand{\refPRIAttributeItem}[1]{\index{#1} \hyperref[attr:#1]{\color{red}\code{#1}} }
+\newcommand{\refPRIAttributeItem}[1]{\index[index_attribute]{#1} \hyperref[attr:#1]{\color{red}\code{#1}} }
 
 \newcommand{\pastePRIAttributeItemBegin}[1]{
   \refPRIAttributeItem{#1} ~~\StdPaste{str:#1}~~(\StdPaste{attr:#1})
@@ -407,7 +430,7 @@
     \pastePRIAttributeItemEnd{}
 }
 
-\newcommand{\refPRRTEAttributeItem}[1]{\index{#1} \hyperref[attr:#1]{\color{green!60!black}\code{#1}} }
+\newcommand{\refPRRTEAttributeItem}[1]{\index[index_attribute]{#1} \hyperref[attr:#1]{\color{green!60!black}\code{#1}} }
 
 \newcommand{\pastePRRTEAttributeItemBegin}[1]{
   \refPRRTEAttributeItem{#1} ~~\StdPaste{str:#1}~~(\StdPaste{attr:#1})
@@ -647,25 +670,6 @@
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% Indexing and Table of Contents
-
-\usepackage{imakeidx}
-\usepackage[nodotinlabels]{titletoc}   % required for its [nodotinlabels] option
-
-% Clickable links in TOC and index:
-\usepackage[hyperindex=true,linktocpage=true]{hyperref}
-\hypersetup{
-  bookmarksnumbered = true,
-  bookmarksopen     = false,
-  colorlinks  = true, % Colors links instead of red boxes
-  urlcolor    = blue, % Color for external links
-  linkcolor   = blue  % Color for internal links
-}
-
-% \url styled in Roman font.
-\urlstyle{rm}
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Cross reference macros
 % This defines:
 %     \specref          cross reference label as "Section X on page Y"
@@ -687,27 +691,27 @@
 
 \newcommand{\refsection}[2]{\hyperref[#1]{#2}}
 
-\newcommand{\declarestruct}[1]{\index{#1!Definition|textbf} \label{struct:#1}}
-\newcommand{\refstruct}[1]{\index{#1} \hyperref[struct:#1]{\code{#1} }}
+\newcommand{\declarestruct}[1]{\index[index_struct]{#1|indexfmt} \label{struct:#1}}
+\newcommand{\refstruct}[1]{\index[index_struct]{#1} \hyperref[struct:#1]{\code{#1} }}
 \newcommand{\structref}[1] {\refstruct{#1}}
 \newcommand{\specrefstruct}[1]{Section~\ref{struct:#1} on page~\pageref{struct:#1}}
 
-\newcommand{\declareapi}[1]{\index{#1!Definition|textbf} \label{api:#1}}
-\newcommand{\refapi}[1]{\index{#1} \hyperref[api:#1]{\code{#1} }}
+\newcommand{\declareapi}[1]{\index[index_api]{#1|indexfmt} \label{apifn:#1}}
+\newcommand{\refapi}[1]{\index[index_api]{#1} \hyperref[apifn:#1]{\code{#1} }}
 \newcommand{\argapi}[1] {\refapi{#1}}
 
 \newcommand{\refconst}[1]{\hyperref[const:#1]{\code{#1} }}
 
-\newcommand{\declareattr}[1]{\index{#1!Definition|textbf} \label{attr:#1}}
+\newcommand{\declareattr}[1]{\index[index_attribute]{#1|indexfmt} \label{attr:#1}}
 
 \newcommand{\refarg}[1] {{\textrm{\textmd{\itshape{#1}}}}}
 \newcommand{\argref}[1] {\refarg{#1}}
 
-\newcommand{\declaremacro}[1]{\index{#1!Definition|textbf} \label{macro:#1}}
-\newcommand{\refmacro}[1]{\index{#1} \hyperref[macro:#1]{\code{#1} }}
+\newcommand{\declaremacro}[1]{\index[index_macro]{#1|indexfmt} \label{macro:#1}}
+\newcommand{\refmacro}[1]{\index[index_macro]{#1} \hyperref[macro:#1]{\code{#1} }}
 
-\newcommand{\declareterm}[1]{\index{#1!Definition|textbf} \label{macro:#1}}
-\newcommand{\refterm}[1]{\index{#1} \hyperref[macro:#1]{\code{#1} }}
+\newcommand{\declareterm}[1]{\index{#1|indexfmt} \label{term:#1}}
+\newcommand{\refterm}[1]{\index{#1} \hyperref[term:#1]{\code{#1} }}
 
 % Place in text for in-text questions during review
 \newcommand{\rcomment}[1]{(REVIEW COMMENT: \textbf{#1})}


### PR DESCRIPTION
 * Multiple indices will make it easier to find APIs vs attributes vs ...
 * Add an automated document cross-check against OpenPMIx
   - Checks PMIx Standard items not included in OpenPMIx
   - Checks OpenPMIx items not included in PMIx Standard

Closes #149