### PR TITLE
Provide static initializers for PMIx structs

### DIFF
--- a/Chap_API_Data_Mgmt.tex
+++ b/Chap_API_Data_Mgmt.tex
@@ -45,6 +45,20 @@ typedef struct pmix_data_buffer \{
 
 \ac{PMIx} provides a set of convenience macros for creating, initiating, and releasing data buffers.
 
+%%%%
+\littleheader{Static initializer for the data buffer structure}
+\declaremacro{PMIX_DATA_BUFFER_STATIC_INIT}
+
+Provide a static initializer for the \refstruct{pmix_data_buffer_t} fields.
+
+\versionMarker{4.2}
+\cspecificstart
+\begin{codepar}
+PMIX_DATA_BUFFER_STATIC_INIT
+\end{codepar}
+\cspecificend
+
+
 %%%%%%%%%%%
 \littleheader{\code{PMIX_DATA_BUFFER_CREATE}}
 \declaremacro{PMIX_DATA_BUFFER_CREATE}

--- a/Chap_API_Fabric.tex
+++ b/Chap_API_Fabric.tex
@@ -127,6 +127,20 @@ The \refarg{uuid} field contains the \ac{UUID} of the fabric device, the \refarg
 The following macros are provided to support the \refstruct{pmix_endpoint_t} structure.
 
 %%%%
+\littleheader{Static initializer for the endpoint structure}
+\declaremacro{PMIX_ENDPOINT_STATIC_INIT}
+
+Provide a static initializer for the \refstruct{pmix_endpoint_t} fields.
+
+\versionMarker{4.2}
+\cspecificstart
+\begin{codepar}
+PMIX_ENDPOINT_STATIC_INIT
+\end{codepar}
+\cspecificend
+
+
+%%%%
 \littleheader{Initialize the endpoint structure}
 \declaremacro{PMIX_ENDPOINT_CONSTRUCT}
 
@@ -226,6 +240,20 @@ A fabric coordinate is associated with a given fabric device and must be unique 
 \label{api:netcoord:macros}
 
 The following macros are provided to support the \refstruct{pmix_coord_t} structure.
+
+%%%%
+\littleheader{Static initializer for the coord structure}
+\declaremacro{PMIX_COORD_STATIC_INIT}
+
+Provide a static initializer for the \refstruct{pmix_coord_t} fields.
+
+\versionMarker{4.2}
+\cspecificstart
+\begin{codepar}
+PMIX_COORD_STATIC_INIT
+\end{codepar}
+\cspecificend
+
 
 %%%%
 \littleheader{Initialize the coord structure}
@@ -331,6 +359,20 @@ A fabric coordinate is associated with a given fabric device and must be unique 
 \label{api:netgeom:macros}
 
 The following macros are provided to support the \refstruct{pmix_geometry_t} structure.
+
+%%%%
+\littleheader{Static initializer for the geometry structure}
+\declaremacro{PMIX_GEOMETRY_STATIC_INIT}
+
+Provide a static initializer for the \refstruct{pmix_geometry_t} fields.
+
+\versionMarker{4.2}
+\cspecificstart
+\begin{codepar}
+PMIX_GEOMETRY_STATIC_INIT
+\end{codepar}
+\cspecificend
+
 
 %%%%
 \littleheader{Initialize the geometry structure}
@@ -545,6 +587,20 @@ While unusual due to scaling issues, implementations may include an array of \re
 \pasteAttributeItem{PMIX_FABRIC_DEVICE_PCI_DEVID}
 
 \optattrend
+
+%%%%
+\subsubsection{Static initializer for the fabric structure}
+\declaremacro{PMIX_FABRIC_STATIC_INIT}
+
+Provide a static initializer for the \refstruct{pmix_fabric_t} fields.
+
+\versionMarker{4.2}
+\cspecificstart
+\begin{codepar}
+PMIX_FABRIC_STATIC_INIT
+\end{codepar}
+\cspecificend
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsubsection{Initialize the fabric structure}

--- a/Chap_API_Proc_Mgmt.tex
+++ b/Chap_API_Proc_Mgmt.tex
@@ -597,6 +597,20 @@ typedef struct pmix_app \{
 \subsubsection{App structure support macros}
 The following macros are provided to support the \refstruct{pmix_app_t} structure.
 
+%%%%
+\littleheader{Static initializer for the app structure}
+\declaremacro{PMIX_APP_STATIC_INIT}
+
+Provide a static initializer for the \refstruct{pmix_app_t} fields.
+
+\versionMarker{4.2}
+\cspecificstart
+\begin{codepar}
+PMIX_APP_STATIC_INIT
+\end{codepar}
+\cspecificend
+
+
 %%%%%%%%%%%
 \littleheader{Initialize the app structure}
 \declaremacro{PMIX_APP_CONSTRUCT}
@@ -1164,6 +1178,20 @@ typedef struct pmix_topology \{
 
 The following macros support the \refstruct{pmix_topology_t} structure.
 
+%%%%
+\littleheader{Static initializer for the topology structure}
+\declaremacro{PMIX_TOPOLOGY_STATIC_INIT}
+
+Provide a static initializer for the \refstruct{pmix_topology_t} fields.
+
+\versionMarker{4.2}
+\cspecificstart
+\begin{codepar}
+PMIX_TOPOLOGY_STATIC_INIT
+\end{codepar}
+\cspecificend
+
+
 \littleheader{Initialize the topology structure}
 \declaremacro{PMIX_TOPOLOGY_CONSTRUCT}
 
@@ -1592,6 +1620,20 @@ A relative distance value of \code{UINT16_MAX} indicates that the distance from 
 \label{api:netenddist:macros}
 
 The following macros are provided to support the \refstruct{pmix_device_distance_t} structure.
+
+%%%%
+\littleheader{Static initializer for the device distance structure}
+\declaremacro{PMIX_DEVICE_DIST_STATIC_INIT}
+
+Provide a static initializer for the \refstruct{pmix_device_distance_t} fields.
+
+\versionMarker{4.2}
+\cspecificstart
+\begin{codepar}
+PMIX_DEVICE_DIST_STATIC_INIT
+\end{codepar}
+\cspecificend
+
 
 %%%%
 \littleheader{Initialize the device distance structure}

--- a/Chap_API_Publish.tex
+++ b/Chap_API_Publish.tex
@@ -439,6 +439,20 @@ where:
 
 The following macros are provided to support the \refstruct{pmix_pdata_t} structure.
 
+%%%%
+\littleheader{Static initializer for the pdata structure}
+\declaremacro{PMIX_LOOKUP_STATIC_INIT}
+
+Provide a static initializer for the \refstruct{pmix_pdata_t} fields.
+
+\versionMarker{4.2}
+\cspecificstart
+\begin{codepar}
+PMIX_LOOKUP_STATIC_INIT
+\end{codepar}
+\cspecificend
+
+
 \littleheader{Initialize the pdata structure}
 \declaremacro{PMIX_PDATA_CONSTRUCT}
 

--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -1460,6 +1460,20 @@ Used in \refstruct{pmix_regattr_t} to describe accepted values for the associate
 
 The following macros are provided to support the \refstruct{pmix_regattr_t} structure.
 
+%%%%
+\littleheader{Static initializer for the regattr structure}
+\declaremacro{PMIX_REGATTR_STATIC_INIT}
+
+Provide a static initializer for the \refstruct{pmix_regattr_t} fields.
+
+\versionMarker{4.2}
+\cspecificstart
+\begin{codepar}
+PMIX_REGATTR_STATIC_INIT
+\end{codepar}
+\cspecificend
+
+
 %%%%%%%%%%%
 \littleheader{Initialize the regattr structure}
 \declaremacro{PMIX_REGATTR_CONSTRUCT}
@@ -1849,6 +1863,20 @@ typedef struct pmix_cpuset \{
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsubsection{Cpuset support macros}
 The following macros support the \refstruct{pmix_cpuset_t} structure.
+
+%%%%
+\littleheader{Static initializer for the cpuset structure}
+\declaremacro{PMIX_CPUSET_STATIC_INIT}
+
+Provide a static initializer for the \refstruct{pmix_cpuset_t} fields.
+
+\versionMarker{4.2}
+\cspecificstart
+\begin{codepar}
+PMIX_CPUSET_STATIC_INIT
+\end{codepar}
+\cspecificend
+
 
 \littleheader{Initialize the cpuset structure}
 \declaremacro{PMIX_CPUSET_CONSTRUCT}

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -512,6 +512,20 @@ typedef struct pmix_proc \{
 \subsubsection{Process structure support macros}
 The following macros are provided to support the \refstruct{pmix_proc_t} structure.
 
+%%%%
+\littleheader{Static initializer for the proc structure}
+\declaremacro{PMIX_PROC_STATIC_INIT}
+
+Provide a static initializer for the \refstruct{pmix_proc_t} fields.
+
+\versionMarker{4.2}
+\cspecificstart
+\begin{codepar}
+PMIX_PROC_STATIC_INIT
+\end{codepar}
+\cspecificend
+
+
 \littleheader{Initialize the proc structure}
 \declaremacro{PMIX_PROC_CONSTRUCT}
 
@@ -853,6 +867,20 @@ typedef struct pmix_proc_info \{
 The following macros are provided to support the \refstruct{pmix_proc_info_t} structure.
 
 %%%%
+\littleheader{Static initializer for the proc info structure}
+\declaremacro{PMIX_PROC_INFO_STATIC_INIT}
+
+Provide a static initializer for the \refstruct{pmix_proc_info_t} fields.
+
+\versionMarker{4.2}
+\cspecificstart
+\begin{codepar}
+PMIX_PROC_INFO_STATIC_INIT
+\end{codepar}
+\cspecificend
+
+
+%%%%
 \littleheader{Initialize the process information structure}
 \declaremacro{PMIX_PROC_INFO_CONSTRUCT}
 
@@ -1039,6 +1067,20 @@ typedef struct pmix_value \{
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsubsection{Value structure support macros}
 The following macros are provided to support the \refstruct{pmix_value_t} structure.
+
+%%%%
+\littleheader{Static initializer for the value structure}
+\declaremacro{PMIX_VALUE_STATIC_INIT}
+
+Provide a static initializer for the \refstruct{pmix_value_t} fields.
+
+\versionMarker{4.2}
+\cspecificstart
+\begin{codepar}
+PMIX_VALUE_STATIC_INIT
+\end{codepar}
+\cspecificend
+
 
 \littleheader{Initialize the value structure}
 \declaremacro{PMIX_VALUE_CONSTRUCT}
@@ -1245,6 +1287,20 @@ typedef struct pmix_info_t \{
 %%%%%%%%%%%
 \subsubsection{Info structure support macros}
 The following macros are provided to support the \refstruct{pmix_info_t} structure.
+
+%%%%
+\littleheader{Static initializer for the info structure}
+\declaremacro{PMIX_INFO_STATIC_INIT}
+
+Provide a static initializer for the \refstruct{pmix_info_t} fields.
+
+\versionMarker{4.2}
+\cspecificstart
+\begin{codepar}
+PMIX_INFO_STATIC_INIT
+\end{codepar}
+\cspecificend
+
 
 \littleheader{Initialize the info structure}
 \declaremacro{PMIX_INFO_CONSTRUCT}
@@ -1706,6 +1762,20 @@ typedef struct \{
 
 The following macros are provided to support the \refstruct{pmix_envar_t} structure.
 
+%%%%
+\littleheader{Static initializer for the envar structure}
+\declaremacro{PMIX_ENVAR_STATIC_INIT}
+
+Provide a static initializer for the \refstruct{pmix_envar_t} fields.
+
+\versionMarker{4.2}
+\cspecificstart
+\begin{codepar}
+PMIX_ENVAR_STATIC_INIT
+\end{codepar}
+\cspecificend
+
+
 \littleheader{Initialize the envar structure}
 \declaremacro{PMIX_ENVAR_CONSTRUCT}
 
@@ -1814,6 +1884,20 @@ typedef struct pmix_byte_object \{
 \subsubsection{Byte object support macros}
 The following macros support the \refstruct{pmix_byte_object_t} structure.
 
+%%%%
+\littleheader{Static initializer for the byte object structure}
+\declaremacro{PMIX_BYTE_OBJECT_STATIC_INIT}
+
+Provide a static initializer for the \refstruct{pmix_byte_object_t} fields.
+
+\versionMarker{4.2}
+\cspecificstart
+\begin{codepar}
+PMIX_BYTE_OBJECT_STATIC_INIT
+\end{codepar}
+\cspecificend
+
+
 \littleheader{Initialize the byte object structure}
 \declaremacro{PMIX_BYTE_OBJECT_CONSTRUCT}
 
@@ -1919,6 +2003,20 @@ typedef struct pmix_data_array \{
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsubsection{Data array support macros}
 The following macros support the \refstruct{pmix_data_array_t} structure.
+
+%%%%
+\littleheader{Static initializer for the data array structure}
+\declaremacro{PMIX_DATA_ARRAY_STATIC_INIT}
+
+Provide a static initializer for the \refstruct{pmix_data_array_t} fields.
+
+\versionMarker{4.2}
+\cspecificstart
+\begin{codepar}
+PMIX_DATA_ARRAY_STATIC_INIT
+\end{codepar}
+\cspecificend
+
 
 \littleheader{Initialize a data array structure}
 \declaremacro{PMIX_DATA_ARRAY_CONSTRUCT}

--- a/Chap_API_Sync_Access.tex
+++ b/Chap_API_Sync_Access.tex
@@ -885,6 +885,20 @@ where:
 \subsubsection{Query structure support macros}
 The following macros are provided to support the \refstruct{pmix_query_t} structure.
 
+%%%%
+\littleheader{Static initializer for the query structure}
+\declaremacro{PMIX_QUERY_STATIC_INIT}
+
+Provide a static initializer for the \refstruct{pmix_query_t} fields.
+
+\versionMarker{4.2}
+\cspecificstart
+\begin{codepar}
+PMIX_QUERY_STATIC_INIT
+\end{codepar}
+\cspecificend
+
+
 \littleheader{Initialize the query structure}
 \declaremacro{PMIX_QUERY_CONSTRUCT}
 


### PR DESCRIPTION
Programs that utilize PMIx structures benefit from
being provided with static initializers by which global
variables can be safely declared.

Signed-off-by: Ralph Castain <rhc@pmix.org>