### PR TITLE
Fix typo in interface list for v1.0

### DIFF
--- a/Chap_Introduction.tex
+++ b/Chap_Introduction.tex
@@ -248,7 +248,7 @@ Below are a summary listing of the interfaces defined in the 1.0 headers.
 \item \refapi{PMIx_Fence}, \refapi{PMIx_Fence_nb}
 \item \refapi{PMIx_Get}, \refapi{PMIx_Get_nb}
 \item \refapi{PMIx_Publish}, \refapi{PMIx_Publish_nb}
-\item \refapi{PMIx_Lookup}, \refapi{PMIx_Lookup}
+\item \refapi{PMIx_Lookup}, \refapi{PMIx_Lookup_nb}
 \item \refapi{PMIx_Unpublish}, \refapi{PMIx_Unpublish_nb}
 \item \refapi{PMIx_Spawn}, \refapi{PMIx_Spawn_nb}
 \item \refapi{PMIx_Connect}, \refapi{PMIx_Connect_nb}


### PR DESCRIPTION
The duplicate entry for PMIx_Lookup should be PMIx_Lookup_nb, which existed in v1.0 according to the version mark.