### PR TITLE
Extend topology support

### DIFF
--- a/Chap_API_Proc_Mgmt.tex
+++ b/Chap_API_Proc_Mgmt.tex
@@ -607,10 +607,67 @@ Nonblocking \refapi{PMIx_Disconnect} routine. The callback function is called on
 
 The relative locality of processes is often used to optimize their interactions with the hardware and other processes. \ac{PMIx} provides a means by which the host environment can communicate the locality of a given process using the \refapi{PMIx_generate_locality_string} to generate an abstracted representation of that value. This provides a human-readable format and allows the client to parse the locality string with a method of its choice that may differ from the one used by the server that generated it.
 
+There are times, however, when relative locality and other \ac{PMIx}-provided
+information doesn't include some element required by the application. In these
+instances, the application may need access to the full description of the
+local hardware topology. \ac{PMIx} does not itself generate such descriptions
+- there are multiple third-party libraries that fulfill that role. Instead,
+\ac{PMIx} offers an abstraction method by which users can obtain a pointer to
+the description. This transparently enables support for different methods of
+sharing the topology between the host environment (which may well have already
+generated it prior to local start of application processes) and the clients -
+e.g., through passing of a shared memory region.
 
 %%%%%%%%%%%
-\subsection{\code{PMIx_get_relative_locality}}
-\declareapi{PMIx_get_relative_locality}
+\subsection{\code{PMIx_Load_topology}}
+\declareapi{PMIx_Load_topology}
+
+%%%%
+\summary
+
+Load the local hardware topology description
+
+%%%%
+\format
+
+\versionMarker{4.0}
+\cspecificstart
+\begin{codepar}
+pmix_status_t
+PMIx_Load_topology(pmix_topology_t *topo);
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\arginout{topo}{Address of a \refstruct{pmix_topology_t} structure where the topology information is to be loaded (handle)}
+\end{arglist}
+
+Returns \refconst{PMIX_SUCCESS}, indicating that the \refarg{topo} was successfully loaded, or an appropriate \ac{PMIx} error constant.
+
+%%%%
+\descr
+
+Obtain a pointer to the topology description of the local node. If the
+\refarg{source} field of the provided \refstruct{pmix_topology_t} is set, then
+the \ac{PMIx} library must return a description from the specified
+implementation or else indicate that the implementation is not available by
+returning the \refconst{PMIX_ERR_NOT_SUPPORTED} error constant.
+
+The returned pointer may point to a shared memory region or an actual instance
+of the topology description. In either case, the description shall be treated
+as a "read-only" object - attempts to modify the object are likely to fail and
+return an error. The \ac{PMIx} library is responsible for performing any required cleanup when the client library finalizes.
+
+\adviceuserstart
+It is the responsibility of the user to ensure that the \refarg{topo} argument
+is properly initialized prior to calling this \ac{API}, and to check the
+returned \refarg{source} to verify that the returned topology description is
+compatible with the user's code.
+\adviceuserend
+
+%%%%%%%%%%%
+\subsection{\code{PMIx_Get_relative_locality}}
+\declareapi{PMIx_Get_relative_locality}
 
 %%%%
 \summary
@@ -624,7 +681,7 @@ Get the relative locality of two local processes given their locality strings.
 \cspecificstart
 \begin{codepar}
 pmix_status_t
