### PR TITLE
Add a missing constant and enhance check-openpmix.py

### DIFF
--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -2104,6 +2104,9 @@ Structure containing the minimum and maximum relative distance from the caller t
 \declareconstitemNEW{PMIX_ENDPOINT}
 Structure containing an assigned endpoint for a given fabric device. (\refstruct{pmix_endpoint_t}).
 %
+\declareconstitemNEW{PMIX_TOPO}
+Structure containing the topology for a given node. (\refstruct{pmix_topology_t}).
+%
 \declareconstitemNEW{PMIX_DATA_TYPE_MAX}
 A starting point for implementer-specific data types.
 Values above this are guaranteed not to conflict with \ac{PMIx} values.

--- a/Chap_Revisions.tex
+++ b/Chap_Revisions.tex
@@ -210,12 +210,8 @@ The document added a chapter on security credentials, a new section for \ac{IO} 
 
 The following constants were removed in v3.0:
 
-\begin{constantdesc}
-
-\declareconstitemDEP{PMIX_MODEX}
-\declareconstitemDEP{PMIX_INFO_ARRAY}
-
-\end{constantdesc}
+\refconst{PMIX_MODEX}
+\refconst{PMIX_INFO_ARRAY}
 
 \subsection{Deprecated attributes}
 

--- a/bin/check-openpmix.py
+++ b/bin/check-openpmix.py
@@ -7,7 +7,9 @@ import argparse
 import subprocess
 import shutil
 
-def check_missing_pmix_standard(std_all_refs, openpmix_all_refs, verbose=False):
+def check_missing_pmix_standard(std_all_refs, openpmix_all_refs,
+                                std_deprecated, std_removed,
+                                openpmix_deprecated, verbose=False):
     """Check for OpenPMIx definitions missing from the PMIx Standard"""
 
     print "-"*50
@@ -38,11 +40,15 @@ def check_missing_pmix_standard(std_all_refs, openpmix_all_refs, verbose=False):
                     # if this reference is in a comment then ignore it
                     m = re.match(r"^\s*\*", parts[2])
                     if m is not None:
-                        print("Warning: Found reference in comment: " + line)
-                        continue
-
-                    print("ERROR: Suspected Missing \""+openpmix_ref+"\" but found on "+parts[0]+"("+parts[1]+"):"+parts[2])
-                    possible_error = True
+                        m = re.search(r'deprecated.h', parts[0])
+                        if m is not None:
+                            print("Warning: Found reference in comment: " + line)
+                            continue
+                    # if this reference is found in deprecated, ignore it
+                    m = re.search(r'deprecated.h', parts[0])
+                    if m is not None:
+                        print("ERROR: Suspected Missing \""+openpmix_ref+"\" but found on "+parts[0]+"("+parts[1]+"):"+parts[2])
+                        possible_error = True
 
                 if possible_error is True:
                     sys.exit(1)
@@ -52,11 +58,13 @@ def check_missing_pmix_standard(std_all_refs, openpmix_all_refs, verbose=False):
 
     return missing_refs
 
-def check_missing_openpmix(std_all_refs, openpmix_all_refs, verbose=False):
+def check_missing_openpmix(std_all_refs, openpmix_all_refs,
+                           std_deprecated, std_removed,
+                           openpmix_deprecated, verbose=False):
     """Check for PMIx Standard definitions missing from OpenPMIx"""
 
     print "-"*50
-    print "Checking: Defined in PMIx Standard, but not in the OpenPMIx"
+    print "Checking: Defined in PMIx Standard, but not in OpenPMIx"
     print "-"*50
 
     missing_refs = []
@@ -83,17 +91,40 @@ def check_missing_openpmix(std_all_refs, openpmix_all_refs, verbose=False):
                     # if this reference is in a comment then ignore it
                     m = re.match(r"^\s*\*", parts[2])
                     if m is not None:
