### PR TITLE
Updates to Python bindings and missed API

### DIFF
--- a/Acknowledgements.tex
+++ b/Acknowledgements.tex
@@ -15,7 +15,7 @@ The following list includes some of the active participants in the PMIx v4 stand
 
 \begin{itemize}
 \item Ralph H. Castain and Danielle Sikich
-\item Joshua Hursey abd David Solt
+\item Joshua Hursey and David Solt
 \item Dirk Schubert
 \item John DelSignore
 \item Aurelien Bouteiller
@@ -56,10 +56,11 @@ The following list includes some of the active participants in the PMIx v3 stand
 
 \begin{itemize}
 \item Ralph H. Castain, Andrew Friedley, Brandon Yates
-\item Joshua Hursey
+\item Joshua Hursey and David Solt
 \item Aurelien Bouteiller and George Bosilca
 \item Dirk Schubert
 \item Kevin Harms
+\item Artem Polyakov
 \end{itemize}
 
 The following institutions supported this effort through time and travel support for the people listed above.
@@ -72,6 +73,7 @@ The following institutions supported this effort through time and travel support
 \item National Science Foundation
 \item Argonne National Laboratory
 \item Allinea (ARM)
+\item NVIDIA
 \end{itemize}
 
 %%%%%%%%%% Version 2.0

--- a/Acknowledgements.tex
+++ b/Acknowledgements.tex
@@ -14,13 +14,39 @@ The sections below list some of the active participants and organizations in the
 The following list includes some of the active participants in the PMIx v4 standardization process.
 
 \begin{itemize}
-\item \ldots
+\item Ralph H. Castain and Danielle Sikich
+\item Joshua Hursey abd David Solt
+\item Dirk Schubert
+\item John DelSignore
+\item Aurelien Bouteiller
+\item Michael A Raymond
+\item Howard Pritchard and Nathan Hjelm
+\item Brice Goglin
+\item Kathryn Mohror and Stephen Herbein
+\item Thomas Naughton and Swaroop Pophale
+\item William E. Allcock and Paul Rich
+\item Michael Karo
+\item Artem Polyakov
 \end{itemize}
 
 The following institutions supported this effort through time and travel support for the people listed above.
 
 \begin{itemize}
-\item \ldots
+\item Intel Corporation
+\item IBM, Inc.
+\item Allinea (ARM)
+\item Perforce
+\item University of Tennessee, Knoxville
+\item The Exascale Computing Project, an initiative of the US Department of Energy
+\item National Science Foundation
+\item HPE Co.
+\item Los Alamos National Laboratory
+\item INRIA
+\item Lawrence Livermore National Laboratory
+\item Oak Ridge National Laboratory
+\item Argonne National Laboratory
+\item Altair
+\item NVIDIA
 \end{itemize}
 
 %%%%%%%%%% Version 3.0

--- a/App_Python.tex
+++ b/App_Python.tex
@@ -2869,6 +2869,28 @@ Returns:
 See \refapi{PMIx_Device_type_string} for further details.
 
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\subsection{Client.progress}
+\declareapibinding{PMIxClient.progress}{PMIx_Progress}{Python}
+
+%%%%
+\summary
+
+Progress the \ac{PMIx} library.
+
+%%%%
+\format
+
+\versionMarker{4.0}
+\pyspecificstart
+\begin{codepar}
+myclient.progress()
+\end{codepar}
+\pyspecificend
+
+
+See \refapi{PMIx_Progress} for further details.
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -3421,37 +3443,6 @@ See \refapi{PMIx_server_deliver_inventory} for details.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\subsection{Server.generate_locality_string}
-\declareapibinding{PMIxServer.generate_locality_string}{PMIx_server_generate_locality_string}{Python}
-
-\summary
-Generate a \ac{PMIx} locality string from a given cpuset.
-
-\format
-
-\versionMarker{4.0}
-\pyspecificstart
-\begin{codepar}
-rc,locality = myserver.generate_locality_string(cpuset:\refpy{cpuset})
-\end{codepar}
-\pyspecificend
-
-
-\begin{arglist}
-\argin{cpuset} - Python \refpy{cpuset} identifying the \acp{PU} (\refpy{cpuset})
-\end{arglist}
-
-Returns:
-
-\begin{itemize}
-    \item \refarg{rc} - \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant (integer)
-    \item \refarg{locality} - string representation of the locality corresponding to the provided \refarg{cpuset} (str)
-\end{itemize}
-
-See \refapi{PMIx_server_generate_locality_string} for details.
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Server.define_process_set}
 \declareapibinding{PMIxServer.define_process_set}{PMIx_server_define_process_set}{Python}
 
@@ -3487,20 +3478,19 @@ See \refapi{PMIx_server_define_process_set} for details.
 \declareapibinding{PMIxServer.delete_process_set}{PMIx_server_delete_process_set}{Python}
 
 \summary
-Delete members from a \ac{PMIx} process set.
+Delete a \ac{PMIx} process set.
 
 \format
 
 \versionMarker{4.0}
 \pyspecificstart
 \begin{codepar}
-rc = myserver.delete_process_set(members:list, name:str)
+rc = myserver.delete_process_set(name:str)
 \end{codepar}
 \pyspecificend
 
 
 \begin{arglist}
-\argin{members} - List of Python \refpy{proc} dictionaries identifying the processes to be removed from the process set (list)
 \argin{name} - Name of the process set (str)
 \end{arglist}
 
