### PR TITLE
Fix check scripts

### DIFF
--- a/bin/check-attr-refs.py
+++ b/bin/check-attr-refs.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
     #
     # Verify the list against the index
     # If any difference then post a warning
-    #  grep "PMIX_SERVER_REMOTE_CONNECTIONS\!Def" pmix-standard.idx
+    #  grep "PMIX_SERVER_REMOTE_CONNECTIONS\|hyperindexformat" pmix-standard.idx
     #
     if args.verbose is True:
         print "-"*50
@@ -87,7 +87,7 @@ if __name__ == "__main__":
         if args.verbose is True:
             print "Processing Index File: "+fname
 
-        p = subprocess.Popen("grep \"\\!Definition\" "+fname,
+        p = subprocess.Popen("grep \"\\|hyperindexformat\" "+fname,
                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True, close_fds=True)
         p.wait()
         if p.returncode != 0:
@@ -170,7 +170,7 @@ if __name__ == "__main__":
     #
     # Display a list of attributes that are declared but not used
     #
-    for attr in attr_declared:
+    for attr in sorted(attr_declared):
         if attr_declared[attr] <= 0:
             print("Attribute Missing Reference: "+attr)
             count_not_used += 1

--- a/bin/check-openpmix.py
+++ b/bin/check-openpmix.py
@@ -68,7 +68,7 @@ def check_missing_openpmix(std_all_refs, openpmix_all_refs, verbose=False):
                 break
         if found_ref is False:
             # Double check that we didn't miss it earlier when parsing OpenPMIx
-            p = subprocess.Popen("grep -in \""+std_ref+"\" check-openpmix/include/*",
+            p = subprocess.Popen("grep -in \""+std_ref+"[^a-zA-Z0-9_]\" check-openpmix/include/*",
                                  stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True, close_fds=True)
             p.wait()
             if p.returncode != 0 and p.returncode != 1:

--- a/pmix.sty
+++ b/pmix.sty
@@ -133,6 +133,8 @@
 
 % Formatting for "Definition" items in the index
 \newcommand{\indexfmt}[1]{\textbf{\underline{#1}}}
+% Formatting for deprecated items in the index
+\newcommand{\indexdepfmt}[1]{\textbf{\underline{#1}}}
 
 
 % \url styled in Roman font.
@@ -385,7 +387,7 @@
 
 \newcommand{\declareDepAttribute}[4]{%
    {\color{green!80!black}\code{#1}} ~~\code{#2}~~(\code{#3})%
-    \index[index_attribute]{#1|indexfmt} \label{attr:#1}%
+    \index[index_attribute]{#1@#1 \textbf{(Deprecated)}|indexdepfmt} \label{attr:#1}%
     \StdCopy{str:#1}{\code{#2}}%
     \StdCopy{attr:#1}{\code{#3}}%
     \vspace{-1.3ex}%


### PR DESCRIPTION
 * Fix check-ref-attr now that we no longer use "Definition" in the index
 * For deprecated attributes add a "(Deprecated)" note to the index
 * Fix check-openpmix to better match names when double checking to see if something is missing