### PR TITLE
Restore PMIX_EVENT_BASE attribute

### DIFF
--- a/Chap_API_Init.tex
+++ b/Chap_API_Init.tex
@@ -126,6 +126,10 @@ The following attributes are optional for implementers of \ac{PMIx} libraries:
 \pasteAttributeItemBegin{PMIX_TCP_DISABLE_IPV6} If the library supports IPV6 connections, this attribute may be supported for disabling it.
 \pasteAttributeItemEnd{}
 \pasteAttributeItem{PMIX_EXTERNAL_PROGRESS}
+%
+\declareAttribute{PMIX_EVENT_BASE}{"pmix.evbase"}{void*}{
+Pointer to an \code{event_base} to use in place of the internal progress thread. All \ac{PMIx} library events are to be assigned to the provided event base. The event base \emph{must} be compatible with the event library used by the \ac{PMIx} implementation - e.g., either both the host and \ac{PMIx} library must use libevent, or both must use libev. Cross-matches are unlikely to work and should be avoided - it is the responsibility of the host to ensure that the \ac{PMIx} implementation supports (and was built with) the appropriate event library.
+}
 
 \vspace{\baselineskip}
 If provided, the following attributes are used by the event notification system for inter-library coordination:

--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -94,6 +94,7 @@ The following attributes are optional for implementers of \ac{PMIx} libraries:
 \pasteAttributeItemBegin{PMIX_SERVER_REMOTE_CONNECTIONS} If the library supports connections from remote tools, this attribute may be supported for enabling or disabling it.
 \pasteAttributeItemEnd{}
 \pasteAttributeItem{PMIX_EXTERNAL_PROGRESS}
+\pasteAttributeItem{PMIX_EVENT_BASE}
 \pasteAttributeItem{PMIX_TOPOLOGY2}
 \pasteAttributeItemBegin{PMIX_SERVER_SHARE_TOPOLOGY}The \ac{PMIx} server will
 perform the necessary actions to scalably expose the description to the local

--- a/Chap_API_Tools.tex
+++ b/Chap_API_Tools.tex
@@ -1118,6 +1118,7 @@ The following attributes are optional for implementers of \ac{PMIx} libraries:
 \pasteAttributeItemBegin{PMIX_TCP_DISABLE_IPV6} If the library supports IPV6 connections, this attribute may be supported for disabling it.
 \pasteAttributeItemEnd{}
 \pasteAttributeItem{PMIX_EXTERNAL_PROGRESS}
+\pasteAttributeItem{PMIX_EVENT_BASE}
 
 \optattrend
 

--- a/Chap_Revisions.tex
+++ b/Chap_Revisions.tex
@@ -999,9 +999,5 @@ Spawned processes will not call \refapi{PMIx_Init}.
 \declareAttributeDEP{PMIX_ARCH}{"pmix.arch"}{uint32_t}{
 Architecture flag.
 }
-%
-\declareAttributeDEP{PMIX_EVENT_BASE}{"pmix.evbase"}{struct event_base *}{
-Pointer to libevent\footnote{\url{http://libevent.org/}} \code{event_base} to use in place of the internal progress thread.
-}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Turns out we do need this in the standard

Signed-off-by: Ralph Castain <rhc@pmix.org>