@@ -3511,68 +3501,6 @@ Returns:
 \end{itemize}
 
 See \refapi{PMIx_server_delete_process_set} for details.
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\subsection{Server.generate_locality_string}
-\declareapibinding{PMIxServer.generate_locality_string}{PMIx_server_generate_locality_string}{Python}
-
-\summary
-Generate a \ac{PMIx} locality string from a given cpuset.
-
-\format
-
-\versionMarker{4.0}
-\pyspecificstart
-\begin{codepar}
-rc,locality = myserver.generate_locality_string(cpuset:dict)
-\end{codepar}
-\pyspecificend
-
-
-\begin{arglist}
-\argin{cpuset} - Python \refpy{cpuset} dictionary containing the bitmap of assigned \acp{PU} (dict)
-\end{arglist}
-
-Returns:
-
-\begin{itemize}
-    \item \refarg{rc} - \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant (integer)
-    \item \refarg{locality} - String representation of the \ac{PMIx} locality corresponding to the input bitmap (str)
-\end{itemize}
-
-See \refapi{PMIx_server_generate_locality_string} for details.
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\subsection{Server.generate_cpuset_string}
-\declareapibinding{PMIxServer.generate_cpuset_string}{PMIx_server_generate_cpuset_string}{Python}
-
-\summary
-Generate a \ac{PMIx} string representation of the provided cpuset.
-
-\format
-
-\versionMarker{4.0}
-\pyspecificstart
-\begin{codepar}
-rc,cpusetstr = myserver.generate_cpuset_string(cpuset:dict)
-\end{codepar}
-\pyspecificend
-
-
-\begin{arglist}
-\argin{cpuset} - Python \refpy{cpuset} dictionary containing the bitmap of assigned \acp{PU} (dict)
-\end{arglist}
-
-Returns:
-
-\begin{itemize}
-    \item \refarg{rc} - \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant (integer)
-    \item \refarg{cpusetstr} - String representation of the \ac{PMIx} input bitmap (str)
-\end{itemize}
-
-See \refapi{PMIx_server_generate_cpuset_string} for details.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -3738,8 +3666,7 @@ See \refapi{PMIx_tool_disconnect} for details.
 \declareapibinding{PMIxTool.attach_to_server}{PMIx_tool_attach_to_server}{Python}
 
 \summary
-Switch connection from the current \ac{PMIx} server to another one, or initialize a connection to a specified server.
-
+Establish a connection to a PMIx server.
 
 \format
 

--- a/App_Python.tex
+++ b/App_Python.tex
@@ -74,9 +74,9 @@ Table~\ref{app:python:ctopy} lists the correspondence between data types in the 
         \refstruct{pmix_proc_state_t} & PMIX_PROC_STATE & integer & value shall be limited to the \code{uint8_t} range \\ \hline
         \refstruct{pmix_proc_info_t} & PMIX_PROC_INFO & \{'proc': \{'nspace': nspace, 'rank': rank\}, 'hostname': hostname, 'executable': executable, 'pid': pid, 'exitcode': exitcode, 'state': state\} & \refarg{proc} is a Python \refpy{proc} dictionary; \refarg{hostname} and \refarg{executable} are Python strings; and \refarg{pid}, \refarg{exitcode}, and \refarg{state} are Python integers \\ \hline
         \refstruct{pmix_data_array_t} & PMIX_DATA_ARRAY & \pylabel{array}\{'type': type, 'array': array\} & \refarg{type} is the \ac{PMIx} type of object in the array and \refarg{array} is a Python \emph{list} containing the individual array elements. Note that \refarg{array} can consist of \emph{any} \ac{PMIx} types, including (for example) a Python \refpy{info} object that itself contains an \refpy{array} value \\ \hline
-        \refstruct{pmix_info_directives_t}  & PMIX_INFO_DIRECTIVES & \pylabel{info directives}bitarray & 32-bit array \\ \hline
+        \refstruct{pmix_info_directives_t}  & PMIX_INFO_DIRECTIVES & \pylabel{info directives}list & list of integer values (defined in Section \ref{api:struct:infodirs}) \\ \hline
         \refstruct{pmix_alloc_directive_t} & PMIX_ALLOC_DIRECTIVE & \pylabel{allocdir}integer & value shall be limited to the \code{uint8_t} range \\ \hline