-                        print("Warning: Found reference in comment: " + line)
+                        # if this is a deprecated or removed reference, don't worry about it
+                        if any(std_ref in s for s in openpmix_deprecated):
+                            continue
+                        elif any(std_ref in s for s in std_deprecated):
+                            continue
+                        elif any(std_ref in s for s in std_removed):
+                            continue
+                        else:
+                            print("Warning: Found reference in comment: " + line)
                         continue
 
-                    print("ERROR: Suspected Missing \""+std_ref+"\" but found on "+parts[0]+"("+parts[1]+"):"+parts[2])
-                    possible_error = True
+                    # if this is a deprecated or removed reference, don't worry about it
+                    if any(std_ref in s for s in openpmix_deprecated):
+                        continue
+                    elif any(std_ref in s for s in std_deprecated):
+                        continue
+                    elif any(std_ref in s for s in std_removed):
+                        continue
+                    else:
+                        print("ERROR1: Suspected Missing \""+std_ref+"\" but found on "+parts[0]+"("+parts[1]+"):"+parts[2])
+                        possible_error = True
 
                 if possible_error is True:
                     sys.exit(1)
 
-            # Ok it's missing so add it to the list
-            missing_refs.append(std_ref)
+            # Ok it's missing so add it to the list if it hasn't been deprecated or removed
+            if any(std_ref in s for s in openpmix_deprecated):
+                continue
+            elif any(std_ref in s for s in std_deprecated):
+                continue
+            elif any(std_ref in s for s in std_removed):
+                continue
+            else:
+                missing_refs.append(std_ref)
 
     return missing_refs
 
@@ -105,12 +136,15 @@ if __name__ == "__main__":
     std_structs = {}
     std_apis = {}
     std_all_refs = {}
+    std_deprecated = []
+    std_removed = []
 
     openpmix_defines = {}
     openpmix_structs = {}
     openpmix_apis = {}
     openpmix_cbs = {}
     openpmix_all_refs = {}
+    openpmix_deprecated = []
 
     #
     # Command line parsing
@@ -170,11 +204,14 @@ if __name__ == "__main__":
                 print("Error: Failed to extract an \""+ref_str+"\" on the following line")
                 print(" line: "+line)
                 sys.exit(1)
-                
+
             # Count will return to 0 when verified
-            #print("Found \""+ref_str+"\" : "+m.group(1)+" on line " + line)
             std_all_refs[m.group(1)] = -1
-            if ref_str == "attr":
+            if "Deprecated" in line:
+                std_deprecated.append(m.group(1))
+            elif re.search('removed', line, re.IGNORECASE):
+                std_removed.append(m.group(1))
+            elif ref_str == "attr":
                 std_attributes[m.group(1)] = -1
             elif ref_str == "const":
                 std_consts[m.group(1)] = -1
@@ -205,6 +242,12 @@ if __name__ == "__main__":
         for val in std_apis:
             print("Std API      : " + val)
         print "-"*50
+        for val in std_deprecated:
+            print("Std Deprecated      : " + val)
+        print "-"*50
+        for val in std_removed:
+            print("Std Removed      : " + val)
+        print "-"*50
 
     print("Number of Standard attributes  : " + str(len(std_attributes)))
     print("Number of Standard consts      : " + str(len(std_consts)))
@@ -212,6 +255,8 @@ if __name__ == "__main__":
     print("Number of Standard macros      : " + str(len(std_macros)))
     print("Number of Standard apis        : " + str(len(std_apis)))
     print("Total Number of Standard items : " + str(len(std_all_refs)))
+    print("Number of Deprecated items     : " + str(len(std_deprecated)))
+    print("Number of Removed items        : " + str(len(std_removed)))
     print("")
 
 
@@ -233,6 +278,10 @@ if __name__ == "__main__":
             print "Extracting OpenPMIx Definitions from: " + openpmix_file
             print "-"*50
 
+        if "deprecated.h" in openpmix_file:
+            parse_deprecated = True
+        else:
+            parse_deprecated = False
         parse_active = False
         parse_enum = False
         parse_struct = False
@@ -255,17 +304,23 @@ if __name__ == "__main__":
                 if parse_enum is True:
                     m = re.match(r'\s*}\s*(pmi\w*)', line)
                     if m is not None:
-                        openpmix_structs[m.group(1)] = -1
-                        openpmix_all_refs[m.group(1)] = -1
-                        defs_found = defs_found + 1
+                        if parse_deprecated:
+                            openpmix_deprecated.append(m.group(1))
+                        else:
+                            openpmix_structs[m.group(1)] = -1
+                            openpmix_all_refs[m.group(1)] = -1
+                            defs_found = defs_found + 1
                         parse_enum = False
                         continue
                     m = re.match(r'\s+(\w+)', line)
                     if m is not None:
                         #print("Define Enum: "+m.group(1))
-                        openpmix_defines[m.group(1)] = -1
-                        openpmix_all_refs[m.group(1)] = -1
-                        defs_found = defs_found + 1
+                        if parse_deprecated:
+                            openpmix_deprecated.append(m.group(1))
+                        else:
+                            openpmix_defines[m.group(1)] = -1
+                            openpmix_all_refs[m.group(1)] = -1
+                            defs_found = defs_found + 1
                         continue
 
                 # typedef struct pmix_data_buffer {
@@ -282,9 +337,12 @@ if __name__ == "__main__":
                     m = re.match(r'\s*}\s*(pmi\w+)', line)
                     if m is not None:
                         #print("Define Struct: "+m.group(1))
-                        openpmix_structs[m.group(1)] = -1
-                        openpmix_all_refs[m.group(1)] = -1
-                        defs_found = defs_found + 1
+                        if parse_deprecated:
+                            openpmix_deprecated.append(m.group(1))
+                        else:
+                            openpmix_structs[m.group(1)] = -1
+                            openpmix_all_refs[m.group(1)] = -1
+                            defs_found = defs_found + 1
                         parse_struct = False
                         continue
                     else:
@@ -294,54 +352,72 @@ if __name__ == "__main__":
                 m = re.match(r'\s*typedef\s*\w*\s*(pmi\w*)[;|\[]', line);
                 if m is not None:
                     #print("Define Struct1: "+m.group(1))
-                    openpmix_structs[m.group(1)] = -1
-                    openpmix_all_refs[m.group(1)] = -1
-                    defs_found = defs_found + 1
+                    if parse_deprecated:
+                        openpmix_deprecated.append(m.group(1))
+                    else:
+                        openpmix_structs[m.group(1)] = -1
+                        openpmix_all_refs[m.group(1)] = -1
+                        defs_found = defs_found + 1
                     continue
-                
+
                 # #define PMIX_EVENT_BASE                     "pmix.evbase"
                 m = re.match(r'#define\s+(\w+)\(', line);
                 if m is not None:
-                    openpmix_defines[m.group(1)] = -1
-                    openpmix_all_refs[m.group(1)] = -1
-                    #print("Define FN: "+m.group(1))
-                    defs_found = defs_found + 1
+                    if parse_deprecated:
+                        openpmix_deprecated.append(m.group(1))
+                    else:
+                        openpmix_defines[m.group(1)] = -1
+                        openpmix_all_refs[m.group(1)] = -1
+                        #print("Define FN: "+m.group(1))
+                        defs_found = defs_found + 1
                     continue
 
                 # #define PMIx_Heartbeat()
                 m = re.match(r'#define\s+(\w+)', line);
                 if m is not None:
-                    openpmix_defines[m.group(1)] = -1
-                    openpmix_all_refs[m.group(1)] = -1
-                    #print("Define: "+m.group(1))
-                    defs_found = defs_found + 1
+                    if parse_deprecated:
+                        openpmix_deprecated.append(m.group(1))
+                    else:
+                        openpmix_defines[m.group(1)] = -1
+                        openpmix_all_refs[m.group(1)] = -1
+                        #print("Define: "+m.group(1))
+                        defs_found = defs_found + 1
                     continue
 
                 # PMIX_EXPORT const char* PMIx_Error_string
                 m = re.match(r'PMIX_EXPORT\s+\w+\s+\w+\*\s+(PMI\w+)', line);
                 if m is not None:
-                    openpmix_apis[m.group(1)] = -1
-                    openpmix_all_refs[m.group(1)] = -1
-                    #print("API1: "+m.group(1))
-                    defs_found = defs_found + 1
+                    if parse_deprecated:
+                        openpmix_deprecated.append(m.group(1))
+                    else:
+                        openpmix_apis[m.group(1)] = -1
+                        openpmix_all_refs[m.group(1)] = -1
+                        #print("API1: "+m.group(1))
+                        defs_found = defs_found + 1
                     continue
 
                 # PMIX_EXPORT pmix_status_t PMIx_Init(
                 m = re.match(r'PMIX_EXPORT\s+\w+\s+(PMI\w+)', line);
                 if m is not None:
-                    openpmix_apis[m.group(1)] = -1
-                    openpmix_all_refs[m.group(1)] = -1
-                    #print("API2: "+m.group(1))
-                    defs_found = defs_found + 1
+                    if parse_deprecated:
+                        openpmix_deprecated.append(m.group(1))
+                    else:
+                        openpmix_apis[m.group(1)] = -1
+                        openpmix_all_refs[m.group(1)] = -1
+                        #print("API2: "+m.group(1))
+                        defs_found = defs_found + 1
                     continue
 
                 # typedef void (*pmix_iof_cbfunc_t)(
                 m = re.match(r'\s*typedef\s+\w+\s+\(\*(\w+)', line);
                 if m is not None:
-                    openpmix_cbs[m.group(1)] = -1
-                    openpmix_all_refs[m.group(1)] = -1
-                    #print("CB: "+m.group(1))
-                    defs_found = defs_found + 1
+                    if parse_deprecated:
+                        openpmix_deprecated.append(m.group(1))
+                    else:
+                        openpmix_cbs[m.group(1)] = -1
+                        openpmix_all_refs[m.group(1)] = -1
+                        #print("CB: "+m.group(1))
+                        defs_found = defs_found + 1
                     continue
 
         if args.verbose is True:
@@ -352,6 +428,7 @@ if __name__ == "__main__":
     print("Number of OpenPMIx APIs        : " + str(len(openpmix_apis)))
     print("Number of OpenPMIx callbacks   : " + str(len(openpmix_cbs)))
     print("Total Number of OpenPMIx items : " + str(len(openpmix_all_refs)))
+    print("Number of Deprecated items     : " + str(len(openpmix_deprecated)))
     print("")
 
     # --------------------------------------------------
@@ -360,7 +437,9 @@ if __name__ == "__main__":
     # --------------------------------------------------
     total_missing_refs = 0
 
-    missing_refs = check_missing_pmix_standard(std_all_refs, openpmix_all_refs, args.verbose)
+    missing_refs = check_missing_pmix_standard(std_all_refs, openpmix_all_refs,
+                                               std_deprecated, std_removed,
+                                               openpmix_deprecated, args.verbose)
     total_missing_refs = total_missing_refs + len(missing_refs)
     if len(missing_refs) > 0:
         print "-"*50
@@ -373,7 +452,9 @@ if __name__ == "__main__":
     # --------------------------------------------------
     # Check to make sure that all of the items defined in the PMIx Standard are in OpenPMIx
     # --------------------------------------------------
-    missing_refs = check_missing_openpmix(std_all_refs, openpmix_all_refs, args.verbose)
+    missing_refs = check_missing_openpmix(std_all_refs, openpmix_all_refs,
+                                          std_deprecated, std_removed,
+                                          openpmix_deprecated, args.verbose)
     total_missing_refs = total_missing_refs + len(missing_refs)
     if len(missing_refs) > 0:
         print "-"*50


### PR DESCRIPTION
Add missing PMIX_TOPO data type constant.
Fix a double-define of PMIX_MODEX and PMIX_INFO_ARRAY constants
Extend the check-openpmix.py script to identify and handle deprecated
and removed values so it doesn't report them as an error.

Signed-off-by: Ralph Castain <rhc@pmix.org>