### PR TITLE
Assign specific values to PMIx constants

### DIFF
--- a/Chap_API_Event.tex
+++ b/Chap_API_Event.tex
@@ -171,7 +171,7 @@ Error in event registration.
 
 \begin{constantdesc}
 %
-\declareconstitemvalueNEW{PMIX_EVENT_SYS_BASE}{-230}
+\declareconstitemNEW{PMIX_EVENT_SYS_BASE}
 Mark the beginning of a dedicated range of constants for system event reporting.
 %
 \declareconstitemvalueNEW{PMIX_EVENT_NODE_DOWN}{-231}
@@ -180,7 +180,7 @@ A node has gone down - the identifier of the affected node will be included in t
 \declareconstitemvalueNEW{PMIX_EVENT_NODE_OFFLINE}{-232}
 A node has been marked as \emph{offline} - the identifier of the affected node will be included in the notification.
 %
-\declareconstitemvalueNEW{PMIX_EVENT_SYS_OTHER}{-330}
+\declareconstitemNEW{PMIX_EVENT_SYS_OTHER}
 Mark the end of a dedicated range of constants for system event reporting.
 %
 \end{constantdesc}

--- a/Chap_API_Event.tex
+++ b/Chap_API_Event.tex
@@ -160,7 +160,7 @@ As previously stated, upon completing its work, and prior to returning, each han
 
 \begin{constantdesc}
 %
-\declareconstitem{PMIX_ERR_EVENT_REGISTRATION}
+\declareconstitemvalue{PMIX_ERR_EVENT_REGISTRATION}{-144}
 Error in event registration.
 %
 \end{constantdesc}
@@ -171,16 +171,16 @@ Error in event registration.
 
 \begin{constantdesc}
 %
-\declareconstitemNEW{PMIX_EVENT_SYS_BASE}
+\declareconstitemvalueNEW{PMIX_EVENT_SYS_BASE}{-230}
 Mark the beginning of a dedicated range of constants for system event reporting.
 %
-\declareconstitemNEW{PMIX_EVENT_NODE_DOWN}
+\declareconstitemvalueNEW{PMIX_EVENT_NODE_DOWN}{-231}
 A node has gone down - the identifier of the affected node will be included in the notification.
 %
-\declareconstitemNEW{PMIX_EVENT_NODE_OFFLINE}
+\declareconstitemvalueNEW{PMIX_EVENT_NODE_OFFLINE}{-232}
 A node has been marked as \emph{offline} - the identifier of the affected node will be included in the notification.
 %
-\declareconstitemNEW{PMIX_EVENT_SYS_OTHER}
+\declareconstitemvalueNEW{PMIX_EVENT_SYS_OTHER}{-330}
 Mark the end of a dedicated range of constants for system event reporting.
 %
 \end{constantdesc}
@@ -557,16 +557,16 @@ The following status code may be returned indicating various actions taken by ot
 
 \begin{constantdesc}
 %
-\declareconstitem{PMIX_EVENT_NO_ACTION_TAKEN}
+\declareconstitemvalue{PMIX_EVENT_NO_ACTION_TAKEN}{-331}
 Event handler: No action taken.
 %
-\declareconstitem{PMIX_EVENT_PARTIAL_ACTION_TAKEN}
+\declareconstitemvalue{PMIX_EVENT_PARTIAL_ACTION_TAKEN}{-332}
 Event handler: Partial action taken.
 %
-\declareconstitem{PMIX_EVENT_ACTION_DEFERRED}
+\declareconstitemvalue{PMIX_EVENT_ACTION_DEFERRED}{-333}
 Event handler: Action deferred.
 %
-\declareconstitem{PMIX_EVENT_ACTION_COMPLETE}
+\declareconstitemvalue{PMIX_EVENT_ACTION_COMPLETE}{-334}
 Event handler: Action complete.
 %
 \end{constantdesc}

--- a/Chap_API_Fabric.tex
+++ b/Chap_API_Fabric.tex
@@ -81,13 +81,13 @@ The following events are defined for use in fabric-related operations.
 
 \begin{constantdesc}
 %
-\declareconstitemNEW{PMIX_FABRIC_UPDATE_PENDING}
+\declareconstitemvalueNEW{PMIX_FABRIC_UPDATE_PENDING}{-176}
 The \ac{PMIx} server library has been alerted to a change in the fabric that requires updating of one or more registered \refstruct{pmix_fabric_t} objects.
 %
-\declareconstitemNEW{PMIX_FABRIC_UPDATED}
+\declareconstitemvalueNEW{PMIX_FABRIC_UPDATED}{-175}
 The \ac{PMIx} server library has completed updating the entries of all affected \refstruct{pmix_fabric_t} objects registered with the library. Access to the entries of those objects may now resume.
 %
-\declareconstitemNEW{PMIX_FABRIC_UPDATE_ENDPOINTS}
+\declareconstitemvalueNEW{PMIX_FABRIC_UPDATE_ENDPOINTS}{-113}
 Endpoint assignments have been updated, usually in response to migration
 or restart of a process. Clients should use \refapi{PMIx_Get} to update any
 internally cached connections.
@@ -374,13 +374,13 @@ Fabric coordinates can be reported based on different \emph{views} according to 
 
 \begin{constantdesc}
 %
-\declareconstitemNEW{PMIX_COORD_VIEW_UNDEF}
+\declareconstitemvalueNEW{PMIX_COORD_VIEW_UNDEF}{0x00}
 The coordinate view has not been defined.
 %
-\declareconstitemNEW{PMIX_COORD_LOGICAL_VIEW}
+\declareconstitemvalueNEW{PMIX_COORD_LOGICAL_VIEW}{0x01}
 The coordinates are provided in a \emph{logical} view, typically given in Cartesian (x,y,z) dimensions, that describes the data flow in the fabric as defined by the arrangement of the hierarchical addressing scheme, fabric segmentation, routing domains, and other similar factors employed by that fabric.
 %
-\declareconstitemNEW{PMIX_COORD_PHYSICAL_VIEW}
+\declareconstitemvalueNEW{PMIX_COORD_PHYSICAL_VIEW}{0x02}
 The coordinates are provided in a \emph{physical} view based on the actual wiring diagram of the fabric - i.e., values along each axis reflect the relative position of that interface on the specific fabric cabling.
 %
 \end{constantdesc}