-PMIx_get_relative_locality(const char *locality1,
+PMIx_Get_relative_locality(const char *locality1,
                            const char *locality2,
                            pmix_locality_t *locality);
 \end{codepar}
@@ -644,11 +701,49 @@ Returns \refconst{PMIX_SUCCESS}, indicating that the \refarg{locality} was succe
 Parse the locality strings of the two processes and set the appropriate \refstruct{pmix_locality_t} locality bits in the provided memory location.
 
 %%%%%%%
+\subsubsection{Topology description}
+\declarestruct{pmix_topology_t}
+
+The \refstruct{pmix_topology_t} structure contains a (case-insensitive)
+string identifying the source of the topology (e.g., "hwloc") and a pointer
+to the corresponding implementation-specific topology description.
+
+\versionMarker{4.0}
+\cspecificstart
+\begin{codepar}
+typedef struct pmix_topology \{
+    char *source;
+    void *topology;
+\} pmix_topoology_t;
+\end{codepar}
+\cspecificend
+
+\subsubsection{Initialize the topology description structure}
+\declaremacro{PMIX_TOPO_CONSTRUCT}
+
+Initialize the \refstruct{pmix_topology_t} fields to \code{NULL}
+
+\versionMarker{4.0}
+\cspecificstart
+\begin{codepar}
+PMIX_TOPOLOGY_CONSTRUCT(m)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{m}{Pointer to the structure to be initialized (pointer to \refstruct{pmix_topology_t})}
+\end{arglist}
+
+
+%%%%%%%
 \subsubsection{Relative locality of two processes}
 \declarestruct{pmix_locality_t}
 
 \versionMarker{4.0}
-The \refstruct{pmix_locality_t} datatype is a \code{uint16_t} bitmask that defines the relative locality of two processes on a node. The following constants represent specific bits in the mask and can be used to test a locality value using standard bit-test methods.
+The \refstruct{pmix_locality_t} datatype is a \code{uint16_t} bitmask that
+defines the relative locality of two processes on a node. The following
+constants represent specific bits in the mask and can be used to test a
+locality value using standard bit-test methods.
 
 \begin{constantdesc}
 %
@@ -691,12 +786,18 @@ Implementers and vendors may choose to extend these definitions as needed to des
 
 %
 \declareAttribute{PMIX_LOCALITY_STRING}{"pmix.locstr"}{char*}{
-String describing a process's bound location - referenced using the process's rank. The string is prefixed by the implementation that created it (e.g., "hwloc") followed by a colon. The remainder of the string represents the corresponding locality as expressed by the underlying implementation. The entire string must be passed to \refapi{PMIx_get_relative_locality} for processing. Note that hosts are only required to provide locality strings for local client processes - thus, a call to \refapi{PMIx_Get} for the locality string of a process that returns \refconst{PMIX_ERR_NOT_FOUND} indicates that the process is not executing on the same node.
+String describing a process's bound location - referenced using the process's
+rank. The string is prefixed by the implementation that created it (e.g.,
+"hwloc") followed by a colon. The remainder of the string represents the
+corresponding locality as expressed by the underlying implementation. The
+entire string must be passed to \refapi{PMIx_Get_relative_locality} for
+processing. Note that hosts are only required to provide locality strings for
+local client processes - thus, a call to \refapi{PMIx_Get} for the locality
+string of a process that returns \refconst{PMIX_ERR_NOT_FOUND} indicates that
+the process is not executing on the same node.
 }
 
 %
 \declareAttributeDEP{PMIX_LOCALITY}{"pmix.loc"}{\refstruct{pmix_locality_t}}{
 Relative locality of the specified process to the requester, expressed as a bitmask as per the description in the \refstruct{pmix_locality_t} section. This value is unique to the requesting process and thus cannot be communicated by the server as part of the job-level information. Its use has therefore been deprecated and the key will be removed in a future release.
 }
-
-

--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -9,6 +9,22 @@ The \ac{RM} daemon that hosts the \ac{PMIx} server library interacts with that l
 Second, the host can provide a set of callback functions by which the \ac{PMIx} server library can pass requests upward for servicing by the host. These include notifications of client connection and finalize, as well as requests by clients for information and/or services that the \ac{PMIx} server library does not itself provide.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\section{Server-Specific Attributes}
+\label{chap:api_init:serverattrs}
+
+%
+\declareAttributeDEP{PMIX_TOPOLOGY}{"pmix.topo"}{hwloc_topology_t}{
+Provide a pointer to an HWLOC description of the local node
+topology.
+}
+
+%
+\declareAttribute{PMIX_TOPOLOGY2}{"pmix.topo2"}{pmix_topology_t}{
+Provide a pointer to an implementation-specific description of the local node
+topology.
+}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Server Initialization and Finalization}
 \label{chap:api_init:server}
 
@@ -80,6 +96,13 @@ The following attributes are optional for implementers of \ac{PMIx} libraries:
 \pasteAttributeItemBegin{PMIX_SERVER_REMOTE_CONNECTIONS} If the library supports connections from remote tools, this attribute may be supported for enabling or disabling it.
 \pasteAttributeItemEnd{}
 \pasteAttributeItem{PMIX_EVENT_BASE}
