### PR TITLE
Modify process set definitions

### DIFF
--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -101,7 +101,10 @@ perform the necessary actions to scalably expose the description to the local
 clients. This includes creating any required shared memory backing stores and/
 or \ac{XML} representations, plus ensuring that all necessary key-value pairs
 for clients to access the description are included in the job-level
-information provided to each client.
+information provided to each client. All required files are to be installed
+under the effective \refattr{PMIX_SERVER_TMPDIR} directory. The \ac{PMIx}
+server library is responsible for cleaning up any artifacts (e.g., shared
+memory backing files or cached key-value pairs) at library finalize.
 \pasteAttributeItemEnd{}
 
 \optattrend
@@ -338,7 +341,7 @@ Application-level information is accessed by providing both the namespace of the
 plus the following optional information:
 
 \begin{itemize}
-    \item \pasteAttributeItem{PMIX_PSET_NAME}
+    \item \pasteAttributeItem{PMIX_PSET_NAMES}
 \end{itemize}
 
 The data may also include attributes provided by the host environment that identify the programming model (as specified by the user) being executed within the namespace. The \ac{PMIx} server library may utilize this information to customize the environment to fit that model (e.g., adding environmental variables specified by the corresponding standard for that model):
@@ -1306,6 +1309,107 @@ PMIX_CPUSET_CONSTRUCT(m)
 \begin{arglist}
 \argin{m}{Pointer to the structure to be initialized (pointer to \refstruct{pmix_cpuset_t})}
 \end{arglist}
+
+
+%%%%%%%%%%%
+\subsection{\code{PMIx_server_define_process_set}}
+\declareapi{PMIx_server_define_process_set}
+
+%%%%
+\summary
+
+Add members to a \ac{PMIx} process set
+
+%%%%
+\format
+
+\versionMarker{4.0}
+\cspecificstart
+\begin{codepar}
+pmix_status_t
+PMIx_server_define_process_set(const pmix_proc_t *members,
+                               char *pset_name);
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{members}{Pointer to an array of \refstruct{pmix_proc_t} containing the
+identifiers of the processes to be added to the process set (handle)}
+\argin{pset_name}{String name of the process set to which the specified
+processes are to be added (\code{char*})}
+\end{arglist}
+
+Returns either \refconst{PMIX_SUCCESS} or an appropriate \ac{PMIx} error constant.
+
+
+%%%%
+\descr
+
+Provide a function by which the host environment can add processes to a
+process set, creating the set if it doesn't already exist. The \ac{PMIx}
+server shall alert all local clients of the new process set (including process
+set name and membership) via the \refconst{PMIX_PROCESS_SET_DEFINE} event.
+
+\advicermstart
+The host environment is responsible for ensuring:
+
+\begin{itemize}
+    \item consistent knowledge of process set membership across all involved
+    \ac{PMIx} servers; and
+    \item that process set names do not conflict with system-assigned
+    namespaces within the scope of the set
+\end{itemize}
+
+\advicermend
+
+%%%%%%%%%%%
+\subsection{\code{PMIx_server_delete_process_set}}
+\declareapi{PMIx_server_delete_process_set}
+
+%%%%
+\summary
+
+Delete members from a \ac{PMIx} process set
+
+%%%%
+\format
+
+\versionMarker{4.0}
+\cspecificstart
+\begin{codepar}
+pmix_status_t
+PMIx_server_delete_process_set(const pmix_proc_t *members,
+                               char *pset_name);
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{members}{Pointer to an array of \refstruct{pmix_proc_t} containing the
+identifiers of the processes to be removed from the process set (handle)}
+\argin{pset_name}{String name of the process set from which the specified
+processes are to be removed (\code{char*})}
+\end{arglist}
+
+Returns either \refconst{PMIX_SUCCESS} or an appropriate \ac{PMIx} error
+constant.
+
+
+%%%%
+\descr
+
+Provide a function by which the host environment can remove processes from a
+process set. If the array of members is \code{NULL}, then all current members
+are to be removed and the process set name deleted from the \ac{PMIx} server.
+If the array of members is non-\code{NULL}, then the identified members shall
+be removed from the process set - once the last member has been removed, the
+server shall delete the process set name from its storage. The \ac{PMIx}
+server shall alert all local clients of the process set modifications via the
+\refconst{PMIX_PROCESS_SET_DELETE} event.
+
+\advicermstart
+The host environment is responsible for ensuring consistent knowledge of
+process set membership across all involved \ac{PMIx} servers.
+\advicermend
 
 
 %%%%%%%%%%%