@@ -401,13 +401,13 @@ The following constants can be used to set a variable of the type \refstruct{pmi
 
 \begin{constantdesc}
 %
-\declareconstitemNEW{PMIX_LINK_STATE_UNKNOWN}
+\declareconstitemvalueNEW{PMIX_LINK_STATE_UNKNOWN}{0}
 The port state is unknown or not applicable.
 %
-\declareconstitemNEW{PMIX_LINK_DOWN}
+\declareconstitemvalueNEW{PMIX_LINK_DOWN}{1}
 The port is inactive.
 %
-\declareconstitemNEW{PMIX_LINK_UP}
+\declareconstitemvalueNEW{PMIX_LINK_UP}{2}
 The port is active.
 %
 \end{constantdesc}
@@ -421,10 +421,10 @@ The \refstruct{pmix_fabric_operation_t} data type is an enumerated type for spec
 
 \begin{constantdesc}
 %
-\declareconstitemNEW{PMIX_FABRIC_REQUEST_INFO}
+\declareconstitemvalueNEW{PMIX_FABRIC_REQUEST_INFO}{0}
 Request information on a specific fabric - if the fabric isn't specified as per \refapi{PMIx_Fabric_register}, then return information on the default fabric of the overall system. Information to be returned is described in \refstruct{pmix_fabric_t}.
 %
-\declareconstitemNEW{PMIX_FABRIC_UPDATE_INFO}
+\declareconstitemvalueNEW{PMIX_FABRIC_UPDATE_INFO}{1}
 Update information on a specific fabric - the index of the fabric (\refattr{PMIX_FABRIC_INDEX}) to be updated must be provided.
 %
 \end{constantdesc}

--- a/Chap_API_Init.tex
+++ b/Chap_API_Init.tex
@@ -164,16 +164,16 @@ The following events are typically associated with calls to \refapi{PMIx_Init}:
 
 \begin{constantdesc}
 %
-\declareconstitem{PMIX_MODEL_DECLARED}
+\declareconstitemvalue{PMIX_MODEL_DECLARED}{-147}
 Model declared.
 %
-\declareconstitem{PMIX_MODEL_RESOURCES}
+\declareconstitemvalue{PMIX_MODEL_RESOURCES}{-151}
 Resource usage by a programming model has changed.
 %
-\declareconstitem{PMIX_OPENMP_PARALLEL_ENTERED}
+\declareconstitemvalue{PMIX_OPENMP_PARALLEL_ENTERED}{-152}
 An OpenMP parallel code region has been entered.
 %
-\declareconstitem{PMIX_OPENMP_PARALLEL_EXITED}
+\declareconstitemvalue{PMIX_OPENMP_PARALLEL_EXITED}{-153}
 An OpenMP parallel code region has completed.
 %
 \end{constantdesc}

--- a/Chap_API_Job_Mgmt.tex
+++ b/Chap_API_Job_Mgmt.tex
@@ -287,7 +287,7 @@ Attributes in the accompanying \refstruct{pmix_info_t} array may be used to spec
 \declareconstitemvalue{PMIX_ALLOC_REAQUIRE}{4}
 Reacquire resources that were previously ``lent'' back to the scheduler.
 %
-\declareconstitemvalue{PMIX_ALLOC_EXTERNAL}{128}
+\declareconstitem{PMIX_ALLOC_EXTERNAL}
 A value boundary above which implementers are free to define their own directive values.
 %
 \end{constantdesc}

--- a/Chap_API_Job_Mgmt.tex
+++ b/Chap_API_Job_Mgmt.tex
@@ -273,21 +273,21 @@ The following constants can be used to set a variable of the type \refstruct{pmi
 
 \begin{constantdesc}
 %
-\declareconstitem{PMIX_ALLOC_NEW}
+\declareconstitemvalue{PMIX_ALLOC_NEW}{1}
 A new allocation is being requested.
 The resulting allocation will be disjoint (i.e., not connected in a job sense) from the requesting allocation.
 %
-\declareconstitem{PMIX_ALLOC_EXTEND}
+\declareconstitemvalue{PMIX_ALLOC_EXTEND}{2}
 Extend the existing allocation, either in time or as additional resources.
 %
-\declareconstitem{PMIX_ALLOC_RELEASE}
+\declareconstitemvalue{PMIX_ALLOC_RELEASE}{3}
 Release part of the existing allocation.
 Attributes in the accompanying \refstruct{pmix_info_t} array may be used to specify permanent release of the identified resources, or ``lending'' of those resources for some period of time.
 %
-\declareconstitem{PMIX_ALLOC_REAQUIRE}
+\declareconstitemvalue{PMIX_ALLOC_REAQUIRE}{4}
 Reacquire resources that were previously ``lent'' back to the scheduler.
 %
-\declareconstitem{PMIX_ALLOC_EXTERNAL}
+\declareconstitemvalue{PMIX_ALLOC_EXTERNAL}{128}
 A value boundary above which implementers are free to define their own directive values.
 %
 \end{constantdesc}
@@ -477,7 +477,7 @@ The following constants are specifically defined for return by the job control \
 \begin{constantdesc}
 
 %
-\declareconstitemNEW{PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES}
+\declareconstitemvalueNEW{PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES}{-51}
 Conflicting directives given for job/process cleanup.
 
 \end{constantdesc}
@@ -490,22 +490,22 @@ The following job control events may be available for registration, depending up
 
 \begin{constantdesc}
 %
-\declareconstitem{PMIX_JCTRL_CHECKPOINT}
+\declareconstitemvalue{PMIX_JCTRL_CHECKPOINT}{-106}
 Monitored by \ac{PMIx} client to trigger a checkpoint operation.
 %
-\declareconstitem{PMIX_JCTRL_CHECKPOINT_COMPLETE}
+\declareconstitemvalue{PMIX_JCTRL_CHECKPOINT_COMPLETE}{-107}
 Sent by a \ac{PMIx} client and monitored by a \ac{PMIx} server to notify that requested checkpoint operation has completed.
 %
-\declareconstitem{PMIX_JCTRL_PREEMPT_ALERT}
+\declareconstitemvalue{PMIX_JCTRL_PREEMPT_ALERT}{-108}
 Monitored by a \ac{PMIx} client to detect that an \ac{RM} intends to preempt the job.
 %
-\declareconstitem{PMIX_ERR_PROC_RESTART}
+\declareconstitemvalue{PMIX_ERR_PROC_RESTART}{-4}
 Error in process restart.
 %
-\declareconstitem{PMIX_ERR_PROC_CHECKPOINT}
+\declareconstitemvalue{PMIX_ERR_PROC_CHECKPOINT}{-5}
 Error in process checkpoint.
 %
-\declareconstitem{PMIX_ERR_PROC_MIGRATE}
+\declareconstitemvalue{PMIX_ERR_PROC_MIGRATE}{-6}
 Error in process migration.
 %
 \end{constantdesc}
@@ -784,10 +784,10 @@ The following monitoring events may be available for registration, depending upo
 
 \begin{constantdesc}
 %
-\declareconstitem{PMIX_MONITOR_HEARTBEAT_ALERT}
+\declareconstitemvalue{PMIX_MONITOR_HEARTBEAT_ALERT}{-109}
 Heartbeat failed to arrive within specified window. The process that triggered this alert will be identified in the event.
 %
-\declareconstitem{PMIX_MONITOR_FILE_ALERT}
+\declareconstitemvalue{PMIX_MONITOR_FILE_ALERT}{-110}
 File failed its monitoring detection criteria. The file that triggered this alert will be identified in the event.
 %
 \end{constantdesc}

--- a/Chap_API_NonReserved_Keys.tex
+++ b/Chap_API_NonReserved_Keys.tex
@@ -104,22 +104,22 @@ If a specified scope value is not supported, then the \refapi{PMIx_Put} call mus
 
 \begin{constantdesc}
 %
-\declareconstitem{PMIX_SCOPE_UNDEF}
+\declareconstitemvalue{PMIX_SCOPE_UNDEF}{0}
 Undefined scope.
 %
-\declareconstitem{PMIX_LOCAL}
+\declareconstitemvalue{PMIX_LOCAL}{1}
 The data is intended only for other application processes on the same node.
 Data marked in this way will not be included in data packages sent to remote requesters - i.e., it is only available to processes on the local node.
 %
-\declareconstitem{PMIX_REMOTE}
+\declareconstitemvalue{PMIX_REMOTE}{2}
 The data is intended solely for applications processes on remote nodes.
 Data marked in this way will not be shared with other processes on the same node - i.e., it is only available to  processes on remote nodes.
 %
-\declareconstitem{PMIX_GLOBAL}
+\declareconstitemvalue{PMIX_GLOBAL}{3}
 The data is to be shared with all other requesting processes, regardless of location.
 %
 \versionMarker{2.0}
-\declareconstitem{PMIX_INTERNAL}
+\declareconstitemvalue{PMIX_INTERNAL}{4}
 The data is intended solely for this process and is not shared with other processes.
 %
 \end{constantdesc}

--- a/Chap_API_Proc_Mgmt.tex
+++ b/Chap_API_Proc_Mgmt.tex
@@ -305,19 +305,19 @@ In addition to the generic error constants, the following spawn-specific error c
 
 \begin{constantdesc}
 %
-\declareconstitemNEW{PMIX_ERR_JOB_ALLOC_FAILED}
+\declareconstitemvalueNEW{PMIX_ERR_JOB_ALLOC_FAILED}{-188}
 The job request could not be executed due to failure to obtain the specified allocation
 %
-\declareconstitemNEW{PMIX_ERR_JOB_APP_NOT_EXECUTABLE}
+\declareconstitemvalueNEW{PMIX_ERR_JOB_APP_NOT_EXECUTABLE}{-177}
 The specified application executable either could not be found, or lacks execution privileges.
 %
-\declareconstitemNEW{PMIX_ERR_JOB_NO_EXE_SPECIFIED}
+\declareconstitemvalueNEW{PMIX_ERR_JOB_NO_EXE_SPECIFIED}{-178}
 The job request did not specify an executable.
 %
-\declareconstitemNEW{PMIX_ERR_JOB_FAILED_TO_MAP}
+\declareconstitemvalueNEW{PMIX_ERR_JOB_FAILED_TO_MAP}{-179}
 The launcher was unable to map the processes for the specified job request.
 %
-\declareconstitemNEW{PMIX_ERR_JOB_FAILED_TO_LAUNCH}
+\declareconstitemvalueNEW{PMIX_ERR_JOB_FAILED_TO_LAUNCH}{-181}
 One or more processes in the job request failed to launch
 %
 \end{constantdesc}
@@ -1181,34 +1181,34 @@ locality value using standard bit-test methods.
 
 \begin{constantdesc}
 %
-\declareconstitemNEW{PMIX_LOCALITY_UNKNOWN}
+\declareconstitemvalueNEW{PMIX_LOCALITY_UNKNOWN}{0x0000}
 All bits are set to zero, indicating that the relative locality of the two processes is unknown
 %
-\declareconstitemNEW{PMIX_LOCALITY_NONLOCAL}
+\declareconstitemvalueNEW{PMIX_LOCALITY_NONLOCAL}{0x0000}
 The two processes do not share any common locations
 %
-\declareconstitemNEW{PMIX_LOCALITY_SHARE_HWTHREAD}
+\declareconstitemvalueNEW{PMIX_LOCALITY_SHARE_HWTHREAD}{0x0001}
 The two processes share at least one hardware thread
 %
-\declareconstitemNEW{PMIX_LOCALITY_SHARE_CORE}
+\declareconstitemvalueNEW{PMIX_LOCALITY_SHARE_CORE}{0x0002}
 The two processes share at least one core
 %
-\declareconstitemNEW{PMIX_LOCALITY_SHARE_L1CACHE}
+\declareconstitemvalueNEW{PMIX_LOCALITY_SHARE_L1CACHE}{0x0004}
 The two processes share at least an L1 cache
 %
-\declareconstitemNEW{PMIX_LOCALITY_SHARE_L2CACHE}
+\declareconstitemvalueNEW{PMIX_LOCALITY_SHARE_L2CACHE}{0x0008}
 The two processes share at least an L2 cache
 %
-\declareconstitemNEW{PMIX_LOCALITY_SHARE_L3CACHE}
+\declareconstitemvalueNEW{PMIX_LOCALITY_SHARE_L3CACHE}{0x0010}
 The two processes share at least an L3 cache
 %
-\declareconstitemNEW{PMIX_LOCALITY_SHARE_PACKAGE}
+\declareconstitemvalueNEW{PMIX_LOCALITY_SHARE_PACKAGE}{0x0020}
 The two processes share at least a package
 %
-\declareconstitemNEW{PMIX_LOCALITY_SHARE_NUMA}
+\declareconstitemvalueNEW{PMIX_LOCALITY_SHARE_NUMA}{0x0040}
 The two processes share at least one \ac{NUMA} region
 %
-\declareconstitemNEW{PMIX_LOCALITY_SHARE_NODE}
+\declareconstitemvalueNEW{PMIX_LOCALITY_SHARE_NODE}{0x4000}
 The two processes are executing on the same node
 %
 \end{constantdesc}
@@ -1307,10 +1307,10 @@ defines the envelope of threads within a possibly multi-threaded process that ar
 
 \begin{constantdesc}
 %
-\declareconstitemNEW{PMIX_CPUBIND_PROCESS}
+\declareconstitemvalueNEW{PMIX_CPUBIND_PROCESS}{0}
 Use the location of all threads in the possibly multi-threaded process.
 %
-\declareconstitemNEW{PMIX_CPUBIND_THREAD}
+\declareconstitemvalueNEW{PMIX_CPUBIND_THREAD}{1}
 Use only the location of the thread calling the \ac{API}.
 %
 \end{constantdesc}
@@ -1451,25 +1451,25 @@ The following constants can be used to set a variable of the type \refstruct{pmi
 
 \begin{constantdesc}
 %
-\declareconstitemNEW{PMIX_DEVTYPE_UNKNOWN}
+\declareconstitemvalueNEW{PMIX_DEVTYPE_UNKNOWN}{0x00}
 The device is of an unknown type - will not be included in returned device distances.
 %
-\declareconstitemNEW{PMIX_DEVTYPE_BLOCK}
+\declareconstitemvalueNEW{PMIX_DEVTYPE_BLOCK}{0x01}
 Operating system block device, or non-volatile memory device (e.g., "sda" or "dax2.0" on Linux).
 %
-\declareconstitemNEW{PMIX_DEVTYPE_GPU}
+\declareconstitemvalueNEW{PMIX_DEVTYPE_GPU}{0x02}
 Operating system \ac{GPU} device (e.g., "card0" for a Linux \ac{DRM} device).
 %
-\declareconstitemNEW{PMIX_DEVTYPE_NETWORK}
+\declareconstitemvalueNEW{PMIX_DEVTYPE_NETWORK}{0x04}
 Operating system network device (e.g., the "eth0" interface on Linux).
 %
-\declareconstitemNEW{PMIX_DEVTYPE_OPENFABRICS}
+\declareconstitemvalueNEW{PMIX_DEVTYPE_OPENFABRICS}{0x08}
 Operating system OpenFabrics device (e.g., an "mlx4_0" InfiniBand \ac{HCA}, or "hfi1_0" Omni-Path interface on Linux).
 %
-\declareconstitemNEW{PMIX_DEVTYPE_DMA}
+\declareconstitemvalueNEW{PMIX_DEVTYPE_DMA}{0x10}
 Operating system \ac{DMA} engine device (e.g., the "dma0chan0" \ac{DMA} channel on Linux).
 %
-\declareconstitemNEW{PMIX_DEVTYPE_COPROC}
+\declareconstitemvalueNEW{PMIX_DEVTYPE_COPROC}{0x20}
 Operating system co-processor device (e.g., "mic0" for a Xeon Phi on Linux, "opencl0d0" for a OpenCL device, or "cuda0" for a \ac{CUDA} device).
 %
 \end{constantdesc}

--- a/Chap_API_Publish.tex
+++ b/Chap_API_Publish.tex
@@ -140,7 +140,7 @@ The following constants are defined for use with the \refapi{PMIx_Publish} \acp{
 
 \begin{constantdesc}
 %
-\declareconstitemNEW{PMIX_ERR_DUPLICATE_KEY}
+\declareconstitemvalueNEW{PMIX_ERR_DUPLICATE_KEY}{-53}
 The provided key has already been published on the same data range.
 %
 \end{constantdesc}
@@ -190,31 +190,31 @@ The following constants can be used to set a variable of the type \refstruct{pmi
 
 \begin{constantdesc}
 %
-\declareconstitem{PMIX_RANGE_UNDEF}
+\declareconstitemvalue{PMIX_RANGE_UNDEF}{0}
 Undefined range.
 %
-\declareconstitem{PMIX_RANGE_RM}
+\declareconstitemvalue{PMIX_RANGE_RM}{1}
 Data is intended for the host environment, or lookup is restricted to data published by the host environment.
 %
-\declareconstitem{PMIX_RANGE_LOCAL}
+\declareconstitemvalue{PMIX_RANGE_LOCAL}{2}
 Data is only available to processes on the local node, or lookup is restricted to data published by processes on the local node of the requester.
 %
-\declareconstitem{PMIX_RANGE_NAMESPACE}
+\declareconstitemvalue{PMIX_RANGE_NAMESPACE}{3}
 Data is only available to processes in the same namespace, or lookup is restricted to data published by processes in the same namespace as the requester.
 %
-\declareconstitem{PMIX_RANGE_SESSION}
+\declareconstitemvalue{PMIX_RANGE_SESSION}{4}
 Data is only available to all processes in the session, or lookup is restricted to data published by other processes in the same session as the requester.
 %
-\declareconstitem{PMIX_RANGE_GLOBAL}
+\declareconstitemvalue{PMIX_RANGE_GLOBAL}{5}
 Data is available to all processes, or lookup is open to data published by anyone.
 %
-\declareconstitem{PMIX_RANGE_CUSTOM}
+\declareconstitemvalue{PMIX_RANGE_CUSTOM}{6}
 Data is available only to processes as specified in the \refstruct{pmix_info_t} associated with this call, or lookup is restricted to data published by processes as specified in the \refstruct{pmix_info_t}.
 %
-\declareconstitem{PMIX_RANGE_PROC_LOCAL}
+\declareconstitemvalue{PMIX_RANGE_PROC_LOCAL}{7}
 Data is only available to this process, or lookup is restricted to data published by this process.
 %
-\declareconstitem{PMIX_RANGE_INVALID}
+\declareconstitemvalue{PMIX_RANGE_INVALID}{UINT8_MAX}
 Invalid value - typically used to indicate that a range has not yet been set.
 %
 \end{constantdesc}
@@ -230,22 +230,22 @@ The following constants can be used to set a variable of the type \refstruct{pmi
 
 \begin{constantdesc}
 %
-\declareconstitem{PMIX_PERSIST_INDEF}
+\declareconstitemvalue{PMIX_PERSIST_INDEF}{0}
 Retain data until specifically deleted.
 %
-\declareconstitem{PMIX_PERSIST_FIRST_READ}
+\declareconstitemvalue{PMIX_PERSIST_FIRST_READ}{1}
 Retain data until the first access, then the data is deleted.
 %
-\declareconstitem{PMIX_PERSIST_PROC}
+\declareconstitemvalue{PMIX_PERSIST_PROC}{2}
 Retain data until the publishing process terminates.
 %
-\declareconstitem{PMIX_PERSIST_APP}
+\declareconstitemvalue{PMIX_PERSIST_APP}{3}
 Retain data until the application terminates.
 %
-\declareconstitem{PMIX_PERSIST_SESSION}
+\declareconstitemvalue{PMIX_PERSIST_SESSION}{4}
 Retain data until the session/allocation terminates.
 %
-\declareconstitem{PMIX_PERSIST_INVALID}
+\declareconstitemvalue{PMIX_PERSIST_INVALID}{UINT8_MAX}
 Invalid value - typically used to indicate that a persistence has not yet been set.
 %
 \end{constantdesc}

--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -1343,7 +1343,7 @@ Constants supporting attribute registration.
 
 \begin{constantdesc}
 %
-\declareconstitemNEW{PMIX_ERR_REPEAT_ATTR_REGISTRATION}
+\declareconstitemvalueNEW{PMIX_ERR_REPEAT_ATTR_REGISTRATION}{-171}
 The attributes for an identical function have already been registered at the specified level (host, server, or client).
 %
 \end{constantdesc}
@@ -4104,10 +4104,10 @@ The \refstruct{pmix_group_operation_t} structure is a \code{uint8_t} value for s
 
 \begin{constantdesc}
 %
-\declareconstitemNEW{PMIX_GROUP_CONSTRUCT}
+\declareconstitemvalueNEW{PMIX_GROUP_CONSTRUCT}{0}
 Construct a group composed of the specified processes - used by a \ac{PMIx} server library to direct host operation.
 %
-\declareconstitemNEW{PMIX_GROUP_DESTRUCT}
+\declareconstitemvalueNEW{PMIX_GROUP_DESTRUCT}{1}
 Destruct the specified group - used by a \ac{PMIx} server library to direct host operation.
 %
 \end{constantdesc}

--- a/Chap_API_Sets_Groups.tex
+++ b/Chap_API_Sets_Groups.tex
@@ -83,10 +83,10 @@ notifications must register for the corresponding event:
 
 \begin{constantdesc}
 %
-\declareconstitemNEW{PMIX_PROCESS_SET_DEFINE}
+\declareconstitemvalueNEW{PMIX_PROCESS_SET_DEFINE}{-55}
 The host environment has defined a new process set - the event will include the process set name (\refattr{PMIX_PSET_NAME}) and the membership (\refattr{PMIX_PSET_MEMBERS}).
 %
-\declareconstitemNEW{PMIX_PROCESS_SET_DELETE}
+\declareconstitemvalueNEW{PMIX_PROCESS_SET_DELETE}{-56}
 The host environment has deleted a process set - the event will include the process set name (\refattr{PMIX_PSET_NAME}).
 %
 \end{constantdesc}
@@ -183,40 +183,40 @@ Asynchronous process group operations rely heavily on \ac{PMIx} events.  The fol
 
 \begin{constantdesc}
 %
-\declareconstitemNEW{PMIX_GROUP_INVITED}
+\declareconstitemvalueNEW{PMIX_GROUP_INVITED}{-159}
 The process has been invited to join a \ac{PMIx} Group - the identifier of the group and the ID's of other invited (or already joined) members will be included in the notification.
 %
-\declareconstitemNEW{PMIX_GROUP_LEFT}
+\declareconstitemvalueNEW{PMIX_GROUP_LEFT}{-160}
 A process has asynchronously left a \ac{PMIx} Group - the process identifier of the departing process will in included in the notification.
 %
-\declareconstitemNEW{PMIX_GROUP_MEMBER_FAILED}
+\declareconstitemvalueNEW{PMIX_GROUP_MEMBER_FAILED}{-170}
 A member of a \ac{PMIx} Group has abnormally terminated (i.e., without formally leaving the group prior to termination) - the process identifier of the failed process will be included in the notification.
 %
-\declareconstitemNEW{PMIX_GROUP_INVITE_ACCEPTED}
+\declareconstitemvalueNEW{PMIX_GROUP_INVITE_ACCEPTED}{-161}
 A process has accepted an invitation to join a \ac{PMIx} Group - the identifier of the group being joined will be included in the notification.
 %
-\declareconstitemNEW{PMIX_GROUP_INVITE_DECLINED}
+\declareconstitemvalueNEW{PMIX_GROUP_INVITE_DECLINED}{-162}
 A process has declined an invitation to join a \ac{PMIx} Group - the identifier of the declined group will be included in the notification.
 %
-\declareconstitemNEW{PMIX_GROUP_INVITE_FAILED}
+\declareconstitemvalueNEW{PMIX_GROUP_INVITE_FAILED}{-163}
 An invited process failed or terminated prior to responding to the invitation - the identifier of the failed process will be included in the notification.
 %
-\declareconstitemNEW{PMIX_GROUP_MEMBERSHIP_UPDATE}
+\declareconstitemvalueNEW{PMIX_GROUP_MEMBERSHIP_UPDATE}{-164}
 The membership of a \ac{PMIx} group has changed - the identifiers of the revised membership will be included in the notification.
 %
-\declareconstitemNEW{PMIX_GROUP_CONSTRUCT_ABORT}
+\declareconstitemvalueNEW{PMIX_GROUP_CONSTRUCT_ABORT}{-165}
 Any participant in a \ac{PMIx} group construct operation that returns \refconst{PMIX_GROUP_CONSTRUCT_ABORT} from the \emph{leader failed} event handler will cause all participants to receive an event notifying them of that status. Similarly, the leader may elect to abort the procedure by either returning this error code from the handler assigned to the \refconst{PMIX_GROUP_INVITE_ACCEPTED} or \refconst{PMIX_GROUP_INVITE_DECLINED} codes, or by generating an event for the abort code. Abort events will be sent to all invited or existing members of the group.
 %
-\declareconstitemNEW{PMIX_GROUP_CONSTRUCT_COMPLETE}
+\declareconstitemvalueNEW{PMIX_GROUP_CONSTRUCT_COMPLETE}{-166}
 The group construct operation has completed - the final membership will be included in the notification.
 %
-\declareconstitemNEW{PMIX_GROUP_LEADER_FAILED}
+\declareconstitemvalueNEW{PMIX_GROUP_LEADER_FAILED}{-168}
 The current \emph{leader} of a group including this process has abnormally terminated - the group identifier will be included in the notification.
 %
-\declareconstitemNEW{PMIX_GROUP_LEADER_SELECTED}
+\declareconstitemvalueNEW{PMIX_GROUP_LEADER_SELECTED}{-167}
 A new \emph{leader} of a group including this process has been selected - the identifier of the new leader will be included in the notification.
 %
-\declareconstitemNEW{PMIX_GROUP_CONTEXT_ID_ASSIGNED}
+\declareconstitemvalueNEW{PMIX_GROUP_CONTEXT_ID_ASSIGNED}{-169}
 A new \ac{PGCID} has been assigned by the host environment to a group that includes this process - the group identifier will be included in the notification.
 %
 \end{constantdesc}
@@ -849,10 +849,10 @@ The \refstruct{pmix_group_opt_t} type is a \code{uint8_t} value used with the \r
 
 \begin{constantdesc}
 %
-\declareconstitem{PMIX_GROUP_DECLINE}
+\declareconstitemvalue{PMIX_GROUP_DECLINE}{0}
 Decline the invitation.
 %
-\declareconstitem{PMIX_GROUP_ACCEPT}
+\declareconstitemvalue{PMIX_GROUP_ACCEPT}{1}
 Accept the invitation.
 %
 \end{constantdesc}

--- a/Chap_API_Storage.tex
+++ b/Chap_API_Storage.tex
@@ -23,25 +23,25 @@ The \refstruct{pmix_storage_medium_t} is a \code{uint64_t} type that defines a s
 
 \begin{constantdesc}
 %
-\declareconstitemProvisional{PMIX_STORAGE_MEDIUM_UNKNOWN}
+\declareconstitemvalueProvisional{PMIX_STORAGE_MEDIUM_UNKNOWN}{0x0000000000000001}
 The storage medium type is unknown.
 %
-\declareconstitemProvisional{PMIX_STORAGE_MEDIUM_TAPE}
+\declareconstitemvalueProvisional{PMIX_STORAGE_MEDIUM_TAPE}{0x0000000000000002}
 The storage system uses tape media.
 %
-\declareconstitemProvisional{PMIX_STORAGE_MEDIUM_HDD}
+\declareconstitemvalueProvisional{PMIX_STORAGE_MEDIUM_HDD}{0x0000000000000004}
 The storage system uses HDDs with traditional SAS, SATA interfaces.
 %
-\declareconstitemProvisional{PMIX_STORAGE_MEDIUM_SSD}
+\declareconstitemvalueProvisional{PMIX_STORAGE_MEDIUM_SSD}{0x0000000000000008}
 The storage system uses SSDs with traditional SAS, SATA interfaces.
 %
-\declareconstitemProvisional{PMIX_STORAGE_MEDIUM_NVME}
+\declareconstitemvalueProvisional{PMIX_STORAGE_MEDIUM_NVME}{0x0000000000000010}
 The storage system uses SSDs with NVMe interface.
 %
-\declareconstitemProvisional{PMIX_STORAGE_MEDIUM_PMEM}
+\declareconstitemvalueProvisional{PMIX_STORAGE_MEDIUM_PMEM}{0x0000000000000020}
 The storage system uses persistent memory.
 %
-\declareconstitemProvisional{PMIX_STORAGE_MEDIUM_RAM}
+\declareconstitemvalueProvisional{PMIX_STORAGE_MEDIUM_RAM}{0x0000000000000040}
 The storage system is volatile (e.g., tmpfs).
 %
 \end{constantdesc}

--- a/Chap_API_Storage.tex
+++ b/Chap_API_Storage.tex
@@ -59,22 +59,22 @@ The \refstruct{pmix_storage_accessibility_t} is a \code{uint64_t} type that defi
 
 \begin{constantdesc}
 %
-\declareconstitemProvisional{PMIX_STORAGE_ACCESSIBILITY_NODE}
+\declareconstitemvalueProvisional{PMIX_STORAGE_ACCESSIBILITY_NODE}{0x0000000000000001}
 The storage system resources are accessible within the same node.
 %
-\declareconstitemProvisional{PMIX_STORAGE_ACCESSIBILITY_SESSION}
+\declareconstitemvalueProvisional{PMIX_STORAGE_ACCESSIBILITY_SESSION}{0x0000000000000002}
 The storage system resources are accessible within the same session.
 %
-\declareconstitemProvisional{PMIX_STORAGE_ACCESSIBILITY_JOB}
+\declareconstitemvalueProvisional{PMIX_STORAGE_ACCESSIBILITY_JOB}{0x0000000000000004}
 The storage system resources are accessible within the same job.
 %
-\declareconstitemProvisional{PMIX_STORAGE_ACCESSIBILITY_RACK}
+\declareconstitemvalueProvisional{PMIX_STORAGE_ACCESSIBILITY_RACK}{0x0000000000000008}
 The storage system resources are accessible within the same rack.
 %
-\declareconstitemProvisional{PMIX_STORAGE_ACCESSIBILITY_CLUSTER}
+\declareconstitemvalueProvisional{PMIX_STORAGE_ACCESSIBILITY_CLUSTER}{0x0000000000000010}
 The storage system resources are accessible within the same cluster.
 %
-\declareconstitemProvisional{PMIX_STORAGE_ACCESSIBILITY_REMOTE}
+\declareconstitemvalueProvisional{PMIX_STORAGE_ACCESSIBILITY_REMOTE}{0x0000000000000020}
 The storage system resources are remote.
 %
 \end{constantdesc}
@@ -82,29 +82,29 @@ The storage system resources are remote.
 \declarestruct{pmix_storage_persistence_t}
 \provisionalMarker{}
 
-The \refstruct{pmix_storage_persistence_t} type specifies different levels of persistence for a particular storage system.
+The \refstruct{pmix_storage_persistence_t} is a \code{uint64_t} type that defines a set of bit-mask flags for specifying different levels of persistence for a particular storage system.
 
 \begin{constantdesc}
 %
-\declareconstitemProvisional{PMIX_STORAGE_PERSISTENCE_TEMPORARY}
+\declareconstitemvalueProvisional{PMIX_STORAGE_PERSISTENCE_TEMPORARY}{0x0000000000000001}
 Data on the storage system is persisted only temporarily (i.e, it does not survive across sessions or node reboots).
 %
-\declareconstitemProvisional{PMIX_STORAGE_PERSISTENCE_NODE}
+\declareconstitemvalueProvisional{PMIX_STORAGE_PERSISTENCE_NODE}{0x0000000000000002}
 Data on the storage system is persisted on the node.
 %
-\declareconstitemProvisional{PMIX_STORAGE_PERSISTENCE_SESSION}
+\declareconstitemvalueProvisional{PMIX_STORAGE_PERSISTENCE_SESSION}{0x0000000000000004}
 Data on the storage system is persisted for the duration of the session.
 %
-\declareconstitemProvisional{PMIX_STORAGE_PERSISTENCE_JOB}
+\declareconstitemvalueProvisional{PMIX_STORAGE_PERSISTENCE_JOB}{0x0000000000000008}
 Data on the storage system is persisted for the duration of the job.
 %
-\declareconstitemProvisional{PMIX_STORAGE_PERSISTENCE_SCRATCH}
+\declareconstitemvalueProvisional{PMIX_STORAGE_PERSISTENCE_SCRATCH}{0x0000000000000010}
 Data on the storage system is persisted according to scratch storage policies (short-term storage, typically persisted for days to weeks).
 %
-\declareconstitemProvisional{PMIX_STORAGE_PERSISTENCE_PROJECT}
+\declareconstitemvalueProvisional{PMIX_STORAGE_PERSISTENCE_PROJECT}{0x0000000000000020}
 Data on the storage system is persisted according to project storage policies (long-term storage, typically persisted for the duration of a project).
 %
-\declareconstitemProvisional{PMIX_STORAGE_PERSISTENCE_ARCHIVE}
+\declareconstitemvalueProvisional{PMIX_STORAGE_PERSISTENCE_ARCHIVE}{0x0000000000000040}
 Data on the storage system is persisted according to archive storage policies (long-term storage, typically persisted indefinitely).
 %
 \end{constantdesc}
@@ -112,17 +112,17 @@ Data on the storage system is persisted according to archive storage policies (l
 \declarestruct{pmix_storage_access_type_t}
 \provisionalMarker{}
 
-The \refstruct{pmix_storage_access_type_t} type specifies different storage system access types.
+The \refstruct{pmix_storage_access_type_t} is a \code{uint16_t} type that defines a set of bit-mask flags for specifying different storage system access types.
 
 \begin{constantdesc}
 %
-\declareconstitemProvisional{PMIX_STORAGE_ACCESS_RD}
+\declareconstitemvalueProvisional{PMIX_STORAGE_ACCESS_RD}{0x0001}
 Provide information on storage system read operations.
 %
-\declareconstitemProvisional{PMIX_STORAGE_ACCESS_WR}
+\declareconstitemvalueProvisional{PMIX_STORAGE_ACCESS_WR}{0x0002}
 Provide information on storage system write operations.
 %
-\declareconstitemProvisional{PMIX_STORAGE_ACCESS_RDWR}
+\declareconstitemvalueProvisional{PMIX_STORAGE_ACCESS_RDWR}{0x0003}
 Provide information on storage system read and write operations.
 %
 \end{constantdesc}

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -67,7 +67,7 @@ Additional constants associated with specific data structures or types are defin
 
 \begin{constantdesc}
 %
-\declareconstitemvalue{PMIX_MAX_NSLEN}{255}
+\declareconstitem{PMIX_MAX_NSLEN}
 Maximum namespace string length as an integer.
 \end{constantdesc}
 
@@ -78,7 +78,7 @@ a space of size \refconst{PMIX_MAX_NSLEN}+1 to allow room for the \code{NULL} te
 
 \begin{constantdesc}
 %
-\declareconstitemvalue{PMIX_MAX_KEYLEN}{511}
+\declareconstitem{PMIX_MAX_KEYLEN}
 Maximum key string length as an integer.
 \end{constantdesc}
 
@@ -104,7 +104,7 @@ The \refstruct{pmix_status_t} type is an \code{int} compatible value for return 
 \refconst{PMIX_SUCCESS}, which must have an integer value of 0:
  
 \begin{constantdesc}
-\declareconstitem{PMIX_SUCCESS}
+\declareconstitemvalue{PMIX_SUCCESS}{0}
 Success.
 \end{constantdesc}
 
@@ -124,9 +124,6 @@ The presentation of each \ac{API} in this document includes a list of return sta
 In addition, the following are general constants covering a variety of possible reasons an implementation of an \ac{API} may return a constant other than one of the constants presented with the \ac{API}.  Although implementations can define and return additional error constants, implementations are encouraged to return one of the return constants listed with the \ac{API} or in the list presented here to encourage portability across implementations. 
 
 \begin{constantdesc}
-%
-\declareconstitemvalue{PMIX_SUCCESS}{0}
-Success.
 %
 \declareconstitemvalue{PMIX_ERROR}{-1}
 General Error.

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -240,7 +240,7 @@ The operation is considered successful but not all elements of the operation wer
 
 \begin{constantdesc}
 %
-\declareconstitemvalue{PMIX_EXTERNAL_ERR_BASE}{-3000}
+\declareconstitem{PMIX_EXTERNAL_ERR_BASE}
 A starting point for user-level defined error and event constants.
 Negative values that are more negative than the defined constant are guaranteed not to conflict with \ac{PMIx} values.
 Definitions should always be based on the \refconst{PMIX_EXTERNAL_ERR_BASE} constant and not a specific value as the value of the constant may change.
@@ -724,14 +724,14 @@ Process has been locally \code{fork}'ed by the \ac{RM}.
 \declareconstitemvalue{PMIX_PROC_STATE_CONNECTED}{6}
 Process has connected to PMIx server.
 %
-\declareconstitemvalue{PMIX_PROC_STATE_UNTERMINATED}{15}
+\declareconstitem{PMIX_PROC_STATE_UNTERMINATED}
 Define a ``boundary'' between the terminated states and \refconst{PMIX_PROC_STATE_CONNECTED} so users can easily and quickly determine if a process is still running or not.
 Any value less than this constant means that the process has not terminated.
 %
-\declareconstitemvalue{PMIX_PROC_STATE_TERMINATED}{20}
+\declareconstitem{PMIX_PROC_STATE_TERMINATED}
 Process has terminated and is no longer running.
 %
-\declareconstitemvalue{PMIX_PROC_STATE_ERROR}{50}
+\declareconstitem{PMIX_PROC_STATE_ERROR}
 Define a boundary so users can easily and quickly determine if a process abnormally terminated.
 Any value above this constant means that the process has terminated abnormally.
 %
@@ -911,14 +911,14 @@ All processes in the job have been suspended.
 \declareconstitemvalueNEW{PMIX_JOB_STATE_CONNECTED}{5}
 All processes in the job have connected to their \ac{PMIx} server.
 %
-\declareconstitemvalueNEW{PMIX_JOB_STATE_UNTERMINATED}{15}
+\declareconstitemNEW{PMIX_JOB_STATE_UNTERMINATED}
 Define a ``boundary'' between the terminated states and \refconst{PMIX_JOB_STATE_TERMINATED} so users can easily and quickly determine if a job is still running or not.
 Any value less than this constant means that the job has not terminated.
 %
-\declareconstitemvalueNEW{PMIX_JOB_STATE_TERMINATED}{20}
+\declareconstitemNEW{PMIX_JOB_STATE_TERMINATED}
 All processes in the job have terminated and are no longer running - typically will be accompanied by the job exit status in response to a query.
 %
-\declareconstitemvalueNEW{PMIX_JOB_STATE_TERMINATED_WITH_ERROR}{50}
+\declareconstitemNEW{PMIX_JOB_STATE_TERMINATED_WITH_ERROR}
 Define a boundary so users can easily and quickly determine if a job abnormally terminated - typically will be accompanied by a job-related error code in response to a query
 Any value above this constant means that the job terminated abnormally.
 %
@@ -2223,7 +2223,7 @@ Bitmask specifying different levels of persistence for a particular storage syst
 \declareconstitemvalueNEW{PMIX_STOR_ACCESS_TYPE}{69}
 Bitmask specifying different storage system access types. (\refstruct{pmix_storage_access_type_t}).
 %
-\declareconstitemvalueNEW{PMIX_DATA_TYPE_MAX}{500}
+\declareconstitemNEW{PMIX_DATA_TYPE_MAX}
 A starting point for implementer-specific data types.
 Values above this are guaranteed not to conflict with \ac{PMIx} values.
 Definitions should always be based on the \refconst{PMIX_DATA_TYPE_MAX} constant and not a specific value as the value of the constant may change.

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -67,7 +67,7 @@ Additional constants associated with specific data structures or types are defin
 
 \begin{constantdesc}
 %
-\declareconstitem{PMIX_MAX_NSLEN}
+\declareconstitemvalue{PMIX_MAX_NSLEN}{255}
 Maximum namespace string length as an integer.
 \end{constantdesc}
 
@@ -78,7 +78,7 @@ a space of size \refconst{PMIX_MAX_NSLEN}+1 to allow room for the \code{NULL} te
 
 \begin{constantdesc}
 %
-\declareconstitem{PMIX_MAX_KEYLEN}
+\declareconstitemvalue{PMIX_MAX_KEYLEN}{511}
 Maximum key string length as an integer.
 \end{constantdesc}
 
@@ -89,7 +89,7 @@ a space of size \refconst{PMIX_MAX_KEYLEN}+1 to allow room for the \code{NULL} t
 
 \begin{constantdesc}
 %
-\declareconstitemNEW{PMIX_APP_WILDCARD}
+\declareconstitemvalueNEW{PMIX_APP_WILDCARD}{UINT32_MAX}
 A value to indicate that the user wants the data for the given key from every application that posted that key, or that the given value applies to all applications within the given namespace.
 \end{constantdesc}
 
@@ -125,105 +125,108 @@ In addition, the following are general constants covering a variety of possible 
 
 \begin{constantdesc}
 %
-\declareconstitem{PMIX_ERROR}
+\declareconstitemvalue{PMIX_SUCCESS}{0}
+Success.
+%
+\declareconstitemvalue{PMIX_ERROR}{-1}
 General Error.
 %
-\declareconstitemNEW{PMIX_ERR_EXISTS}
-Requested operation would overwrite an existing value - typically returned
+\declareconstitemvalueNEW{PMIX_ERR_EXISTS}{-11}
+The requested operation would overwrite an existing value - typically returned
 when an operation would overwrite an existing file or directory.
 %
-\declareconstitemNEW{PMIX_ERR_EXISTS_OUTSIDE_SCOPE}
+\declareconstitemvalueNEW{PMIX_ERR_EXISTS_OUTSIDE_SCOPE}{-62}
 The requested key exists, but was posted in a \emph{scope} (see Section \ref{api:nres:scope}) that does not include the requester
 %
-\declareconstitem{PMIX_ERR_INVALID_CRED}
+\declareconstitemvalue{PMIX_ERR_INVALID_CRED}{-12}
 Invalid security credentials.
 %
-\declareconstitem{PMIX_ERR_WOULD_BLOCK}
+\declareconstitemvalue{PMIX_ERR_WOULD_BLOCK}{-15}
 Operation would block.
 %
-\declareconstitem{PMIX_ERR_UNKNOWN_DATA_TYPE}
+\declareconstitemvalue{PMIX_ERR_UNKNOWN_DATA_TYPE}{-16}
 The data type specified in an input to the \ac{PMIx} library is not recognized
 by the implementation.
 %
-\declareconstitem{PMIX_ERR_TYPE_MISMATCH}
+\declareconstitemvalue{PMIX_ERR_TYPE_MISMATCH}{-18}
 The data type found in an object does not match the expected data type
 as specified in the \ac{API} call - e.g., a request to unpack a
 \refconst{PMIX_BOOL} value from a buffer that does not contain a value of
 that type in the current unpack location.
 %
-\declareconstitem{PMIX_ERR_UNPACK_INADEQUATE_SPACE}
+\declareconstitemvalue{PMIX_ERR_UNPACK_INADEQUATE_SPACE}{-19}
 Inadequate space to unpack data - the number of values in the buffer exceeds
 the specified number to unpack.
 %
-\declareconstitem{PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER}
+\declareconstitemvalue{PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER}{-50}
 Unpacking past the end of the provided buffer - the number of values in the
 buffer is less than the specified number to unpack, or a request was made to
 unpack a buffer beyond the buffer's end.
 %
-\declareconstitem{PMIX_ERR_UNPACK_FAILURE}
+\declareconstitemvalue{PMIX_ERR_UNPACK_FAILURE}{-20}
 The unpack operation failed for an unspecified reason.
 %
-\declareconstitem{PMIX_ERR_PACK_FAILURE}
+\declareconstitemvalue{PMIX_ERR_PACK_FAILURE}{-21}
 The pack operation failed for an unspecified reason.
 %
-\declareconstitem{PMIX_ERR_NO_PERMISSIONS}
+\declareconstitemvalue{PMIX_ERR_NO_PERMISSIONS}{-23}
 The user lacks permissions to execute the specified operation.
 %
-\declareconstitem{PMIX_ERR_TIMEOUT}
+\declareconstitemvalue{PMIX_ERR_TIMEOUT}{-24}
 Either a user-specified or system-internal timeout expired.
 %
-\declareconstitem{PMIX_ERR_UNREACH}
+\declareconstitemvalue{PMIX_ERR_UNREACH}{-25}
 The specified target server or client process is not reachable - i.e., a
 suitable connection either has not been or can not be made.
 %
-\declareconstitem{PMIX_ERR_BAD_PARAM}
+\declareconstitemvalue{PMIX_ERR_BAD_PARAM}{-27}
 One or more incorrect parameters (e.g., passing an attribute with a value of the wrong type), or multiple parameters containing conflicting directives (e.g., multiple instances of the same attribute with different values, or different attributes specifying conflicting behaviors), were passed to a \ac{PMIx} \ac{API}.
 %
-\declareconstitemNEW{PMIX_ERR_EMPTY}
+\declareconstitemvalueNEW{PMIX_ERR_EMPTY}{-60}
 An array or list was given that has no members in it - i.e., the object is empty.
 %
-\declareconstitem{PMIX_ERR_RESOURCE_BUSY}
+\declareconstitemvalue{PMIX_ERR_RESOURCE_BUSY}{-28}
 Resource busy - typically seen when an attempt to establish a connection
 to another process (e.g., a \ac{PMIx} server) cannot be made due to a
 communication failure.
 %
-\declareconstitem{PMIX_ERR_OUT_OF_RESOURCE}
+\declareconstitemvalue{PMIX_ERR_OUT_OF_RESOURCE}{-29}
 Resource exhausted.
 %
-\declareconstitem{PMIX_ERR_INIT}
+\declareconstitemvalue{PMIX_ERR_INIT}{-31}
 The requested operation requires that the \ac{PMIx} library be initialized prior to being called.
 %
-\declareconstitem{PMIX_ERR_NOMEM}
+\declareconstitemvalue{PMIX_ERR_NOMEM}{-32}
 Out of memory.
 %
-\declareconstitem{PMIX_ERR_NOT_FOUND}
+\declareconstitemvalue{PMIX_ERR_NOT_FOUND}{-46}
 The requested information was not found.
 %
-\declareconstitem{PMIX_ERR_NOT_SUPPORTED}
+\declareconstitemvalue{PMIX_ERR_NOT_SUPPORTED}{-47}
 The requested operation is not supported by either the \ac{PMIx} implementation
 or the host environment.
 %
-\declareconstitemNEW{PMIX_ERR_PARAM_VALUE_NOT_SUPPORTED}
+\declareconstitemvalueNEW{PMIX_ERR_PARAM_VALUE_NOT_SUPPORTED}{-59}
 The requested operation is supported by the \ac{PMIx} implementation and (if applicable) the host environment. However, at least one supplied parameter was given an unsupported value, and the operation cannot therefore be executed as requested.
 %
-\declareconstitem{PMIX_ERR_COMM_FAILURE}
+\declareconstitemvalue{PMIX_ERR_COMM_FAILURE}{-49}
 Communication failure - a message failed to be sent or received, but the
 connection remains intact.
 %
-\declareconstitemNEW{PMIX_ERR_LOST_CONNECTION}
+\declareconstitemvalueNEW{PMIX_ERR_LOST_CONNECTION}{-61}
 Lost connection between server and client or tool.
 %
-\declareconstitem{PMIX_ERR_INVALID_OPERATION}
+\declareconstitemvalue{PMIX_ERR_INVALID_OPERATION}{-158}
 The requested operation is supported by the implementation and host environment, but fails to meet a requirement (e.g., requesting to \textit{disconnect} from processes without first \textit{connecting} to them, inclusion of conflicting directives, or a request to perform an operation that conflicts with an ongoing one).
 %
-\declareconstitem{PMIX_OPERATION_IN_PROGRESS}
+\declareconstitemvalue{PMIX_OPERATION_IN_PROGRESS}{-156}
 A requested operation is already in progress - the duplicate request
 shall therefore be ignored.
 %
-\declareconstitem{PMIX_OPERATION_SUCCEEDED}
+\declareconstitemvalue{PMIX_OPERATION_SUCCEEDED}{-157}
 The requested operation was performed atomically - no callback function will be executed.
 %
-\declareconstitemNEW{PMIX_ERR_PARTIAL_SUCCESS}
+\declareconstitemvalueNEW{PMIX_ERR_PARTIAL_SUCCESS}{-52}
 The operation is considered successful but not all elements of the operation were concluded (e.g., some members of a group construct operation chose not to participate).
 %
 \end{constantdesc}
@@ -237,7 +240,7 @@ The operation is considered successful but not all elements of the operation wer
 
 \begin{constantdesc}
 %
-\declareconstitem{PMIX_EXTERNAL_ERR_BASE}
+\declareconstitemvalue{PMIX_EXTERNAL_ERR_BASE}{-3000}
 A starting point for user-level defined error and event constants.
 Negative values that are more negative than the defined constant are guaranteed not to conflict with \ac{PMIx} values.
 Definitions should always be based on the \refconst{PMIX_EXTERNAL_ERR_BASE} constant and not a specific value as the value of the constant may change.
@@ -410,24 +413,24 @@ The following constants can be used to set a variable of the type \refstruct{pmi
 
 \begin{constantdesc}
 %
-\declareconstitem{PMIX_RANK_UNDEF}
+\declareconstitemvalue{PMIX_RANK_UNDEF}{UINT32_MAX}
 A value to request job-level data where the information itself is not associated with any specific rank, or when passing a \refstruct{pmix_proc_t} identifier to an operation that only references the namespace field of that structure.
 %
-\declareconstitem{PMIX_RANK_WILDCARD}
+\declareconstitemvalue{PMIX_RANK_WILDCARD}{UINT32_MAX-1}
 A value to indicate that the user wants the data for the given key from every rank that posted that key.
 %
-\declareconstitem{PMIX_RANK_LOCAL_NODE}
+\declareconstitemvalue{PMIX_RANK_LOCAL_NODE}{UINT32_MAX-2}
 Special rank value used to define groups of ranks.
 This constant defines the group of all ranks on a local node.
 %
-\declareconstitem{PMIX_RANK_LOCAL_PEERS}
+\declareconstitemvalue{PMIX_RANK_LOCAL_PEERS}{UINT32_MAX-4}
 Special rank value used to define groups of ranks.
 This constant defines the group of all ranks on a local node within the same namespace as the current process.
 %
-\declareconstitem{PMIX_RANK_INVALID}
+\declareconstitemvalue{PMIX_RANK_INVALID}{UINT32_MAX-3}
 An invalid rank value.
 %
-\declareconstitem{PMIX_RANK_VALID}
+\declareconstitemvalue{PMIX_RANK_VALID}{UINT32_MAX-50}
 Define an upper boundary for valid rank values.
 %
 \end{constantdesc}
@@ -700,75 +703,75 @@ The fine-grained nature of the following constants may exceed the ability of an 
 
 \begin{constantdesc}
 %
-\declareconstitem{PMIX_PROC_STATE_UNDEF}
+\declareconstitemvalue{PMIX_PROC_STATE_UNDEF}{0}
 Undefined process state.
 %
-\declareconstitem{PMIX_PROC_STATE_PREPPED}
+\declareconstitemvalue{PMIX_PROC_STATE_PREPPED}{1}
 Process is ready to be launched.
 %
-\declareconstitem{PMIX_PROC_STATE_LAUNCH_UNDERWAY}
+\declareconstitemvalue{PMIX_PROC_STATE_LAUNCH_UNDERWAY}{2}
 Process launch is underway.
 %
-\declareconstitem{PMIX_PROC_STATE_RESTART}
+\declareconstitemvalue{PMIX_PROC_STATE_RESTART}{3}
 Process is ready for restart.
 %
-\declareconstitem{PMIX_PROC_STATE_TERMINATE}
+\declareconstitemvalue{PMIX_PROC_STATE_TERMINATE}{4}
 Process is marked for termination.
 %
-\declareconstitem{PMIX_PROC_STATE_RUNNING}
+\declareconstitemvalue{PMIX_PROC_STATE_RUNNING}{5}
 Process has been locally \code{fork}'ed by the \ac{RM}.
 %
-\declareconstitem{PMIX_PROC_STATE_CONNECTED}
+\declareconstitemvalue{PMIX_PROC_STATE_CONNECTED}{6}
 Process has connected to PMIx server.
 %
-\declareconstitem{PMIX_PROC_STATE_UNTERMINATED}
+\declareconstitemvalue{PMIX_PROC_STATE_UNTERMINATED}{15}
 Define a ``boundary'' between the terminated states and \refconst{PMIX_PROC_STATE_CONNECTED} so users can easily and quickly determine if a process is still running or not.
 Any value less than this constant means that the process has not terminated.
 %
-\declareconstitem{PMIX_PROC_STATE_TERMINATED}
+\declareconstitemvalue{PMIX_PROC_STATE_TERMINATED}{20}
 Process has terminated and is no longer running.
 %
-\declareconstitem{PMIX_PROC_STATE_ERROR}
+\declareconstitemvalue{PMIX_PROC_STATE_ERROR}{50}
 Define a boundary so users can easily and quickly determine if a process abnormally terminated.
 Any value above this constant means that the process has terminated abnormally.
 %
-\declareconstitem{PMIX_PROC_STATE_KILLED_BY_CMD}
+\declareconstitemvalue{PMIX_PROC_STATE_KILLED_BY_CMD}{51}
 Process was killed by a command.
 %
-\declareconstitem{PMIX_PROC_STATE_ABORTED}
+\declareconstitemvalue{PMIX_PROC_STATE_ABORTED}{52}
 Process was aborted by a call to \refapi{PMIx_Abort}.
 %
-\declareconstitem{PMIX_PROC_STATE_FAILED_TO_START}
+\declareconstitemvalue{PMIX_PROC_STATE_FAILED_TO_START}{53}
 Process failed to start.
 %
-\declareconstitem{PMIX_PROC_STATE_ABORTED_BY_SIG}
+\declareconstitemvalue{PMIX_PROC_STATE_ABORTED_BY_SIG}{54}
 Process aborted by a signal.
 %
-\declareconstitem{PMIX_PROC_STATE_TERM_WO_SYNC}
+\declareconstitemvalue{PMIX_PROC_STATE_TERM_WO_SYNC}{55}
 Process exited without calling \refapi{PMIx_Finalize}.
 %
-\declareconstitem{PMIX_PROC_STATE_COMM_FAILED}
+\declareconstitemvalue{PMIX_PROC_STATE_COMM_FAILED}{56}
 Process communication has failed.
 %
-\declareconstitemNEW{PMIX_PROC_STATE_SENSOR_BOUND_EXCEEDED}
+\declareconstitemvalueNEW{PMIX_PROC_STATE_SENSOR_BOUND_EXCEEDED}{57}
 Process exceeded a specified sensor limit.
 %
-\declareconstitem{PMIX_PROC_STATE_CALLED_ABORT}
+\declareconstitemvalue{PMIX_PROC_STATE_CALLED_ABORT}{58}
 Process called \refapi{PMIx_Abort}.
 %
-\declareconstitemNEW{PMIX_PROC_STATE_HEARTBEAT_FAILED}
+\declareconstitemvalueNEW{PMIX_PROC_STATE_HEARTBEAT_FAILED}{59}
 Frocess failed to send heartbeat within specified time limit.
 %
-\declareconstitem{PMIX_PROC_STATE_MIGRATING}
+\declareconstitemvalue{PMIX_PROC_STATE_MIGRATING}{60}
 Process failed and is waiting for resources before restarting.
 %
-\declareconstitem{PMIX_PROC_STATE_CANNOT_RESTART}
+\declareconstitemvalue{PMIX_PROC_STATE_CANNOT_RESTART}{61}
 Process failed and cannot be restarted.
 %
-\declareconstitem{PMIX_PROC_STATE_TERM_NON_ZERO}
+\declareconstitemvalue{PMIX_PROC_STATE_TERM_NON_ZERO}{62}
 Process exited with a non-zero status.
 %
-\declareconstitem{PMIX_PROC_STATE_FAILED_TO_LAUNCH}
+\declareconstitemvalue{PMIX_PROC_STATE_FAILED_TO_LAUNCH}{63}
 Unable to launch process.
 %
 \end{constantdesc}
@@ -890,32 +893,32 @@ The fine-grained nature of the following constants may exceed the ability of an 
 
 \begin{constantdesc}
 %
-\declareconstitemNEW{PMIX_JOB_STATE_UNDEF}
+\declareconstitemvalueNEW{PMIX_JOB_STATE_UNDEF}{0}
 Undefined job state.
 %
-\declareconstitemNEW{PMIX_JOB_STATE_AWAITING_ALLOC}
+\declareconstitemvalueNEW{PMIX_JOB_STATE_AWAITING_ALLOC}{1}
 Job is waiting for resources to be allocated to it.
 %
-\declareconstitemNEW{PMIX_JOB_STATE_LAUNCH_UNDERWAY}
+\declareconstitemvalueNEW{PMIX_JOB_STATE_LAUNCH_UNDERWAY}{2}
 Job launch is underway.
 %
-\declareconstitemNEW{PMIX_JOB_STATE_RUNNING}
+\declareconstitemvalueNEW{PMIX_JOB_STATE_RUNNING}{3}
 All processes in the job have been spawned and are executing.
 %
-\declareconstitemNEW{PMIX_JOB_STATE_SUSPENDED}
+\declareconstitemvalueNEW{PMIX_JOB_STATE_SUSPENDED}{4}
 All processes in the job have been suspended.
 %
-\declareconstitemNEW{PMIX_JOB_STATE_CONNECTED}
+\declareconstitemvalueNEW{PMIX_JOB_STATE_CONNECTED}{5}
 All processes in the job have connected to their \ac{PMIx} server.
 %
-\declareconstitemNEW{PMIX_JOB_STATE_UNTERMINATED}
+\declareconstitemvalueNEW{PMIX_JOB_STATE_UNTERMINATED}{15}
 Define a ``boundary'' between the terminated states and \refconst{PMIX_JOB_STATE_TERMINATED} so users can easily and quickly determine if a job is still running or not.
 Any value less than this constant means that the job has not terminated.
 %
-\declareconstitemNEW{PMIX_JOB_STATE_TERMINATED}
+\declareconstitemvalueNEW{PMIX_JOB_STATE_TERMINATED}{20}
 All processes in the job have terminated and are no longer running - typically will be accompanied by the job exit status in response to a query.
 %
-\declareconstitemNEW{PMIX_JOB_STATE_TERMINATED_WITH_ERROR}
+\declareconstitemvalueNEW{PMIX_JOB_STATE_TERMINATED_WITH_ERROR}{50}
 Define a boundary so users can easily and quickly determine if a job abnormally terminated - typically will be accompanied by a job-related error code in response to a query
 Any value above this constant means that the job terminated abnormally.
 %
@@ -1404,16 +1407,16 @@ The following constants were introduced in version 2.0 (unless otherwise marked)
 
 \begin{constantdesc}
 %
-\declareconstitem{PMIX_INFO_REQD}
+\declareconstitemvalue{PMIX_INFO_REQD}{0x00000001}
 The behavior defined in the \refstruct{pmix_info_t} array is required, and not optional. This is a bit-mask value.
 %
-\declareconstitemNEW{PMIX_INFO_REQD_PROCESSED}
+\declareconstitemvalueNEW{PMIX_INFO_REQD_PROCESSED}{0x00000004}
 Mark that this required attribute has been processed. A required attribute can be handled at any level - the \ac{PMIx} client library might take care of it, or it may be resolved by the \ac{PMIx} server library, or it may pass up to the host environment for handling. If a level does not recognize or support the required attribute, it is required to pass it upwards to give the next level an opportunity to process it. Thus, the host environment (or the server library if the host does not support the given operation) must know if a lower level has handled the requirement so it can return a \refconst{PMIX_ERR_NOT_SUPPORTED} error status if the host itself cannot meet the request. Upon processing the request, the level must therefore mark the attribute with this directive to alert any subsequent levels that the requirement has been met.
 %
-\declareconstitem{PMIX_INFO_ARRAY_END}
+\declareconstitemvalue{PMIX_INFO_ARRAY_END}{0x00000002}
 Mark that this \refstruct{pmix_info_t} struct is at the end of an array created by the \refmacro{PMIX_INFO_CREATE} macro. This is a bit-mask value.
 %
-\declareconstitemNEW{PMIX_INFO_DIR_RESERVED}
+\declareconstitemvalueNEW{PMIX_INFO_DIR_RESERVED}{0xffff0000}
 A bit-mask identifying the bits reserved for internal use by implementers - these currently are set as \code{0xffff0000}.
 %
 \end{constantdesc}
@@ -2034,184 +2037,181 @@ The following constants can be used to set a variable of the type \refstruct{pmi
 
 \begin{constantdesc}
 %
-\declareconstitem{PMIX_UNDEF}
+\declareconstitemvalue{PMIX_UNDEF}{0}
 Undefined.
 %
-\declareconstitem{PMIX_BOOL}
+\declareconstitemvalue{PMIX_BOOL}{1}
 Boolean (converted to/from native \code{true}/\code{false}) (\code{bool}).
 %
-\declareconstitem{PMIX_BYTE}
+\declareconstitemvalue{PMIX_BYTE}{2}
 A byte of data (\code{uint8_t}).
 %
-\declareconstitem{PMIX_STRING}
+\declareconstitemvalue{PMIX_STRING}{3}
 \code{NULL} terminated string (\code{char*}).
 %
-\declareconstitem{PMIX_SIZE}
+\declareconstitemvalue{PMIX_SIZE}{4}
 Size \code{size_t}.
 %
-\declareconstitem{PMIX_PID}
+\declareconstitemvalue{PMIX_PID}{5}
 Operating \ac{PID} (\code{pid_t}).
 %
-\declareconstitem{PMIX_INT}
+\declareconstitemvalue{PMIX_INT}{6}
 Integer (\code{int}).
 %
-\declareconstitem{PMIX_INT8}
+\declareconstitemvalue{PMIX_INT8}{7}
 8-byte integer (\code{int8_t}).
 %
-\declareconstitem{PMIX_INT16}
+\declareconstitemvalue{PMIX_INT16}{8}
 16-byte integer (\code{int16_t}).
 %
-\declareconstitem{PMIX_INT32}
+\declareconstitemvalue{PMIX_INT32}{9}
 32-byte integer (\code{int32_t}).
 %
-\declareconstitem{PMIX_INT64}
+\declareconstitemvalue{PMIX_INT64}{10}
 64-byte integer (\code{int64_t}).
 %
-\declareconstitem{PMIX_UINT}
+\declareconstitemvalue{PMIX_UINT}{11}
 Unsigned integer (\code{unsigned int}).
 %
-\declareconstitem{PMIX_UINT8}
+\declareconstitemvalue{PMIX_UINT8}{12}
 Unsigned 8-byte integer (\code{uint8_t}).
 %
-\declareconstitem{PMIX_UINT16}
+\declareconstitemvalue{PMIX_UINT16}{13}
 Unsigned 16-byte integer (\code{uint16_t}).
 %
-\declareconstitem{PMIX_UINT32}
+\declareconstitemvalue{PMIX_UINT32}{14}
 Unsigned 32-byte integer (\code{uint32_t}).
 %
-\declareconstitem{PMIX_UINT64}
+\declareconstitemvalue{PMIX_UINT64}{15}
 Unsigned 64-byte integer (\code{uint64_t}).
 %
-\declareconstitem{PMIX_FLOAT}
+\declareconstitemvalue{PMIX_FLOAT}{16}
 Float (\code{float}).
 %
-\declareconstitem{PMIX_DOUBLE}
+\declareconstitemvalue{PMIX_DOUBLE}{17}
 Double (\code{double}).
 %
-\declareconstitem{PMIX_TIMEVAL}
+\declareconstitemvalue{PMIX_TIMEVAL}{18}
 Time value (\code{struct timeval}).
 %
-\declareconstitem{PMIX_TIME}
+\declareconstitemvalue{PMIX_TIME}{19}
 Time (\code{time_t}).
 %
-\declareconstitem{PMIX_STATUS}
+\declareconstitemvalue{PMIX_STATUS}{20}
 Status code {\refstruct{pmix_status_t}}.
 %
-\declareconstitem{PMIX_VALUE}
+\declareconstitemvalue{PMIX_VALUE}{21}
 Value (\refstruct{pmix_value_t}).
 %
-\declareconstitem{PMIX_PROC}
+\declareconstitemvalue{PMIX_PROC}{22}
 Process (\refstruct{pmix_proc_t}).
 %
-\declareconstitem{PMIX_APP}
+\declareconstitemvalue{PMIX_APP}{23}
 Application context.
 %
-\declareconstitem{PMIX_INFO}
+\declareconstitemvalue{PMIX_INFO}{24}
 Info object.
 %
-\declareconstitem{PMIX_PDATA}
+\declareconstitemvalue{PMIX_PDATA}{25}
 Pointer to data.
 %
-\declareconstitem{PMIX_BUFFER}
-Buffer.
-%
-\declareconstitem{PMIX_BYTE_OBJECT}
+\declareconstitemvalue{PMIX_BYTE_OBJECT}{27}
 Byte object (\refstruct{pmix_byte_object_t}).
 %
-\declareconstitem{PMIX_KVAL}
+\declareconstitemvalue{PMIX_KVAL}{28}
 Key/value pair.
 %
-\declareconstitem{PMIX_PERSIST}
+\declareconstitemvalue{PMIX_PERSIST}{30}
 Persistance (\refstruct{pmix_persistence_t}).
 %
-\declareconstitem{PMIX_POINTER}
+\declareconstitemvalue{PMIX_POINTER}{31}
 Pointer to an object (\code{void*}).
 %
-\declareconstitem{PMIX_SCOPE}
+\declareconstitemvalue{PMIX_SCOPE}{32}
 Scope (\refstruct{pmix_scope_t}).
 %
-\declareconstitem{PMIX_DATA_RANGE}
+\declareconstitemvalue{PMIX_DATA_RANGE}{33}
 Range for data (\refstruct{pmix_data_range_t}).
 %
-\declareconstitem{PMIX_COMMAND}
+\declareconstitemvalue{PMIX_COMMAND}{34}
 PMIx command code (used internally).
 %
-\declareconstitem{PMIX_INFO_DIRECTIVES}
+\declareconstitemvalue{PMIX_INFO_DIRECTIVES}{35}
 Directives flag for \refstruct{pmix_info_t} (\refstruct{pmix_info_directives_t}).
 %
-\declareconstitem{PMIX_DATA_TYPE}
+\declareconstitemvalue{PMIX_DATA_TYPE}{36}
 Data type code (\refstruct{pmix_data_type_t}).
 %
-\declareconstitem{PMIX_PROC_STATE}
+\declareconstitemvalue{PMIX_PROC_STATE}{37}
 Process state (\refstruct{pmix_proc_state_t}).
 %
-\declareconstitem{PMIX_PROC_INFO}
+\declareconstitemvalue{PMIX_PROC_INFO}{38}
 Process information (\refstruct{pmix_proc_info_t}).
 %
-\declareconstitem{PMIX_DATA_ARRAY}
+\declareconstitemvalue{PMIX_DATA_ARRAY}{39}
 Data array (\refstruct{pmix_data_array_t}).
 %
-\declareconstitem{PMIX_PROC_RANK}
+\declareconstitemvalue{PMIX_PROC_RANK}{40}
 Process rank (\refstruct{pmix_rank_t}).
 %
-\declareconstitemNEW{PMIX_PROC_NSPACE}
+\declareconstitemvalueNEW{PMIX_PROC_NSPACE}{60}
 Process namespace (\refstruct{pmix_nspace_t}).
 \%
-\declareconstitem{PMIX_QUERY}
+\declareconstitemvalue{PMIX_QUERY}{41}
 Query structure (\refstruct{pmix_query_t}).
 %
-\declareconstitem{PMIX_COMPRESSED_STRING}
+\declareconstitemvalue{PMIX_COMPRESSED_STRING}{42}
 String compressed with zlib (\code{char*}).
 %
-\declareconstitemProvisional{PMIX_COMPRESSED_BYTE_OBJECT}
+\declareconstitemvalueProvisional{PMIX_COMPRESSED_BYTE_OBJECT}{59}
 Byte object whose bytes have been compressed with zlib (\code{pmix_byte_object_t}).
 %
-\declareconstitem{PMIX_ALLOC_DIRECTIVE}
+\declareconstitemvalue{PMIX_ALLOC_DIRECTIVE}{43}
 Allocation directive (\refstruct{pmix_alloc_directive_t}).
 %
-\declareconstitem{PMIX_IOF_CHANNEL}
+\declareconstitemvalue{PMIX_IOF_CHANNEL}{45}
 Input/output forwarding channel (\refstruct{pmix_iof_channel_t}).
 %
-\declareconstitem{PMIX_ENVAR}
+\declareconstitemvalue{PMIX_ENVAR}{46}
 Environmental variable structure (\refstruct{pmix_envar_t}).
 %
-\declareconstitemNEW{PMIX_COORD}
+\declareconstitemvalueNEW{PMIX_COORD}{47}
 Structure containing fabric coordinates (\refstruct{pmix_coord_t}).
 %
-\declareconstitemNEW{PMIX_REGATTR}
+\declareconstitemvalueNEW{PMIX_REGATTR}{48}
 Structure supporting attribute registrations (\refstruct{pmix_regattr_t}).
 %
-\declareconstitemNEW{PMIX_REGEX}
+\declareconstitemvalueNEW{PMIX_REGEX}{49}
 Regular expressions - can be a valid NULL-terminated string or an arbitrary array of bytes.
 %
-\declareconstitemNEW{PMIX_JOB_STATE}
+\declareconstitemvalueNEW{PMIX_JOB_STATE}{50}
 Job state (\refstruct{pmix_job_state_t}).
 %
-\declareconstitemNEW{PMIX_LINK_STATE}
+\declareconstitemvalueNEW{PMIX_LINK_STATE}{51}
 Link state (\refstruct{pmix_link_state_t}).
 %
-\declareconstitemNEW{PMIX_PROC_CPUSET}
+\declareconstitemvalueNEW{PMIX_PROC_CPUSET}{52}
 Structure containing the binding bitmap of a process (\refstruct{pmix_cpuset_t}).
 %
-\declareconstitemNEW{PMIX_GEOMETRY}
+\declareconstitemvalueNEW{PMIX_GEOMETRY}{53}
 Geometry structure containing the fabric coordinates of a specified device.(\refstruct{pmix_geometry_t}).
 %
-\declareconstitemNEW{PMIX_DEVICE_DIST}
+\declareconstitemvalueNEW{PMIX_DEVICE_DIST}{54}
 Structure containing the minimum and maximum relative distance from the caller to a given fabric device. (\refstruct{pmix_device_distance_t}).
 %
-\declareconstitemNEW{PMIX_ENDPOINT}
+\declareconstitemvalueNEW{PMIX_ENDPOINT}{55}
 Structure containing an assigned endpoint for a given fabric device. (\refstruct{pmix_endpoint_t}).
 %
-\declareconstitemNEW{PMIX_TOPO}
+\declareconstitemvalueNEW{PMIX_TOPO}{56}
 Structure containing the topology for a given node. (\refstruct{pmix_topology_t}).
 %
-\declareconstitemNEW{PMIX_DEVTYPE}
+\declareconstitemvalueNEW{PMIX_DEVTYPE}{57}
 Bitmask containing the types of devices being referenced. (\refstruct{pmix_device_type_t}).
 %
-\declareconstitemNEW{PMIX_LOCTYPE}
+\declareconstitemvalueNEW{PMIX_LOCTYPE}{58}
 Bitmask describing the relative location of another process. (\refstruct{pmix_locality_t}).
 %
-\declareconstitemNEW{PMIX_DATA_TYPE_MAX}
+\declareconstitemvalueNEW{PMIX_DATA_TYPE_MAX}{500}
 A starting point for implementer-specific data types.
 Values above this are guaranteed not to conflict with \ac{PMIx} values.
 Definitions should always be based on the \refconst{PMIX_DATA_TYPE_MAX} constant and not a specific value as the value of the constant may change.

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -2211,6 +2211,18 @@ Bitmask containing the types of devices being referenced. (\refstruct{pmix_devic
 \declareconstitemvalueNEW{PMIX_LOCTYPE}{58}
 Bitmask describing the relative location of another process. (\refstruct{pmix_locality_t}).
 %
+\declareconstitemvalueNEW{PMIX_STOR_MEDIUM}{66}
+Bitmask specifying different types of storage mediums. (\refstruct{pmix_storage_medium_t}).
+%
+\declareconstitemvalueNEW{PMIX_STOR_ACCESS}{67}
+Bitmask specifying different levels of storage accessibility (i.e,. from where a storage system may be accessed). (\refstruct{pmix_storage_accessibility_t}).
+%
+\declareconstitemvalueNEW{PMIX_STOR_PERSIST}{68}
+Bitmask specifying different levels of persistence for a particular storage system. (\refstruct{pmix_storage_persistence_t}).
+%
+\declareconstitemvalueNEW{PMIX_STOR_ACCESS_TYPE}{69}
+Bitmask specifying different storage system access types. (\refstruct{pmix_storage_access_type_t}).
+%
 \declareconstitemvalueNEW{PMIX_DATA_TYPE_MAX}{500}
 A starting point for implementer-specific data types.
 Values above this are guaranteed not to conflict with \ac{PMIx} values.

--- a/Chap_API_Sync_Access.tex
+++ b/Chap_API_Sync_Access.tex
@@ -661,7 +661,7 @@ Non-blocking form of the \refapi{PMIx_Query_info} \ac{API}.
 
 \begin{constantdesc}
 %
-\declareconstitem{PMIX_QUERY_PARTIAL_SUCCESS}
+\declareconstitemvalue{PMIX_QUERY_PARTIAL_SUCCESS}{-104}
 Some, but not all, of the requested information was returned.
 %
 \end{constantdesc}

--- a/Chap_API_Tools.tex
+++ b/Chap_API_Tools.tex
@@ -517,7 +517,7 @@ The following constants refer to events relating to rendezvous of a tool and lau
 
 \begin{constantdesc}
 %
-\declareconstitemNEW{PMIX_LAUNCHER_READY}
+\declareconstitemvalueNEW{PMIX_LAUNCHER_READY}{-155}
 An application launcher (e.g., \emph{mpiexec}) shall generate this event to signal a tool that started it that the launcher is ready to receive directives/commands (e.g., \refapi{PMIx_Spawn}). This is only used when the initiator is able to parse the command line itself, or the launcher is started as a persistent \ac{DVM}.
 %
 \end{constantdesc}
@@ -637,22 +637,22 @@ The \refstruct{pmix_iof_channel_t} structure is a \code{uint16_t} type that defi
 
 \begin{constantdesc}
 %
-\declareconstitem{PMIX_FWD_NO_CHANNELS}
+\declareconstitemvalue{PMIX_FWD_NO_CHANNELS}{0x0000}
 Forward no channels.
 %
-\declareconstitem{PMIX_FWD_STDIN_CHANNEL}
+\declareconstitemvalue{PMIX_FWD_STDIN_CHANNEL}{0x0001}
 Forward \code{stdin}.
 %
-\declareconstitem{PMIX_FWD_STDOUT_CHANNEL}
+\declareconstitemvalue{PMIX_FWD_STDOUT_CHANNEL}{0x0002}
 Forward \code{stdout}.
 %
-\declareconstitem{PMIX_FWD_STDERR_CHANNEL}
+\declareconstitemvalue{PMIX_FWD_STDERR_CHANNEL}{0x0004}
 Forward \code{stderr}.
 %
-\declareconstitem{PMIX_FWD_STDDIAG_CHANNEL}
+\declareconstitemvalue{PMIX_FWD_STDDIAG_CHANNEL}{0x0008}
 Forward \code{stddiag}, if available.
 %
-\declareconstitem{PMIX_FWD_ALL_CHANNELS}
+\declareconstitemvalue{PMIX_FWD_ALL_CHANNELS}{0x00ff}
 Forward all available channels.
 %
 \end{constantdesc}
@@ -662,10 +662,10 @@ Forward all available channels.
 
 \begin{constantdesc}
 %
-\declareconstitemNEW{PMIX_ERR_IOF_FAILURE}
+\declareconstitemvalueNEW{PMIX_ERR_IOF_FAILURE}{-172}
 An \ac{IO} forwarding operation failed - the affected channel will be included in the notification.
 %
-\declareconstitemNEW{PMIX_ERR_IOF_COMPLETE}
+\declareconstitemvalueNEW{PMIX_ERR_IOF_COMPLETE}{-173}
 \ac{IO} forwarding of the standard input for this process has completed - i.e., the stdin file descriptor has closed.
 %
 \end{constantdesc}
@@ -950,19 +950,19 @@ to the \refapi{PMIx_Register_event_handler} \ac{API}.
 
 \begin{constantdesc}
 %
-\declareconstitemNEW{PMIX_EVENT_JOB_START}
+\declareconstitemvalueNEW{PMIX_EVENT_JOB_START}{-191}
 The first process in the job has been spawned - includes \refattr{PMIX_EVENT_TIMESTAMP} as well as the \refattr{PMIX_JOBID} and/or \refattr{PMIX_NSPACE} of the job.
 %
-\declareconstitemNEW{PMIX_LAUNCH_COMPLETE}
+\declareconstitemvalueNEW{PMIX_LAUNCH_COMPLETE}{-174}
 All processes in the job have been spawned - includes \refattr{PMIX_EVENT_TIMESTAMP} as well as the \refattr{PMIX_JOBID} and/or \refattr{PMIX_NSPACE} of the job.
 %
-\declareconstitemNEW{PMIX_EVENT_JOB_END}
+\declareconstitemvalueNEW{PMIX_EVENT_JOB_END}{-145}
 All processes in the job have terminated - includes \refattr{PMIX_EVENT_TIMESTAMP} when the last process terminated as well as the \refattr{PMIX_JOBID} and/or \refattr{PMIX_NSPACE} of the job.
 %
-\declareconstitemNEW{PMIX_EVENT_SESSION_START}
+\declareconstitemvalueNEW{PMIX_EVENT_SESSION_START}{-192}
 The allocation has been instantiated and is ready for use - includes \refattr{PMIX_EVENT_TIMESTAMP} as well as the \refattr{PMIX_SESSION_ID} of the allocation. This event is issued after any system-controlled prologue has completed, but before any user-specified actions are taken.
 %
-\declareconstitemNEW{PMIX_EVENT_SESSION_END}
+\declareconstitemvalueNEW{PMIX_EVENT_SESSION_END}{-193}
 The allocation has terminated - includes \refattr{PMIX_EVENT_TIMESTAMP} as well as the \refattr{PMIX_SESSION_ID} of the allocation. This event is issued after any user-specified actions have completed, but before any system-controlled epilogue is performed.
 %
 \end{constantdesc}
@@ -971,13 +971,13 @@ The following events relate to processes within a job:
 
 \begin{constantdesc}
 %
-\declareconstitem{PMIX_EVENT_PROC_TERMINATED}
+\declareconstitemvalue{PMIX_EVENT_PROC_TERMINATED}{-201}
 The specified process(es) terminated - normal or abnormal
 termination will be indicated by the \refattr{PMIX_PROC_TERM_STATUS} in the
 \refarg{info} array of the notification. Note that a request for individual
 process events can generate a significant event volume from large-scale jobs.
 %
-\declareconstitemNEW{PMIX_ERR_PROC_TERM_WO_SYNC}
+\declareconstitemvalueNEW{PMIX_ERR_PROC_TERM_WO_SYNC}{-200}
 Process terminated without calling \refapi{PMIx_Finalize}, or was a member of an assemblage formed via \refapi{PMIx_Connect} and terminated or called \refapi{PMIx_Finalize} without first calling \refapi{PMIx_Disconnect} (or its non-blocking form) from that assemblage.
 %
 \end{constantdesc}
@@ -989,28 +989,28 @@ information regarding the reason for job abnormal termination:
 
 \begin{constantdesc}
 %
-\declareconstitemNEW{PMIX_ERR_JOB_CANCELED}
+\declareconstitemvalueNEW{PMIX_ERR_JOB_CANCELED}{-180}
 The job was canceled by the host environment.
 %
-\declareconstitemNEW{PMIX_ERR_JOB_ABORTED}
+\declareconstitemvalueNEW{PMIX_ERR_JOB_ABORTED}{-182}
 One or more processes in the job called abort, causing the job to be terminated.
 %
-\declareconstitemNEW{PMIX_ERR_JOB_KILLED_BY_CMD}
+\declareconstitemvalueNEW{PMIX_ERR_JOB_KILLED_BY_CMD}{-183}
 The job was killed by user command.
 %
-\declareconstitemNEW{PMIX_ERR_JOB_ABORTED_BY_SIG}
+\declareconstitemvalueNEW{PMIX_ERR_JOB_ABORTED_BY_SIG}{-184}
 The job was aborted due to receipt of an error signal (e.g., SIGKILL).
 %
-\declareconstitemNEW{PMIX_ERR_JOB_TERM_WO_SYNC}
+\declareconstitemvalueNEW{PMIX_ERR_JOB_TERM_WO_SYNC}{-185}
 The job was terminated due to at least one process terminating without calling \refapi{PMIx_Finalize}, or was a member of an assemblage formed via \refapi{PMIx_Connect} and terminated or called \refapi{PMIx_Finalize} without first calling \refapi{PMIx_Disconnect} (or its non-blocking form) from that assemblage.
 %
-\declareconstitemNEW{PMIX_ERR_JOB_SENSOR_BOUND_EXCEEDED}
+\declareconstitemvalueNEW{PMIX_ERR_JOB_SENSOR_BOUND_EXCEEDED}{-186}
 The job was terminated due to one or more processes exceeding a specified sensor limit.
 %
-\declareconstitemNEW{PMIX_ERR_JOB_NON_ZERO_TERM}
+\declareconstitemvalueNEW{PMIX_ERR_JOB_NON_ZERO_TERM}{-187}
 The job was terminated due to one or more processes exiting with a non-zero status.
 %
-\declareconstitemNEW{PMIX_ERR_JOB_ABORTED_BY_SYS_EVENT}
+\declareconstitemvalueNEW{PMIX_ERR_JOB_ABORTED_BY_SYS_EVENT}{-189}
 The job was aborted due to receipt of a system event.
 %
 \end{constantdesc}
@@ -1039,11 +1039,11 @@ The following constants are used in events used to coordinate applications and t
 
 \begin{constantdesc}
 %
-\declareconstitemNEW{PMIX_DEBUG_WAITING_FOR_NOTIFY}
+\declareconstitemvalueNEW{PMIX_DEBUG_WAITING_FOR_NOTIFY}{-58}
 All processes in the job to be debugged are paused waiting for a release at some point within the application. The application shall remain in a paused
 state awaiting release until receipt of the \refconst{PMIX_DEBUGGER_RELEASE}.
 %
-\declareconstitemNEW{PMIX_DEBUGGER_RELEASE}
+\declareconstitemvalueNEW{PMIX_DEBUGGER_RELEASE}{-3}
 Release processes that are paused at the \refattr{PMIX_DEBUG_WAIT_FOR_NOTIFY}
 point in the target application.
 %

--- a/Chap_Revisions.tex
+++ b/Chap_Revisions.tex
@@ -1198,6 +1198,18 @@ Architecture flag.
 
 The v4.1 update includes clarifications and corrections from the v4.0 document:
 
+\subsection{Removed constants}
+
+The following constants were removed from the \ac{PMIx} Standard in v4.1
+as they are internal to a particular \ac{PMIx} implementation.
+
+\begin{constantdesc}
+%!TEX encoding = UTF-8 Unicode
+\declareconstitemRM{PMIX_BUFFER}
+Buffer.
+%
+\end{constantdesc}
+
 \begin{compactitemize}
     \item Remove some stale language in \refsection{chap:api_event:notify}{Chapter 9.1}.
     \item Provisional Items:

--- a/pmix.sty
+++ b/pmix.sty
@@ -420,6 +420,7 @@
 %  \declareconstitemDEP            Declare Constant - Deprecated
 %  \declareconstitemRM             Declare Constant - Removed
 %  \declareconstitemvalue          Declare Constant Value
+%  \declareconstitemvalueNEW       Declare Constant Value - NEW
 %
 %  \pasteAttributeItem             Paste a copy of the Attribute declaration
 %  \pasteAttributeItemBegin        Paste a copy of the Attribute declaration
@@ -439,7 +440,12 @@
 }
 \newcommand{\declareconstitemvalue}[2]{%
   \item[\code{#1}]%
-  \index[index_const]{#1|indexfmt}%
+  \index[index_const]{#1|indexfmt} \label{const:#1}%
+  \hspace{0.25em} \code{#2} \hspace{1em}%
+}
+\newcommand{\declareconstitemvalueNEW}[2]{%
+  \item[\color{magenta}\code{#1}]%
+  \index[index_const]{#1|indexfmt} \label{const:#1}%
   \hspace{0.25em} \code{#2} \hspace{1em}%
 }
 
@@ -447,6 +453,11 @@
   \item[\hl{\code{#1}}]\provisionalMarker{}%
   \index[index_const]{#1|indexfmt} \label{const:#1}%
   \hspace{1em}%
+}
+\newcommand{\declareconstitemvalueProvisional}[2]{%
+  \item[\hl{\code{#1}}]\provisionalMarker{}%
+  \index[index_const]{#1|indexfmt} \label{const:#1}%
+  \hspace{1em} \code{#2} \hspace{1em}%
 }
 
 \newcommand{\declareconstitemNEW}[1]{%


### PR DESCRIPTION
The Standard currently only defines the name of PMIx constants - it does
not assign them a value, thus leaving the value to each implementation.
This creates a problem for vendors seeking to distribute
implementation-agnostic products as they cannot know the meaning of a
particular value returned by a function call.

Implementation-agnostic products (e.g., debuggers) are typically compiled
against one implementation, but are designed to work against whatever
implementation is installed on the target system. This is done by using
the combination of dlopen and dlsym to load the library and access its
public APIs.

Unfortunately, the value of the constants in the code is determined at
compile time - it isn't possible to load them via dlopen. Thus, the
resulting binary is "locked" to the implementation against which it was
compiled, thereby forcing the vendor to distribute
implementation-specific copies of their product.

The solution to the problem is to have the Standard define the actual
value of each constant and not just its name. Doing this forces all
implementations to use the same value, thus allowing for
implementation-agnostic products to be distributed.

Refs https://github.com/pmix/pmix-standard/issues/358

Signed-off-by: Ralph Castain <rhc@pmix.org>
Signed-off-by: John DelSignore <JDelSignore@perforce.com>