-        \refstruct{pmix_iof_channel_t} & PMIX_IOF_CHANNEL & \pylabel{channel}bitarray & 16-bit array \\ \hline
+        \refstruct{pmix_iof_channel_t} & PMIX_IOF_CHANNEL & \pylabel{channel}list & list of integer values (defined in Section \ref{api:tool:iofchannels}) \\ \hline
         \refstruct{pmix_envar_t} & PMIX_ENVAR & \{'envar': envar, 'value': value, 'separator': separator\} & \refarg{envar} and \refarg{value} are Python strings, and \refarg{separator} a single-character Python string \\ \hline
         \refstruct{pmix_value_t} & PMIX_VALUE & \pylabel{value}\{'value': value, 'val_type': type\} & \refarg{type} is the \ac{PMIx} datatype of \refarg{value}, and \refarg{value} is the associated value expressed in the appropriate Python form for the specified datatype  \\ \hline
         \refstruct{pmix_info_t} & PMIX_INFO & \pylabel{info}\{'key': key, 'flags': flags, value': value, 'val_type': type\} & \refarg{key} is a Python string \refpy{key}, \refarg{flags} is an \refpy{info directives} value, \refarg{type} is the \ac{PMIx} datatype of \refarg{value}, and \refarg{value} is the associated value expressed in the appropriate Python form for the specified datatype \\ \hline
@@ -86,15 +86,15 @@ Table~\ref{app:python:ctopy} lists the correspondence between data types in the 
         \refstruct{pmix_regattr_t} & PMIX_REGATTR & \pylabel{regattr}\{'name': name, 'key': key, 'type': type, 'info': [info], 'description': [desc]\} & \refarg{name} and \refarg{string} are Python strings; \refarg{type} is the \ac{PMIx} datatype for the attribute's value; \refarg{info} is a Python \emph{list} of \refpy{info} values; and \refarg{description} is a list of Python strings describing the attribute  \\ \hline
         \refstruct{pmix_job_state_t} & PMIX_JOB_STATE & integer & value shall be limited to the \code{uint8_t} range \\ \hline
         \refstruct{pmix_link_state_t} & PMIX_LINK_STATE & integer & value shall be limited to the \code{uint8_t} range \\ \hline
-        \refstruct{pmix_cpuset_t} & PMIX_PROC_CPUSET & \pylabel{cpuset}\{'source': source, 'cpus': bitmap\} & \refarg{source} is a string name of the library that created the cpuset; and \refarg{cpus} is a bitarray containing the cpuset \\ \hline
-        \refstruct{pmix_locality_t} & PMIX_LOCTYPE & \pylabel{locality}bitarray & 16-bit array containing the relative locality of the specified local process \\ \hline
+        \refstruct{pmix_cpuset_t} & PMIX_PROC_CPUSET & \pylabel{cpuset}\{'source': source, 'cpus': bitmap\} & \refarg{source} is a string name of the library that created the cpuset; and \refarg{cpus} is a list of string ranges identifying the \acp{PU} to which the process is bound (e.g., [1, 3-5, 7]) \\ \hline
+        \refstruct{pmix_locality_t} & PMIX_LOCTYPE & \pylabel{locality}list & list of integer values (defined in Section \ref{api:proc:locality}) describing the relative locality of the specified local process \\ \hline
         \refstruct{pmix_fabric_t} & N/A & \pylabel{fabric}\{'name': name, 'index': idx, 'info': [info]\} & \refarg{name} is the string name assigned to the fabric; \refarg{index} is the integer ID assigned to the fabric; \refarg{info} is a list of \refpy{info} describing the fabric \\ \hline
         \refstruct{pmix_endpoint_t} & PMIX_ENDPOINT & \pylabel{endpoint}\{'uuid': uuid, 'osname': osname, endpt': endpt\} & \refarg{uuid} is the string system-unique identifier assigned to the device; \refarg{osname} is the operating system name assigned to the device; \refarg{endpt} is a \refpy{byteobject} containing the endpoint information \\ \hline
         \refstruct{pmix_device_distance_t} & PMIX_DEVICE_DIST & \pylabel{devdist}\{'uuid': uuid, 'osname': osname, mindist': mindist, 'maxdist': maxdist\} & \refarg{uuid} is the string system-unique identifier assigned to the device; \refarg{osname} is the operating system name assigned to the device; and \refarg{mindist} and \refarg{maxdist} are Python integers \\ \hline
         \refstruct{pmix_coord_t} & PMIX_COORD & \pylabel{coord}\{'view': view, 'coord': [coords]\} & \refarg{view} is the \refstruct{pmix_coord_view_t} of the coordinate; and \refarg{coord} is a list of integer coordinates, one for each dimension of the fabric \\ \hline
         \refstruct{pmix_geometry_t} & PMIX_GEOMETRY & \pylabel{geometry}\{'fabric': idx, 'uuid': uuid, 'osname': osname, coordinates': [coords]\} & \refarg{fabric} is the Python integer index of the fabric; \refarg{uuid} is the string system-unique identifier assigned to the device; \refarg{osname} is the operating system name assigned to the device; and \refarg{coordinates} is a list of \refpy{coord} containing the coordinates for the device across all views \\ \hline
-        \refstruct{pmix_device_type_t} & PMIX_DEVTYPE & \pylabel{devtype}bitarray & 16-bit array \\ \hline
-        \refstruct{pmix_bind_envelope_t} & N/A & \pylabel{bindenv}integer & \\ \hline
+        \refstruct{pmix_device_type_t} & PMIX_DEVTYPE & \pylabel{devtype}list & list of integer values (defined in Section \ref{api:proc:devtype}) \\ \hline
+        \refstruct{pmix_bind_envelope_t} & N/A & \pylabel{bindenv}integer & one of the values defined in Section \ref{api:proc:bindenv} \\ \hline
     \end{longtable}
 \end{small}
 \end{landscape}
@@ -2335,7 +2335,7 @@ Returns:
     \item \refarg{rc} - \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant (integer)
 \end{itemize}
 
-See \refapi{PMIx_Load_topology} for details - note that the topology loaded into the \ac{PMIx} library may be utilized by \ac{PMIx} and other libraries, but is not accessible by Python.
+See \refapi{PMIx_Load_topology} for details - note that the topology loaded into the \ac{PMIx} library may be utilized by \ac{PMIx} and other libraries, but is not directly accessible by Python.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -2364,41 +2364,10 @@ Returns:
 
 \begin{itemize}
     \item \refarg{rc} - \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant (integer)
-    \item \refarg{locality} - \refpy{locality} bitarray containing the relative locality of the two processes (bitarray)
+    \item \refarg{locality} - \refpy{locality} list containing the relative locality of the two processes (list)
 \end{itemize}
 
 See \refapi{PMIx_Get_relative_locality} for details.
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\subsection{Client.parse_cpuset_string}
-\declareapibinding{PMIxClient.parse_cpuset_string}{PMIx_Parse_cpuset_string}{Python}
-
-\summary
-Parse the \ac{PU} binding bitmap from its string representation.
-
-\format
-
-\versionMarker{4.0}
-\pyspecificstart
-\begin{codepar}
-rc,cpuset = myclient.parse_cpuset_string(cpusetstr:str)
-\end{codepar}
-\pyspecificend
-
-\begin{arglist}
-\argin{cpusetstr}{String of a cpuset (str)}
-\end{arglist}
-
-
-Returns:
-
-\begin{itemize}
-    \item \refarg{rc} - \refconst{PMIX_SUCCESS} or a negative value corresponding to a PMIx error constant (integer)
-    \item \refarg{cpuset} - \refpy{cpuset} containing the source and bitmap of the cpuset (dict)
-\end{itemize}
-
-See \refapi{PMIx_Parse_cpuset_string} for details.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -2450,7 +2419,7 @@ rc,distances = myclient.compute_distances(cpuset:dict, info:list)
 
 \begin{arglist}
 \argin{cpuset}{\refpy{cpuset} describing the location of the process (dict)}
-\argin{info}{List of \refpy{info} dictionaries describing the devices whose distance is to be computed (str)}
+\argin{info}{List of \refpy{info} dictionaries describing the devices whose distance is to be computed (list)}
 \end{arglist}
 
 
@@ -2461,7 +2430,7 @@ Returns:
     \item \refarg{distances} - List of \refpy{devdist} structures containing the distances from the caller to the specified devices (list)
 \end{itemize}
 
-See \refapi{PMIx_Compute_distances} for details.
+See \refapi{PMIx_Compute_distances} for details. Note that distances can only be computed against the local topology.
 
 
 

--- a/Chap_API_Event.tex
+++ b/Chap_API_Event.tex
@@ -311,6 +311,15 @@ The time in seconds before the \ac{RM} will execute the indicated operation.
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\subsubsection{Hybrid programming event attributes}
+\label{api:struct:attributes:hybrid}
+
+The following attributes may be used by programming models to coordinate their use of common resources within a process in conjunction with the \refconst{PMIX_OPENMP_PARALLEL_ENTERED} event:
+%
+\pasteAttributeItem{PMIX_MODEL_PHASE_NAME}
+\pasteAttributeItem{PMIX_MODEL_PHASE_TYPE}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Notification Function}
 \declareapi{pmix_notification_fn_t}
 

--- a/Chap_API_Fabric.tex
+++ b/Chap_API_Fabric.tex
@@ -614,10 +614,6 @@ The index of the fabric as returned in \refstruct{pmix_fabric_t}.
 Total number of fabric devices in the overall system - corresponds to the number of rows or columns in the cost matrix.
 }
 %
-\declareAttributeNEW{PMIX_FABRIC_VIEW}{"pmix.fab.view"}{pmix_coord_view_t}{
-Used purely as a qualifier to requests, specifies the view type (e.g., local vs. physical) for the requested information.
-}
-%
 \declareAttributeNEW{PMIX_FABRIC_DIMS}{"pmix.fab.dims"}{uint32_t}{
 Number of dimensions in the specified fabric plane/view. If no plane is specified in a request, then the dimensions of all planes in the overall system will be returned as a \refstruct{pmix_data_array_t} containing an array of \code{uint32_t} values. Default is to provide dimensions in \emph{logical} view.
 }

--- a/Chap_API_Init.tex
+++ b/Chap_API_Init.tex
@@ -125,7 +125,7 @@ The following attributes are optional for implementers of \ac{PMIx} libraries:
 \pasteAttributeItemEnd{}
 \pasteAttributeItemBegin{PMIX_TCP_DISABLE_IPV6} If the library supports IPV6 connections, this attribute may be supported for disabling it.
 \pasteAttributeItemEnd{}
-\pasteAttributeItem{PMIX_EVENT_BASE}
+\pasteAttributeItem{PMIX_EXTERNAL_PROGRESS}
 \optattrend
 
 %%%%
@@ -315,5 +315,32 @@ Execute a blocking fence operation before executing the specified operation.
 This attribute directs \refapi{PMIx_Finalize} to execute a barrier as part of the finalize operation.
 }
 
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\section{\code{PMIx_Progress}}
+\declareapi{PMIx_Progress}
+
+%%%%
+\summary
+
+Progress the \ac{PMIx} library.
+
+%%%%
+\format
+
+\versionMarker{4.0}
+\cspecificstart
+\begin{codepar}
+void
+PMIx_Progress(void)
+\end{codepar}
+\cspecificend
+
+
+%%%%
+\descr
+
+Progress the \ac{PMIx} library. Note that special care must be taken to avoid deadlocking in \ac{PMIx} callback functions and acp{API}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/Chap_API_Init.tex
+++ b/Chap_API_Init.tex
@@ -126,6 +126,19 @@ The following attributes are optional for implementers of \ac{PMIx} libraries:
 \pasteAttributeItemBegin{PMIX_TCP_DISABLE_IPV6} If the library supports IPV6 connections, this attribute may be supported for disabling it.
 \pasteAttributeItemEnd{}
 \pasteAttributeItem{PMIX_EXTERNAL_PROGRESS}
+
+\vspace{\baselineskip}
+If provided, the following attributes are used by the event notification system for inter-library coordination:
+
+\pasteAttributeItem{PMIX_PROGRAMMING_MODEL}
+\pasteAttributeItem{PMIX_MODEL_LIBRARY_NAME}
+\pasteAttributeItem{PMIX_MODEL_LIBRARY_VERSION}
+\pasteAttributeItem{PMIX_THREADING_MODEL}
+\pasteAttributeItem{PMIX_MODEL_NUM_THREADS}
+\pasteAttributeItem{PMIX_MODEL_NUM_CPUS}
+\pasteAttributeItem{PMIX_MODEL_CPU_TYPE}
+\pasteAttributeItem{PMIX_MODEL_AFFINITY_POLICY}
+
 \optattrend
 
 %%%%

--- a/Chap_API_Job_Mgmt.tex
+++ b/Chap_API_Job_Mgmt.tex
@@ -693,6 +693,7 @@ The following attributes may be implemented by a \ac{PMIx} library or by the hos
 \pasteAttributeItem{PMIX_MONITOR_FILE_MODIFY}
 \pasteAttributeItem{PMIX_MONITOR_FILE_CHECK_TIME}
 \pasteAttributeItem{PMIX_MONITOR_FILE_DROPS}
+\pasteAttributeItem{PMIX_SEND_HEARTBEAT}
 
 \optattrend
 
@@ -771,6 +772,7 @@ The following attributes may be implemented by a \ac{PMIx} library or by the hos
 \pasteAttributeItem{PMIX_MONITOR_FILE_MODIFY}
 \pasteAttributeItem{PMIX_MONITOR_FILE_CHECK_TIME}
 \pasteAttributeItem{PMIX_MONITOR_FILE_DROPS}
+\pasteAttributeItem{PMIX_SEND_HEARTBEAT}
 
 \optattrend
 
@@ -952,6 +954,9 @@ The following attributes are optional for host environments or \ac{PMIx} librari
 \pasteAttributeItem{PMIX_LOG_XML_OUTPUT}
 \pasteAttributeItem{PMIX_LOG_EMAIL}
 \pasteAttributeItem{PMIX_LOG_EMAIL_ADDR}
+\pasteAttributeItem{PMIX_LOG_EMAIL_SENDER_ADDR}
+\pasteAttributeItem{PMIX_LOG_EMAIL_SERVER}
+\pasteAttributeItem{PMIX_LOG_EMAIL_SRVR_PORT}
 \pasteAttributeItem{PMIX_LOG_EMAIL_SUBJECT}
 \pasteAttributeItem{PMIX_LOG_EMAIL_MSG}
 \pasteAttributeItem{PMIX_LOG_JOB_RECORD}
@@ -1038,6 +1043,9 @@ The following attributes are optional for host environments or \ac{PMIx} librari
 \pasteAttributeItem{PMIX_LOG_XML_OUTPUT}
 \pasteAttributeItem{PMIX_LOG_EMAIL}
 \pasteAttributeItem{PMIX_LOG_EMAIL_ADDR}
+\pasteAttributeItem{PMIX_LOG_EMAIL_SENDER_ADDR}
+\pasteAttributeItem{PMIX_LOG_EMAIL_SERVER}
+\pasteAttributeItem{PMIX_LOG_EMAIL_SRVR_PORT}
 \pasteAttributeItem{PMIX_LOG_EMAIL_SUBJECT}
 \pasteAttributeItem{PMIX_LOG_EMAIL_MSG}
 \pasteAttributeItem{PMIX_LOG_JOB_RECORD}

--- a/Chap_API_Proc_Mgmt.tex
+++ b/Chap_API_Proc_Mgmt.tex
@@ -160,6 +160,9 @@ The following attributes are optional for host environments that support this op
 \pasteAttributeItem{PMIX_ALLOC_FABRIC_PLANE}
 \pasteAttributeItem{PMIX_ALLOC_FABRIC_ENDPTS}
 \pasteAttributeItem{PMIX_ALLOC_FABRIC_ENDPTS_NODE}
+\pasteAttributeItem{PMIX_COSPAWN_APP}
+\pasteAttributeItem{PMIX_SPAWN_TOOL}
+\pasteAttributeItem{PMIX_EVENT_SILENT_TERMINATION}
 
 \optattrend
 
@@ -282,6 +285,9 @@ The following attributes are optional for host environments that support this op
 \pasteAttributeItem{PMIX_ALLOC_FABRIC_PLANE}
 \pasteAttributeItem{PMIX_ALLOC_FABRIC_ENDPTS}
 \pasteAttributeItem{PMIX_ALLOC_FABRIC_ENDPTS_NODE}
+\pasteAttributeItem{PMIX_COSPAWN_APP}
+\pasteAttributeItem{PMIX_SPAWN_TOOL}
+\pasteAttributeItem{PMIX_EVENT_SILENT_TERMINATION}
 
 \optattrend
 

--- a/Chap_API_Proc_Mgmt.tex
+++ b/Chap_API_Proc_Mgmt.tex
@@ -1225,6 +1225,7 @@ PMIX_TOPOLOGY_FREE(m, n)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsubsection{Relative locality of two processes}
 \declarestruct{pmix_locality_t}
+\label{api:proc:locality}
 
 \versionMarker{4.0}
 The \refstruct{pmix_locality_t} datatype is a \code{uint16_t} bitmask that
@@ -1358,6 +1359,7 @@ Obtain and set the appropriate \ac{PU} binding location information in the provi
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsubsection{Binding envelope}
 \declarestruct{pmix_bind_envelope_t}
+\label{api:proc:bindenv}
 
 \versionMarker{4.0}
 The \refstruct{pmix_bind_envelope_t} data type
@@ -1511,6 +1513,7 @@ The array of \refstruct{pmix_device_distance_t} will contain the distance inform
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Device type}
 \declarestruct{pmix_device_type_t}
