### PR TITLE
Update changelog, copyright, and minor wording

### DIFF
--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -2936,7 +2936,7 @@ Register to receive notifications for the specified status codes. The \refarg{in
 The \ac{PMIx} server library must track all client registrations for subsequent notification. This module function shall only be called when:
 
 \begin{itemize}
-    \item the client has requested notification of an environmental code (i.e., a \ac{PMIx} code in the range beyond \refconst{PMIX_EVENT_SYS_OTHER}) or a code that lies outside the defined \ac{PMIx} range of constants; and
+    \item the client has requested notification of an environmental code (i.e., a \ac{PMIx} codes in the range between \refconst{PMIX_EVENT_SYS_BASE} and \refconst{PMIX_EVENT_SYS_OTHER}, inclusive) or codes that lies outside the defined \ac{PMIx} range of constants; and
     \item the \ac{PMIx} server library has not previously requested notification of that code - i.e., the host environment is to be contacted only once a given unique code value
 \end{itemize}
 

--- a/Chap_Revisions.tex
+++ b/Chap_Revisions.tex
@@ -295,7 +295,7 @@ The v3.1 update includes clarifications and corrections from the v3.0 document:
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%% History: Version 3.2
-\section{Version 3.2: Oct. 2019}
+\section{Version 3.2: Sept. 2020}
 
 The v3.2 update includes clarifications and corrections from the v3.1 document:
 
@@ -303,6 +303,8 @@ The v3.2 update includes clarifications and corrections from the v3.1 document:
     \item Correct an error in the \refapi{PMIx_Allocation_request} function signature, and clarify the allocation ID attributes
     \item Rename the \refattr{PMIX_ALLOC_ID} attribute to \refattr{PMIX_ALLOC_REQ_ID} to clarify that this is a string the user provides as a means to identify their request to query status
     \item Add a new \refattr{PMIX_ALLOC_ID} attribute that contains the identifier (provided by the host environment) for the resulting allocation which can later be used to reference the allocated resources in, for example, a call to \refapi{PMIx_Spawn}
+    \item Update the \refapi{PMIx_generate_regex} and \refapi{PMIx_generate_ppn} descriptions to clarify that the output from these generator functions may not be a NULL-terminated string, but instead could be a byte array of arbitrary binary content.
+    \item Add a new \refconst{PMIX_REGEX} constant that represents a regular expression data type.
 \end{compactitemize}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/TitlePage.tex
+++ b/TitlePage.tex
@@ -37,11 +37,11 @@ Please note that messages sent to the mailing list from an unsubscribed e-mail a
 \vfill
 
 \begin{adjustwidth}{0pt}{1em}\setlength{\parskip}{0.25\baselineskip}%
-Copyright \textsuperscript{\textcopyright} 2018-2020 PMIx Administrative Steering Committee (ASC).\\
+Copyright \textsuperscript{\textcopyright} 2018-2020 PMIx \acf{ASC}.\\
 Permission to copy without fee all or part of this material is granted,
-provided the PMIx Standard Review Board copyright notice and
+provided the PMIx \ac{ASC} copyright notice and
 the title of this document appear, and notice is given that copying is by
-permission of PMIx Standard Review Board.
+permission of PMIx \ac{ASC}.
 \end{adjustwidth}
 
   \end{titlepage}


### PR DESCRIPTION
 * Update the v3.2 changelog to match that in PR #271 ([here](https://github.com/pmix/pmix-standard/pull/271/files#diff-3f1d28af62baa7ab4d46c0b4fb758059))
 * Fix the ASC copyright
 * Found some odd wording in `pmix_server_register_events_fn_t` - made it more consistent with wording for `pmix_server_deregister_events_fn_t`