--- a/Chap_API_Sets_Groups.tex
+++ b/Chap_API_Sets_Groups.tex
@@ -4,14 +4,21 @@
 \chapter{Process Sets and Groups}
 \label{chap:api_sets_groups}
 
-\ac{PMIx} supports two slightly related, but functionally different concepts known as \emph{process sets} and \emph{process groups}. This chapter these two concepts and describes how they are utilized, along with their corresponding \acp{API}.
+\ac{PMIx} supports two slightly related, but functionally different concepts
+known as \emph{process sets} and \emph{process groups}. This chapter defines
+these two concepts and describes how they are utilized, along with their
+corresponding \acp{API}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Process Sets}
 \label{chap:api_sets_groups:sets}
 
-A \ac{PMIx} \emph{Process Set} is a user-provided label associated with a given set of application processes. Processes can belong to multiple process \emph{sets} at a time. Definition of a \ac{PMIx} process set typically occurs at time of application execution - e.g., on a command line:
+A \ac{PMIx} \emph{Process Set} is a user-provided or host environment assigned
+label associated with a given set of application processes. Processes can
+belong to multiple process \emph{sets} at a time. Definition of a \ac{PMIx}
+process set typically occurs at time of application execution - e.g., on a
+command line:
 
 \cspecificstart
 \begin{codepar}
@@ -19,22 +26,106 @@ A \ac{PMIx} \emph{Process Set} is a user-provided label associated with a given 
 \end{codepar}
 \cspecificend
 
-In this example, the processes in the first application will be labeled with a \refattr{PMIX_PSET_NAME} attribute of \emph{ocean} while those in the second application will be labeled with an \emph{ice} value. During the execution, application processes could lookup the process set attribute for any other process using \refapi{PMIx_Get}. Alternatively, other executing applications could utilize the \refapi{PMIx_Query_info_nb} \ac{API} to obtain the number of declared process sets in the system, a list of their names, and other information about them. In other words, the \emph{process set} identifier provides a label by which an application can derive information about a process and its application - it does \emph{not}, however, confer any operational function.
+In this example, the processes in the first application will be labeled with a \refattr{PMIX_PSET_NAMES} attribute of \emph{ocean} while those in the second application will be labeled with an \emph{ice} value. During the execution, application processes could lookup the process set attribute for any other process using \refapi{PMIx_Get}. Alternatively, other executing applications could utilize the \refapi{PMIx_Query_info_nb} \ac{API} to obtain the number of declared process sets in the system, a list of their names, and other information about them. In other words, the \emph{process set} identifier provides a label by which an application can derive information about a process and its application - it does \emph{not}, however, confer any operational function.
 
-Thus, process \emph{sets} differ from process \emph{groups} in several key ways:
+Host environments can create or delete process sets at any time, as well as
+add and delete members from existing process sets, through the
+\refapi{PMIx_server_define_process_set} and
+\refapi{PMIx_server_delete_process_set} \acp{API}. \ac{PMIx} servers shall
+notify all local clients of process set operations via the
+\refconst{PMIX_PROCESS_SET_DEFINE} or \refconst{PMIX_PROCESS_SET_DELETE}
+events.
+
+\advicermstart
+The host environment is responsible for ensuring:
+
+\begin{itemize}
+    \item consistent knowledge of process set membership across all involved
+    \ac{PMIx} servers; and
+    \item that process set names do not conflict with system-assigned namespaces within the scope of the set
+\end{itemize}
+
+\advicermend
+
+Process \emph{sets} differ from process \emph{groups} in several key ways:
 
 \begin{itemize}
     \item Process \emph{sets} have no implied relationship between their members - i.e., a process in a process set has no concept of a ``pset rank'' as it would in a process \emph{group}