+\pasteAttributeItemBegin{PMIX_TOPOLOGY2}If provided, the \ac{PMIx} server will
+perform the necessary actions to scalably expose the description to the local
+clients. This includes creating any required shared memory backing stores and/
+or \ac{XML} representations, plus ensuring that all necessary key-value pairs
+for clients to access the description are included in the job-level
+information provided to each client.
+\pasteAttributeItemEnd{}
 
 \optattrend
 
@@ -1245,7 +1268,7 @@ Returns either \refconst{PMIX_SUCCESS} indicating that the returned string conta
 %%%%
 \descr
 
-Provide a function by which the host environment can generate a \ac{PMIx} locality string for inclusion in the call to \refapi{PMIx_server_register_nspace}. This function shall only be called for local client processes, with the returned locality included in the job-level information (via the \refattr{PMIX_LOCALITY_STRING} attribute) provided to local clients. Local clients can use these strings as input to determine the relative locality of their local peers via the \refapi{PMIx_get_relative_locality} \ac{API}.
+Provide a function by which the host environment can generate a \ac{PMIx} locality string for inclusion in the call to \refapi{PMIx_server_register_nspace}. This function shall only be called for local client processes, with the returned locality included in the job-level information (via the \refattr{PMIX_LOCALITY_STRING} attribute) provided to local clients. Local clients can use these strings as input to determine the relative locality of their local peers via the \refapi{PMIx_Get_relative_locality} \ac{API}.
 
 The function is required to return a string prefixed by the \refarg{source} field of the provided \refarg{cpuset} followed by a colon. The remainder of the string shall represent the corresponding locality as expressed by the underlying implementation.
 

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -4088,65 +4088,70 @@ Average Megabytes of memory used by client processes.
 \subsection{Topology information attributes}
 \label{api:struct:attributes:topoinfo}
 
-These attributes are used to describe topology information in the PMIx universe - all are referenced using \refconst{PMIX_RANK_WILDCARD} except where noted.
+These attributes are used to describe topology information in the \ac{PMIx}
+universe - all are referenced using \refconst{PMIX_RANK_WILDCARD} except where
+noted.
+
+\adviceuserstart
+The following attributes are being removed from the \ac{PMIx} Standard as they
+are internal to a given \ac{PMIx} implementation. Users are referred to the
+\refapi{PMIx_Load_topology} \ac{API} for obtaining the local topology
+description.
+\adviceuserend
 
 %
