### PR TITLE
Fix copy/paste error

### DIFF
--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -2346,7 +2346,6 @@ Returns one of the following:
 
 \begin{itemize}
     \item \refconst{PMIX_SUCCESS}, indicating that the request is being processed by the host environment - result will be returned in the provided \refarg{cbfunc}. Note that the host must not invoke the callback function prior to returning from the \ac{API}.
-    \item \refconst{PMIX_OPERATION_SUCCEEDED}, indicating that the request was immediately processed and returned \textit{success} - the \refarg{cbfunc} will not be called
     \item \refconst{PMIX_ERR_NOT_SUPPORTED}, indicating that the host environment does not support the request, even though the function entry was provided in the server module - the \refarg{cbfunc} will not be called
     \item a PMIx error constant indicating either an error in the input or that the request was immediately processed and failed - the \refarg{cbfunc} will not be called
 \end{itemize}

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -280,6 +280,24 @@ PMIX_CHECK_KEY(a, b)
 
 Returns \code{true} if the key matches the given value
 
+\littleheader{Check reserved key macro}
+\declaremacro{PMIX_CHECK_RESERVED_KEY}
+
+Check if the given key is a \ac{PMIx} \emph{reserved} key as described in Chapter \ref{chap:api_rsvd_keys}.
+
+\versionMarker{4.0}
+\cspecificstart
+\begin{codepar}
+PMIX_CHECK_RESERVED_KEY(a)
+\end{codepar}
+\cspecificend
+
+\begin{arglist}
+\argin{a}{String value to be checked (\code{char*})}
+\end{arglist}
+
+Returns \code{true} if the key is reserved by the Standard.
+
 \littleheader{Load key macro}
 \declaremacro{PMIX_LOAD_KEY}
 

--- a/Chap_Revisions.tex
+++ b/Chap_Revisions.tex
@@ -696,6 +696,11 @@ The above changes included introduction of the following \acp{API} and data type
 \refenvar{PMIX_LAUNCHER_RENDEZVOUS_FILE} \\
 %
 %
+\subsection{Added Macros}
+%
+\refmacro{PMIX_CHECK_RESERVED_KEY}
+%
+%
 \subsection{Deprecated \acp{API}}
 
 \declareapiDEP{pmix_evhdlr_reg_cbfunc_t}


### PR DESCRIPTION
The pmix_server_fencenb_fn_t upcall function cannot return "operation
succeeded" as that would prevent the return of any collected data.

Signed-off-by: Ralph Castain <rhc@pmix.org>