-    \item Process \emph{set} identifiers are considered job-level information set at launch. No \ac{PMIx} \ac{API} is provided by which a user can change the process \emph{set} value of a process on-the-fly. In contrast, \ac{PMIx} process \emph{groups} can only be defined dynamically by the application.
+
+    \item Process \emph{set} identifiers are set by the host environment -
+    there are no \ac{PMIx} \acp{API} provided by which an application can
+    change a process \emph{set} membership. In contrast, \ac{PMIx} process
+    \emph{groups} can only be defined dynamically by the application.
+
     \item Process \emph{groups} can be used in calls to \ac{PMIx} operations. Members of process \emph{groups} that are involved in an operation are translated by their \ac{PMIx} server into their \emph{native} identifier prior to the operation being passed to the host environment. For example, an application can define a process group to consist of ranks 0 and 1 from the host-assigned namespace of \emph{210456}, identified by the group id of \emph{foo}. If the application subsequently calls the \refapi{PMIx_Fence} \ac{API} with a process identifier of \{foo, PMIX_RANK_WILDCARD\}, the \ac{PMIx} server will replace that identifier with an array consisting of \{210456, 0\} and \{210456, 1\} - the host-assigned identifiers of the participating processes - prior to passing the request up to the host environment
+
     \item Process \emph{groups} can request that the host environment assign a unique \code{size_t} \ac{PGCID} to the group at time of group construction. An \ac{MPI} library may, for example, use the \ac{PGCID} as the \ac{MPI} communicator identifier for the group.
 \end{itemize}
 
-The two concepts do, however, overlap in one specific area. Process \emph{groups} are included in the process \emph{set} information returned by calls to \refapi{PMIx_Query_info_nb}. Thus, a \emph{process group} can effectively be considered an extended version of a \emph{process set} that adds dynamic definition and operational context to the \emph{process set} concept.
+The two concepts do, however, overlap in one specific area in that they both
+involve collections of processes. Users desiring to create a process group
+based on a process set could, for example, obtain the membership array of the
+process set and use that as input to \refapi{PMIx_Group_construct}, perhaps
+including the process set name as the group identifier for clarity. Note that
+no linkage between the set and group of the same name is implied nor
+maintained - e.g., changes in process set membership would not automatically be
+reflected in the process group using the same identifier.
 
-\adviceimplstart
-\ac{PMIx} implementations are required to include all active \emph{group} identifiers in the returned list of process \emph{set} names provided in response to the appropriate \refapi{PMIx_Query_info_nb} call.
-\adviceimplend
+
+%%%%%%%%%%%
+\subsection{Process Set Constants}
+
+\versionMarker{4.0}
+The \ac{PMIx} server is required to notify all local clients of changes to
+process set membership, including the creation of new process sets as well as
+their complete deletion. Client processes wishing to receive such
+notifications must register for one or more of the following events:
+
+\begin{constantdesc}
+%
+\declareconstitemNEW{PMIX_PROCESS_SET_DEFINE}
+The host environment has defined a new process set, or has added members to
+an existing process set.
+%
+\declareconstitemNEW{PMIX_PROCESS_SET_DELETE}
+The host environment has removed members from an existing process set. If all
+members of the set have been removed, then the set definition has been
+deleted from the system.
+%
+\end{constantdesc}
+
+
+%%%%%%%%%%%
+\subsection{Process Set Attributes}
+
+\versionMarker{4.0}
+Several attributes are provided for querying the system regarding process sets.
+
+%
+\declareAttributeNEW{PMIX_QUERY_NUM_PSETS}{"pmix.qry.psetnum"}{size_t}{
+Return the number of process sets defined in the specified range (defaults
+to session).
+}
+
+%
+\declareAttributeNEW{PMIX_QUERY_PSET_NAMES}{"pmix.qry.psets"}{pmix_data_array_t*}{
+Return a \refstruct{pmix_data_array_t} containing an array of strings of the
+process set names defined in the specified range (defaults to session).
+}
+
+%
+\declareAttributeNEW{PMIX_QUERY_PSET_MEMBERSHIP}{"pmix.qry.pmems"}{pmix_proc_t*}{
+Return a \refstruct{pmix_data_array_t} of \refstruct{pmix_proc_t} containing
+the members of the specified process set.
+}
+
+In addition, a process can request (via \refapi{PMIx_Get}) the process sets to which a given process (including itself) belongs:
+
+%
+\declareAttributeNEW{PMIX_PSET_NAMES}{"pmix.pset.nm"}{pmix_data_array_t*}{
+Returns an array of \code{char*} string names of the process sets in which the given process is a member.
+}
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -100,6 +191,39 @@ Construct a group composed of the specified processes - used by a \ac{PMIx} serv
 Destruct the specified group - used by a \ac{PMIx} server library to direct host operation
 %
 \end{constantdesc}
