### PR TITLE
Minor touchups on the fabric interfaces

### DIFF
--- a/App_Python.tex
+++ b/App_Python.tex
@@ -2341,8 +2341,8 @@ See \refapi{PMIx_Fabric_get_vertex_info} for details
 
 
 %%%%%%%%%%%
-\subsection{Client.fabric_get_index}
-\declareapibinding{PMIxClient.fabric_get_index}{PMIx_Fabric_get_index}{Python}
+\subsection{Client.fabric_get_device_index}
+\declareapibinding{PMIxClient.fabric_get_device_index}{PMIx_Fabric_get_device_index}{Python}
 
 \summary
 Given info describing a given vertex, return the corresponding communication cost matrix index
@@ -2352,7 +2352,7 @@ Given info describing a given vertex, return the corresponding communication cos
 \versionMarker{4.0}
 \pyspecificstart
 \begin{codepar}
-rc,index = myserver.fabric_get_index(info:list)
+rc,index = myserver.fabric_get_device_index(info:list)
 \end{codepar}
 \pyspecificend
 
@@ -2368,7 +2368,7 @@ Returns:
 \end{itemize}
 
 
-See \refapi{PMIx_Fabric_get_index} for details
+See \refapi{PMIx_Fabric_get_device_index} for details
 
 
 %%%%%%%%%%%

--- a/Chap_API_Fabric.tex
+++ b/Chap_API_Fabric.tex
@@ -627,8 +627,8 @@ The caller is responsible for releasing the returned array.
 
 
 %%%%%%%%%%%
-\subsection{\code{PMIx_Fabric_get_index}}
-\declareapi{PMIx_Fabric_get_index}
+\subsection{\code{PMIx_Fabric_get_device_index}}
+\declareapi{PMIx_Fabric_get_device_index}
 
 %%%%
 \summary
@@ -642,7 +642,7 @@ Given vertex info, return the corresponding communication cost matrix index.
 \cspecificstart
 \begin{codepar}
 pmix_status_t
-PMIx_Fabric_get_index(pmix_fabric_t *fabric,
+PMIx_Fabric_get_device_index(pmix_fabric_t *fabric,
                       const pmix_info_t vertex[], size_t ninfo,
                       uint32_t *index)
 \end{codepar}

--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -3029,17 +3029,18 @@ Returns one of the following:
 \end{itemize}
 
 \reqattrstart
-The following directives are required to be supported by all hosts to aid users in identifying the fabric to whom the operation is to be applied:
+The following directives are required to be supported by all hosts to aid users in identifying the fabric and (if applicable) the device to whom the operation references:
 
 \pastePRIAttributeItem{PMIX_FABRIC_VENDOR}
 \pastePRIAttributeItem{PMIX_FABRIC_IDENTIFIER}
 \pastePRIAttributeItem{PMIX_FABRIC_PLANE}
+\pastePRIAttributeItem{PMIX_FABRIC_DEVICE_INDEX}
 
 \reqattrend
 
 %%%%
 \descr
 
-Perform the specified operation. Return the result of any requests in the callback function when the operation is completed. Operations may, for example, include a request for fabric information. See \refstruct{pmix_fabric_t} for a list of expected information to be included in the response.
+Perform the specified operation. Return the result of any requests in the callback function when the operation is completed. Operations may, for example, include a request for fabric information. See \refstruct{pmix_fabric_t} for a list of expected information to be included in the response. Note that requests for device index are to be returned in the callback function's array of \refstruct{pmix_info_t} using the \refattr{PMIX_FABRIC_DEVICE_INDEX} attribute.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Make the API name clearer for get_device_index. Clarify the expected
return info on the server module function.

Signed-off-by: Ralph Castain <rhc@pmix.org>