-\declareAttribute{PMIX_LOCAL_TOPO}{"pmix.ltopo"}{char*}{
+\declareAttributeDEP{PMIX_LOCAL_TOPO}{"pmix.ltopo"}{char*}{
 \ac{XML} representation of local node topology.
 }
 
-%
-\declareAttribute{PMIX_TOPOLOGY}{"pmix.topo"}{hwloc_topology_t}{
-Pointer to the PMIx client's internal hwloc topology object.
-}
 
 %
-\declareAttribute{PMIX_TOPOLOGY_XML}{"pmix.topo.xml"}{char*}{
+\declareAttributeDEP{PMIX_TOPOLOGY_XML}{"pmix.topo.xml"}{char*}{
 \ac{XML}-based description of topology
 }
 
 %
-\declareAttribute{PMIX_TOPOLOGY_FILE}{"pmix.topo.file"}{char*}{
+\declareAttributeDEP{PMIX_TOPOLOGY_FILE}{"pmix.topo.file"}{char*}{
 Full path to file containing \ac{XML} topology description
 }
 
 %
-\declareAttribute{PMIX_TOPOLOGY_SIGNATURE}{"pmix.toposig"}{char*}{
+\declareAttributeDEP{PMIX_TOPOLOGY_SIGNATURE}{"pmix.toposig"}{char*}{
 Topology signature string.
 }
 
 %
-\declareAttribute{PMIX_HWLOC_SHMEM_ADDR}{"pmix.hwlocaddr"}{size_t}{
+\declareAttributeDEP{PMIX_HWLOC_SHMEM_ADDR}{"pmix.hwlocaddr"}{size_t}{
 Address of the HWLOC shared memory segment.
 }
 
 %
-\declareAttribute{PMIX_HWLOC_SHMEM_SIZE}{"pmix.hwlocsize"}{size_t}{
+\declareAttributeDEP{PMIX_HWLOC_SHMEM_SIZE}{"pmix.hwlocsize"}{size_t}{
 Size of the HWLOC shared memory segment.
 }
 
 %
-\declareAttribute{PMIX_HWLOC_SHMEM_FILE}{"pmix.hwlocfile"}{char*}{
+\declareAttributeDEP{PMIX_HWLOC_SHMEM_FILE}{"pmix.hwlocfile"}{char*}{
 Path to the HWLOC shared memory file.
 }
 
 %
-\declareAttribute{PMIX_HWLOC_XML_V1}{"pmix.hwlocxml1"}{char*}{
+\declareAttributeDEP{PMIX_HWLOC_XML_V1}{"pmix.hwlocxml1"}{char*}{
 \ac{XML} representation of local topology using HWLOC's v1.x format.
 }
 
 %
-\declareAttribute{PMIX_HWLOC_XML_V2}{"pmix.hwlocxml2"}{char*}{
+\declareAttributeDEP{PMIX_HWLOC_XML_V2}{"pmix.hwlocxml2"}{char*}{
 \ac{XML} representation of local topology using HWLOC's v2.x format.
 }
 
 %
-\declareAttribute{PMIX_HWLOC_SHARE_TOPO}{"pmix.hwlocsh"}{bool}{
+\declareAttributeDEP{PMIX_HWLOC_SHARE_TOPO}{"pmix.hwlocsh"}{bool}{
 Share the HWLOC topology via shared memory
 }
 
 %
-\declareAttribute{PMIX_HWLOC_HOLE_KIND}{"pmix.hwlocholek"}{char*}{
+\declareAttributeDEP{PMIX_HWLOC_HOLE_KIND}{"pmix.hwlocholek"}{char*}{
 Kind of VM ``hole'' HWLOC should use for shared memory
 }
 

--- a/Chap_Introduction.tex
+++ b/Chap_Introduction.tex
@@ -428,7 +428,7 @@ The above changes included introduction of the following \acp{API}:
         \item \refapi{PMIx_Group_invite}, \refapi{PMIx_Group_invite_nb}
         \item \refapi{PMIx_Group_join}, \refapi{PMIx_Group_join_nb}
         \item \refapi{PMIx_Group_leave}, \refapi{PMIx_Group_leave_nb}
-        \item \refapi{PMIx_get_relative_locality}
+        \item \refapi{PMIx_Get_relative_locality}, \refapi{PMIx_Load_topology}
     \end{itemize}
 
     \item Server \acp{API}


### PR DESCRIPTION
Users and applications would like a scalable way to retrieve the local
topology, preferably via a shared memory region from the local
persistent daemon. This alleviates the discovery time problem for large
ppn scenarios as well as the memory footprint penalty associated with
every proc carrying its own topology description.

Define a new pmix_topology_t abstraction that includes the source of the
topology description (e.g., "hwloc") and a void* pointer to the
description itself. Add a PMIX_TOPOLOGY2 attribute to use that value
in place of hwloc_topology_t to provide more of an abstraction.
Deprecate PMIX_TOPOLOGY.  Server library is responsible for cleaning up
at finalize.
    
When PMIX_TOPOLOGY or PMIX_TOPOLOGY2 is passed to a server during
PMIx_server_init, have the server be responsible for setting up whatever
support is available (depending on topology implementation) and passing
the required keys down to the client. This removes all the current PMIX_*
topology keys as those become hidden inside the PMIx implementation -
so deprecate them in this version.

Add a new PMIx_Load_topology API by which the user/app can retrieve the
topology description for their subsequent use. Strongly warn that the
returned pointer is to be treated as "read only" and that attempts to
modify it will return an error. Client library is responsible for
cleaning up at finalize.

Do a little cleanup of long lines so diff is easier to read. Fix an
error in naming convention - it should be PMIx_Get_relative_locality
with a capital-G as it is a client-facing function.

Signed-off-by: Ralph Castain <rhc@pmix.org>