+
+
+%%%%%%%%%%%
+\subsection{Process Group Attributes}
+
+\versionMarker{4.0}
+Several attributes are provided for querying the system regarding process
+groups.
+
+%
+\declareAttributeNEW{PMIX_QUERY_NUM_GROUPS}{"pmix.qry.pgrpnum"}{size_t}{
+Return the number of process groups defined in the specified range (defaults
+to session).
+}
+
+%
+\declareAttributeNEW{PMIX_QUERY_GROUP_NAMES}{"pmix.qry.pgrp"}{pmix_data_array_t*}{
+Return a \refstruct{pmix_data_array_t} containing an array of string names of
+the process groups defined in the specified range (defaults to session).
+}
+
+%
+\declareAttributeNEW{PMIX_QUERY_GROUP_MEMBERSHIP}{"pmix.qry.pgrpmems"}{pmix_data_array_t*}{
+Return a \refstruct{pmix_data_array_t} of \refstruct{pmix_proc_t} containing
+the members of the specified process group.
+}
+
+In addition, a process can request (via \refapi{PMIx_Get}) the process groups to which a given process (including itself) belongs:
+
+%
+\declareAttributeNEW{PMIX_GROUP_NAMES}{"pmix.pgrp.nm"}{pmix_data_array_t*}{
+Returns an array of \code{char*} string names of the process groups in which the given process is a member.
+}
 
 
 %%%%%%%%%%%

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -3586,11 +3586,6 @@ The requesting process is a PMIx client.
 }
 
 %
-\declareAttributeNEW{PMIX_PSET_NAME}{"pmix.pset.nm"}{char*}{
-User-assigned name for the process set containing the given process.
-}
-
-%
 \declareAttributeNEW{PMIX_REINCARNATION}{"pmix.reinc"}{uint32_t}{
 Number of times this process has been re-instantiated - i.e, a value of zero indicates that the process has never failed and been restarted.
 }
@@ -4772,16 +4767,6 @@ Query number of seconds (\code{uint32_t}) remaining in allocation for the specif
 %
 \declareAttributeNEW{PMIX_QUERY_ATTRIBUTE_SUPPORT}{"pmix.qry.attrs"}{bool}{
 Query list of supported attributes for specified \acp{API}. SUPPORTED QUALIFIERS: \refattr{PMIX_CLIENT_FUNCTIONS}, \refattr{PMIX_SERVER_FUNCTIONS}, \refattr{PMIX_TOOL_FUNCTIONS}, and/or \refattr{PMIX_HOST_FUNCTIONS}
-}
-
-%
-\declareAttributeNEW{PMIX_QUERY_NUM_PSETS}{"pmix.qry.psetnum"}{size_t}{
-Return the number of psets defined in the specified range (defaults to session).
-}
-
-%
-\declareAttributeNEW{PMIX_QUERY_PSET_NAMES}{"pmix.qry.psets"}{char*}{
-Return a comma-delimited list of the names of the psets defined in the specified range (defaults to session).
 }
 
 %


### PR DESCRIPTION
Per feedback, allow processes to belong to more than one process set at
a time. Clarify that process sets are defined by the host environment as
opposed to process groups that are defined by the application. Add APIs
for the host to inform the servers of changes to process sets, and event
statuses to allow the servers to communicate those changes to their
client procs.

Fixes https://github.com/pmix/pmix-standard/issues/254

Signed-off-by: Ralph Castain <rhc@pmix.org>