### PR TITLE
Add a data type constant for pmix_nspace_t

### DIFF
--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -2335,6 +2335,9 @@ Data array (\refstruct{pmix_data_array_t}).
 \declareconstitem{PMIX_PROC_RANK}
 Process rank (\refstruct{pmix_rank_t}).
 %
+\declareconstitemNEW{PMIX_PROC_NSPACE}
+Process namespace (\refstruct{pmix_nspace_t}).
+\%
 \declareconstitem{PMIX_QUERY}
 Query structure (\refstruct{pmix_query_t}).
 %


### PR DESCRIPTION
Define a data type solely for process namespace as we did for process rank.

Signed-off-by: Ralph Castain <rhc@pmix.org>