+\label{api:proc:devtype}
 
 The \refstruct{pmix_device_type_t} is a \code{uint64_t} bitmask for identifying the type(s) whose distances are being requested, or the type of a specific device being referenced (e.g., in a \refstruct{pmix_device_distance_t} object).
 

--- a/Chap_API_Reserved_Keys.tex
+++ b/Chap_API_Reserved_Keys.tex
@@ -107,10 +107,10 @@ A string name for the cluster this allocation is on.
 }
 %
 \declareAttribute{PMIX_UNIV_SIZE}{"pmix.univ.size"}{uint32_t}{
-Number of allocated slots in a session - each slot may or may not be occupied
-by an executing process. Note that this attribute is equivalent to
-the \refattr{PMIX_MAX_PROCS} attributed combined with \refattr{PMIX_SESSION_INFO}
-array - it is included in the \ac{PMIx} Standard for historical reasons.
+Maximum number of process that can be simultaneously executing in 
+a session. Note that this attribute is equivalent to
+the \refattr{PMIX_MAX_PROCS} attribute for the \refterm{session} realm - it 
+is included in the \ac{PMIx} Standard for historical reasons.
 }
 %
 \declareAttribute{PMIX_TMPDIR}{"pmix.tmpdir"}{char*}{
@@ -119,6 +119,10 @@ Full path to the top-level temporary directory assigned to the session.
 %
 \declareAttribute{PMIX_TDIR_RMCLEAN}{"pmix.tdir.rmclean"}{bool}{
 Resource Manager will cleanup assigned temporary directory trees.
+}
+%
+\declareAttributeNEW{PMIX_HOSTNAME_KEEP_FQDN}{"pmix.fqdn"}{bool}{
+\acp{FQDN} are being retained by the \ac{PMIx} library.
 }
 
 \vspace{\baselineskip}
@@ -139,44 +143,44 @@ String name of the \ac{RM}.
 The remaining session-related information can only be retrieved by including the \refattr{PMIX_SESSION_INFO} attribute in the \refarg{info} array passed to \refapi{PMIx_Get}:
 
 \declareAttribute{PMIX_ALLOCATED_NODELIST}{"pmix.alist"}{char*}{
-Comma-delimited list or regular expression of all nodes in the specified realm regardless of whether or not they currently host processes.
+Comma-delimited list or regular expression of all nodes in the specified realm regardless of whether or not they currently host processes. Defaults to the \refterm{job} realm.
 }
 %
 \declareAttributeNEW{PMIX_NUM_ALLOCATED_NODES}{"pmix.num.anodes"}{uint32_t}{
-Number of nodes in the specified realm regardless of whether or not they currently host processes.
+Number of nodes in the specified realm regardless of whether or not they currently host processes. Defaults to the \refterm{job} realm.
 }
 %
 \declareAttribute{PMIX_MAX_PROCS}{"pmix.max.size"}{uint32_t}{
 Maximum number of processes that can be executed in the specified realm.
 Typically, this is a constraint imposed by a scheduler or by user settings in a
-hostfile or other resource description.
+hostfile or other resource description. Defaults to the \refterm{job} realm.
 }
 %
 \declareAttribute{PMIX_NODE_LIST}{"pmix.nlist"}{char*}{
-Comma-delimited list of nodes currently hosting processes in the specified realm.
+Comma-delimited list of nodes currently hosting processes in the specified realm. Defaults to the \refterm{job} realm.
 }
 %
 \declareAttribute{PMIX_NUM_SLOTS}{"pmix.num.slots"}{uint32_t}{
-Number of slots allocated in the specified realm. Note that this attribute is
+Maximum number of processes that can simultaneously be executing in the specified realm. Note that this attribute is
 the equivalent to \refattr{PMIX_MAX_PROCS} -
-it is included in the \ac{PMIx} Standard for historical reasons.
+it is included in the \ac{PMIx} Standard for historical reasons. Defaults to the \refterm{job} realm.
 }
 %
 \declareAttributeNEW{PMIX_NUM_NODES}{"pmix.num.nodes"}{uint32_t}{
-Number of nodes currently hosting processes in the specified realm.
+Number of nodes currently hosting processes in the specified realm. Defaults to the \refterm{job} realm.
 }
 
 %
 \declareAttribute{PMIX_NODE_MAP}{"pmix.nmap"}{char*}{
-Regular expression of nodes currently hosting processes in the specified realm - see \ref{cptr:api_server:noderegex} for an explanation of its generation.
+Regular expression of nodes currently hosting processes in the specified realm - see \ref{cptr:api_server:noderegex} for an explanation of its generation. Defaults to the \refterm{job} realm.
 }
 %
 \declareAttribute{PMIX_PROC_MAP}{"pmix.pmap"}{char*}{
-Regular expression describing processes on each node in the specified realm - see \ref{cptr:api_server:ppnregex} for an explanation of its generation.
+Regular expression describing processes on each node in the specified realm - see \ref{cptr:api_server:ppnregex} for an explanation of its generation. Defaults to the \refterm{job} realm.
 }
 %
 \declareAttribute{PMIX_ANL_MAP}{"pmix.anlmap"}{char*}{
-Process mapping in Argonne National Laboratory's PMI-1/PMI-2 notation.
+Process map equivalent to \refattr{PMIX_PROC_MAP} expressed in Argonne National Laboratory's PMI-1/PMI-2 notation. Defaults to the \refterm{job} realm.
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -198,7 +202,7 @@ Job-level information includes the following attributes:
 
 %
 \declareAttribute{PMIX_NSPACE}{"pmix.nspace"}{char*}{
-Namespace of the job - may be a numerical value expressed as a string, but is often an alphanumeric string carrying information solely of use to the system.
+Namespace of the job - may be a numerical value expressed as a string, but is often an alphanumeric string carrying information solely of use to the system. Required to be unique within the scope of the host environment.
 }
 %
 \declareAttribute{PMIX_JOBID}{"pmix.jobid"}{char*}{
@@ -209,14 +213,13 @@ Job identifier assigned by the scheduler to the specified job - may be identical
 Starting global rank of the specified job.
 }
 %
-\pasteAttributeItemBegin{PMIX_MAX_PROCS}In this context, this is the maximum number of processes that can be executed in the specified job, which may be a subset of the number allocated to the overall session.
+\pasteAttributeItemBegin{PMIX_MAX_PROCS}In this context, this is the maximum number of processes that can be simultaneously executed in the specified job, which may be a subset of the number allocated to the overall session.
 \pasteAttributeItemEnd{}
 %
-\pasteAttributeItemBegin{PMIX_NUM_SLOTS}In this context, this is the number of
-slots assigned to the specified job, which may be a subset of the slots
+\pasteAttributeItemBegin{PMIX_NUM_SLOTS}In this context, this is the maximum number of
+process that can be simultaneously executing within the specified job, which may be a subset of the number
 allocated to the overall session. Jobs may reserve a subset of their assigned
-slots for dynamic operations such as \refapi{PMIx_Spawn} - i.e., not all slots
-may be occupied by executing processes from this job at a given point in time.
+maximum processes for dynamic operations such as \refapi{PMIx_Spawn}.
 \pasteAttributeItemEnd{}
 %
 \pasteAttributeItemBegin{PMIX_NUM_NODES}In this context, this is the number of
@@ -246,10 +249,6 @@ Command line used to execute the specified job (e.g., "mpirun -n 2 --map-by foo 
 %
 \declareAttribute{PMIX_NSDIR}{"pmix.nsdir"}{char*}{
 Full path to the temporary directory assigned to the specified job, under \refattr{PMIX_TMPDIR}.
-}
-%
-\declareAttribute{PMIX_LOCALLDR}{"pmix.lldr"}{pmix_rank_t}{
-Lowest rank within the specified job on the node (defaults to current node in absence of \refattr{PMIX_HOSTNAME} or \refattr{PMIX_NODEID} qualifier).
 }
 %
 \declareAttribute{PMIX_JOB_SIZE}{"pmix.job.size"}{uint32_t}{
@@ -324,7 +323,6 @@ Type of mapping used to layout the application (e.g., \code{cyclic}).
 \declareAttribute{PMIX_APP_MAP_REGEX}{"pmix.apmap.regex"}{char*}{
 Regular expression describing the result of the process mapping.
 }
-
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Process realm attributes}
@@ -443,10 +441,6 @@ Name of the host, as returned by the \code{gethostname} utility or its equivalen
 Comma-delimited list of names by which the target node is known.
 }
 %
-\declareAttributeNEW{PMIX_HOSTNAME_KEEP_FQDN}{"pmix.fqdn"}{bool}{
-\acp{FQDN} are being retained by the \ac{PMIx} library.
-}
-%
 \declareAttribute{PMIX_NODEID}{"pmix.nodeid"}{uint32_t}{
 Node identifier expressed as the node's index (beginning at zero) in an array of nodes within the active session. The value must be unique and directly correlate to the \refattr{PMIX_HOSTNAME} of the node - i.e., users can interchangeably reference the same location using either the \refattr{PMIX_HOSTNAME} or corresponding \refattr{PMIX_NODEID}.
 }
@@ -470,6 +464,10 @@ Comma-delimited list of ranks that are executing on the local node within the sp
 %
 \declareAttribute{PMIX_LOCAL_PROCS}{"pmix.lprocs"}{pmix_proc_t array}{
 Array of \refstruct{pmix_proc_t} of all processes executing on the local node -- shortcut for \refapi{PMIx_Resolve_peers} for the local node and a \code{NULL} namespace argument. The process identifier is ignored for this attribute.
+}
+%
+\declareAttribute{PMIX_LOCALLDR}{"pmix.lldr"}{pmix_rank_t}{
+Lowest rank within the specified job on the node (defaults to current node in absence of \refattr{PMIX_HOSTNAME} or \refattr{PMIX_NODEID} qualifier).
 }
 %
 \declareAttribute{PMIX_LOCAL_CPUSETS}{"pmix.lcpus"}{pmix_data_array_t}{

--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -384,6 +384,12 @@ plus the following optional information:
     \item \pasteAttributeItemBegin{PMIX_CLUSTER_ID}As this information is not related to the namespace, it is best passed using the \refapi{PMIx_server_register_resources} \ac{API}.
     \pasteAttributeItemEnd
     \item \pasteAttributeItem{PMIX_ALLOCATED_NODELIST}
+    \item \pasteAttributeItemBegin{PMIX_RM_NAME}As this information is not related to the namespace, it is best passed using the \refapi{PMIx_server_register_resources} \ac{API}.
+    \pasteAttributeItemEnd
+    \item \pasteAttributeItemBegin{PMIX_RM_VERSION}As this information is not related to the namespace, it is best passed using the \refapi{PMIx_server_register_resources} \ac{API}.
+    \pasteAttributeItemEnd
+    \item \pasteAttributeItemBegin{PMIX_SERVER_HOSTNAME}As this information is not related to the namespace, it is best passed using the \refapi{PMIx_server_register_resources} \ac{API}.
+    \pasteAttributeItemEnd
 \end{itemize}
 
 Job-realm information may be passed as individual \refstruct{pmix_info_t} entries, or as part of a \refstruct{pmix_data_array_t} using the \refattr{PMIX_JOB_INFO_ARRAY} attribute. The list of data referenced in this way shall include:
@@ -414,6 +420,8 @@ plus the following optional information:
     \item \pasteAttributeItem{PMIX_BINDTO}
     \item \pasteAttributeItem{PMIX_HOSTNAME_KEEP_FQDN}
     \item \pasteAttributeItem{PMIX_ANL_MAP}
+    \item \pasteAttributeItem{PMIX_TDIR_RMCLEAN}
+    \item \pasteAttributeItem{PMIX_CRYPTO_KEY}
 \end{itemize}
 
 If more than one application is included in the namespace, then the host environment is also required to supply data consisting of the following items for each application in the job, passed as a \refstruct{pmix_data_array_t} using the \refattr{PMIX_APP_INFO_ARRAY} attribute:
@@ -435,6 +443,10 @@ plus the following optional information:
 
 \begin{itemize}
     \item \pasteAttributeItem{PMIX_PSET_NAMES}
+    \item \pasteAttributeItemBegin{PMIX_APP_MAP_TYPE}This attribute may be provided as an individual \refstruct{pmix_info_t} entry if only one application is included in the namespace.
+    \pasteAttributeItemEnd
+    \item \pasteAttributeItemBegin{PMIX_APP_MAP_REGEX}This attribute may be provided as an individual \refstruct{pmix_info_t} entry if only one application is included in the namespace.
+    \pasteAttributeItemEnd
 \end{itemize}
 
 The data may also include attributes provided by the host environment that identify the programming model (as specified by the user) being executed within the application. The \ac{PMIx} server library may utilize this information to customize the environment to fit that model (e.g., adding environmental variables specified by the corresponding standard for that model):
@@ -2471,6 +2483,11 @@ Returns one of the following:
 
 \reqattrstart
 \ac{PMIx} libraries are required to pass any provided attributes to the host environment for processing.
+
+All host environments are required to support the following attributes:
+
+\pasteAttributeItem{PMIX_REQUIRED_KEY}
+
 \reqattrend
 
 \optattrstart

--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -93,7 +93,7 @@ The following attributes are optional for implementers of \ac{PMIx} libraries:
 \pasteAttributeItemEnd{}
 \pasteAttributeItemBegin{PMIX_SERVER_REMOTE_CONNECTIONS} If the library supports connections from remote tools, this attribute may be supported for enabling or disabling it.
 \pasteAttributeItemEnd{}
-\pasteAttributeItem{PMIX_EVENT_BASE}
+\pasteAttributeItem{PMIX_EXTERNAL_PROGRESS}
 \pasteAttributeItem{PMIX_TOPOLOGY2}
 \pasteAttributeItemBegin{PMIX_SERVER_SHARE_TOPOLOGY}The \ac{PMIx} server will
 perform the necessary actions to scalably expose the description to the local
@@ -224,8 +224,9 @@ Server is acting as a gateway for PMIx requests that cannot be serviced on backe
 Server is supporting system scheduler and desires access to appropriate services.
 }
 %
-\declareAttribute{PMIX_EVENT_BASE}{"pmix.evbase"}{struct event_base *}{
-Pointer to libevent\footnote{\url{http://libevent.org/}} \code{event_base} to use in place of the internal progress thread.
+%
+\declareAttributeNEW{PMIX_EXTERNAL_PROGRESS}{"pmix.evext"}{bool}{
+The host shall progress the \ac{PMIx} library via calls to \refapi{PMIx_Progress}
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -1270,6 +1270,7 @@ A \refstruct{pmix_info_t} structure is considered to be of type \refconst{PMIX_B
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Info Type Directives}
 \declarestruct{pmix_info_directives_t}
+\label{api:struct:infodirs}
 
 \versionMarker{2.0}
 The \refstruct{pmix_info_directives_t} structure is a \code{uint32_t} type that defines the behavior of command directives via \refstruct{pmix_info_t} arrays.

--- a/Chap_API_Sync_Access.tex
+++ b/Chap_API_Sync_Access.tex
@@ -523,6 +523,7 @@ The \refarg{info} array shall contain an element for each query key that returne
 \pasteAttributeItem{PMIX_JOB_INFO}
 \pasteAttributeItem{PMIX_APP_INFO}
 \pasteAttributeItem{PMIX_NODE_INFO}
+\pasteAttributeItem{PMIX_PROC_INFO}
 \pasteAttributeItemBegin{PMIX_PROCID}In this context, specifies the process ID whose information is being requested - e.g., a query asking for the \refstruct{pmix_proc_info_t} of a specified process. Only required when the request is for information on a specific process.
 \pasteAttributeItemEnd
 \pasteAttributeItemBegin{PMIX_NSPACE}Specifies the namespace of the process whose information is being requested. Must be accompanied by the \refattr{PMIX_RANK} attribute. Only required when the request is for information on a specific process.
@@ -562,6 +563,11 @@ The following attributes are optional for host environments that support this op
 \pasteAttributeItemEnd
 \pasteAttributeItemBegin{PMIX_PROC_URI} Requests the URI of the specified \ac{PMIx} server's out-of-band connection. Defaults to requesting the information for the local \ac{PMIx} server.
 \pasteAttributeItemEnd
+\pasteAttributeItem{PMIX_CLIENT_AVG_MEMORY}
+\pasteAttributeItem{PMIX_DAEMON_MEMORY}
+\pasteAttributeItem{PMIX_QUERY_AUTHORIZATIONS}
+\pasteAttributeItem{PMIX_PROC_PID}
+\pasteAttributeItem{PMIX_PROC_STATE_STATUS}
 
 \optattrend
 
@@ -638,6 +644,7 @@ The \refarg{info} array shall contain an element for each query key that returne
 \pasteAttributeItem{PMIX_JOB_INFO}
 \pasteAttributeItem{PMIX_APP_INFO}
 \pasteAttributeItem{PMIX_NODE_INFO}
+\pasteAttributeItem{PMIX_PROC_INFO}
 \pasteAttributeItemBegin{PMIX_PROCID}In this context, specifies the process ID whose information is being requested - e.g., a query asking for the \refstruct{pmix_proc_info_t} of a specified process. Only required when the request is for information on a specific process.
 \pasteAttributeItemEnd
 \pasteAttributeItemBegin{PMIX_NSPACE}Specifies the namespace of the process whose information is being requested. Must be accompanied by the \refattr{PMIX_RANK} attribute. Only required when the request is for information on a specific process.
@@ -676,6 +683,11 @@ The following attributes are optional for host environments that support this op
 \pasteAttributeItemEnd
 \pasteAttributeItemBegin{PMIX_PROC_URI} Requests the URI of the specified \ac{PMIx} server's out-of-band connection. Defaults to requesting the information for the local \ac{PMIx} server.
 \pasteAttributeItemEnd
+\pasteAttributeItem{PMIX_CLIENT_AVG_MEMORY}
+\pasteAttributeItem{PMIX_DAEMON_MEMORY}
+\pasteAttributeItem{PMIX_QUERY_AUTHORIZATIONS}
+\pasteAttributeItem{PMIX_PROC_PID}
+\pasteAttributeItem{PMIX_PROC_STATE_STATUS}
 
 \optattrend
 

--- a/Chap_API_Tools.tex
+++ b/Chap_API_Tools.tex
@@ -564,6 +564,7 @@ Scalable forwarding of \code{stdin} represents a significant challenge. Most env
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{IO Forwarding Channels}
 \declarestruct{pmix_iof_channel_t}
+\label{api:tool:iofchannels}
 
 \versionMarker{3.0}
 The \refstruct{pmix_iof_channel_t} structure is a \code{uint16_t} type that defines a set of bit-mask flags for specifying IO forwarding channels. These can be bitwise OR'd together to reference multiple channels.
@@ -1116,7 +1117,7 @@ The following attributes are optional for implementers of \ac{PMIx} libraries:
 \pasteAttributeItemEnd{}
 \pasteAttributeItemBegin{PMIX_TCP_DISABLE_IPV6} If the library supports IPV6 connections, this attribute may be supported for disabling it.
 \pasteAttributeItemEnd{}
-\pasteAttributeItem{PMIX_EVENT_BASE}
+\pasteAttributeItem{PMIX_EXTERNAL_PROGRESS}
 
 \optattrend
 

--- a/Chap_Revisions.tex
+++ b/Chap_Revisions.tex
@@ -992,5 +992,9 @@ Spawned processes will not call \refapi{PMIx_Init}.
 \declareAttributeDEP{PMIX_ARCH}{"pmix.arch"}{uint32_t}{
 Architecture flag.
 }
+%
+\declareAttributeDEP{PMIX_EVENT_BASE}{"pmix.evbase"}{struct event_base *}{
+Pointer to libevent\footnote{\url{http://libevent.org/}} \code{event_base} to use in place of the internal progress thread.
+}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/Chap_Revisions.tex
+++ b/Chap_Revisions.tex
@@ -338,10 +338,11 @@ In addition to the reorganization, the following changes were introduced in v4.0
     \item Update description to provide an option for blocking behavior of the \refapi{PMIx_Register_event_handler}, \refapi{PMIx_Deregister_event_handler}, \refapi{PMIx_Notify_event}, \refapi{PMIx_IOF_pull}, \refapi{PMIx_IOF_deregister}, and \refapi{PMIx_IOF_push} APIs. The need for blocking forms of these functions was not initially anticipated but has emerged over time. For these functions, the return value is sufficient to provide the caller with information otherwise returned via callback. Thus, use of a \code{NULL} value as the callback function parameter was deemed a minimal disruption method for providing the desired capability
     \item Added a chapter on fabric support that includes new \acp{API}, datatypes, and attributes
     \item Added a chapter on process sets and groups that includes new \acp{API} and attributes
-    \item Added \acp{API} and a new datatype to support generation and parsing of \ac{PMIx} locality strings
+    \item Added \acp{API} and a new datatypes to support generation and parsing of \ac{PMIx} locality and cpuset strings
     \item Added a new chapter on tools that provides deeper explanation on their operation and collecting all tool-relevant definitions into one location. Also introduced two new \acp{API} and removed restriction that limited tools to being connected to only one server at a time.
     \item Extended behavior of \refapi{PMIx_server_init} to scalably expose the topology description to the local clients. This includes creating any required shared memory backing stores and/or \ac{XML} representations, plus ensuring that all necessary key-value pairs for clients to access the description are included in the job-level information provided to each client.
-\end{compactitemize}
+    \item Added a new \ac{API} by which the host can manually progress the \ac{PMIx} library in lieu of the library's own progress thread.
+s\end{compactitemize}
 
 The above changes included introduction of the following \acp{API} and data types:
 
@@ -362,6 +363,7 @@ The above changes included introduction of the following \acp{API} and data type
         \item \refapi{PMIx_Fabric_deregister}, \refapi{PMIx_Fabric_deregister_nb}
         \item \refapi{PMIx_Compute_distances}, \refapi{PMIx_Compute_distances_nb}
         \item \refapi{PMIx_Get_attribute_string}, \refapi{PMIx_Get_attribute_name}
+        \item \refapi{PMIx_Progress}
     \end{compactitemize}
 
     \item Server \acp{API}
@@ -588,6 +590,7 @@ The above changes included introduction of the following \acp{API} and data type
 \pasteAttributeItem{PMIX_HOSTNAME_ALIASES}
 \pasteAttributeItem{PMIX_HOSTNAME_KEEP_FQDN}
 \pasteAttributeItem{PMIX_CPUSET_BITMAP}
+\pasteAttributeItem{PMIX_EXTERNAL_PROGRESS}
 %
 %
 \littleheader{Tool attributes}

--- a/bin/check-attr-refs.py
+++ b/bin/check-attr-refs.py
@@ -93,7 +93,7 @@ if __name__ == "__main__":
         if p.returncode != 0:
             print("Error: Failed to verify declared attribute \""+attr+"\". grep error code "+str(p.returncode)+")");
             sys.exit(2)
-                
+
         # List of Definition is larger than attribute list
         for line in p.stdout:
             line = line.rstrip()
@@ -181,10 +181,10 @@ if __name__ == "__main__":
     #
     for attr in sorted(attr_declared):
         if attr_declared[attr] <= 0:
-            if attr not in deprecated_attr:
+            if attr not in deprecated_attr and attr != "PMIX_ATTR_UNDEF":
                 print("Attribute Missing Reference: "+attr)
                 count_not_used += 1
-            elif args.verbose is True:
+            elif args.verbose is True and attr != "PMIX_ATTR_UNDEF":
                 print("=====> Deprecated Attribute Missing Reference: "+attr)
 
 


### PR DESCRIPTION
Replace the bitarray types in Python bindings with simple integer lists
for ease of use/translation. Cleanup some missing functions.

Add PMIX_EXTERNAL_PROGRESS attribute and PMIx_Progress API so that a
host can externally progress the PMIx library. This is less onerous than
requiring the host to also adopt libevent and provide an event base.
Deprecate the PMIX_EVENT_BASE attribute.

I had forgotten about the external progress promise until someone
pointed it out to me.

Signed-off-by: Ralph Castain <rhc@pmix.org>