### PR TITLE
Fix provisional markers

### DIFF
--- a/Chap_API_Storage.tex
+++ b/Chap_API_Storage.tex
@@ -1,10 +1,8 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Chapter: Storage support
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\chapter{Storage Support Definitions}
+\provisionalChapter{Storage Support Definitions}
 \label{chap:api_storage}
-
-\provisionalMarker{}
 
 Distributed and parallel computing systems are increasingly embracing storage hierarchies to meet the diverse data management needs of applications and other systems software in a cost-effective manner.
 These hierarchies provide access to a number of distinct storage layers, with each potentially composed of different storage hardware (e.g., HDD, SSD, tape, PMEM), deployed at different locations (e.g., on-node, on-switch, on-site, WAN), and designed using different storage paradigms (e.g., file-based, object-based).
@@ -14,12 +12,10 @@ PMIx enables users to better understand storage hierarchies by defining attribut
 These attributes can be queried by applications, I/O libraries and middleware, and workflow systems to discover available storage resources and to inform on which resources are most suitable for different I/O workload requirements.
 
 %%%%%%%%%%%
-\section{Storage support constants}
-
+\provisionalSection{Storage support constants}
 \declarestruct{pmix_storage_medium_t}
-\provisionalMarker{}
 
-The \refstruct{pmix_storage_medium_t} is a \code{uint64_t} type that defines a set of bit-mask flags for specifying different types of storage mediums. These can be bitwise OR'd together to accommodate storage systems that mix storage medium types.
+The \refstruct{pmix_storage_medium_t}~\provisionalMarker{} is a \code{uint64_t} type that defines a set of bit-mask flags for specifying different types of storage mediums. These can be bitwise OR'd together to accommodate storage systems that mix storage medium types.
 
 \begin{constantdesc}
 %
@@ -53,9 +49,8 @@ It is further recommended that implementations should try to allocate empty bits
 \adviceimplend
 
 \declarestruct{pmix_storage_accessibility_t}
-\provisionalMarker{}
 
-The \refstruct{pmix_storage_accessibility_t} is a \code{uint64_t} type that defines a set of bit-mask flags for specifying different levels of storage accessibility (i.e,. from where a storage system may be accessed). These can be bitwise OR'd together to accommodate storage systems that are accessibile in multiple ways.
+The \refstruct{pmix_storage_accessibility_t}~\provisionalMarker{} is a \code{uint64_t} type that defines a set of bit-mask flags for specifying different levels of storage accessibility (i.e,. from where a storage system may be accessed). These can be bitwise OR'd together to accommodate storage systems that are accessibile in multiple ways.
 
 \begin{constantdesc}
 %
@@ -80,9 +75,8 @@ The storage system resources are remote.
 \end{constantdesc}
 
 \declarestruct{pmix_storage_persistence_t}
-\provisionalMarker{}
 
-The \refstruct{pmix_storage_persistence_t} is a \code{uint64_t} type that defines a set of bit-mask flags for specifying different levels of persistence for a particular storage system.
+The \refstruct{pmix_storage_persistence_t}~\provisionalMarker{} is a \code{uint64_t} type that defines a set of bit-mask flags for specifying different levels of persistence for a particular storage system.
 
 \begin{constantdesc}
 %
@@ -110,9 +104,8 @@ Data on the storage system is persisted according to archive storage policies (l
 \end{constantdesc}
 
 \declarestruct{pmix_storage_access_type_t}
-\provisionalMarker{}
 
-The \refstruct{pmix_storage_access_type_t} is a \code{uint16_t} type that defines a set of bit-mask flags for specifying different storage system access types.
+The \refstruct{pmix_storage_access_type_t}~\provisionalMarker{} is a \code{uint16_t} type that defines a set of bit-mask flags for specifying different storage system access types.
 
 \begin{constantdesc}
 %
@@ -129,7 +122,7 @@ Provide information on storage system read and write operations.
 
 
 %%%%%%%%%%%
-\section{Storage support attributes}
+\provisionalSection{Storage support attributes}
 \label{api:struct:attributes:pstrg}
 
 The following attributes may be returned in response to queries (e.g., \refapi{PMIx_Get} or \refapi{PMIx_Query_info}) made by processes or tools.

--- a/TitlePage.tex
+++ b/TitlePage.tex
@@ -37,7 +37,7 @@ Please note that messages sent to the mailing list from an unsubscribed e-mail a
 \vfill
 
 \begin{adjustwidth}{0pt}{1em}\setlength{\parskip}{0.25\baselineskip}%
-Copyright \textsuperscript{\textcopyright} 2018-2020 PMIx \acf{ASC}.\\
+Copyright \textsuperscript{\textcopyright} 2018-2022 PMIx \acf{ASC}.\\
 Permission to copy without fee all or part of this material is granted,
 provided the PMIx \ac{ASC} copyright notice and
 the title of this document appear, and notice is given that copying is by

--- a/pmix-standard.tex
+++ b/pmix-standard.tex
@@ -56,8 +56,9 @@
 \setboolean{is_unofficial_draft}{true}
 
 % Text to appear in the footer on even-numbered pages:
+% Release candidates are marked as an Unofficial Draft
 \ifthenelse{\boolean{is_unofficial_draft}}
-  {\newcommand{\VER}{5.0 (Draft)}
+  {\newcommand{\VER}{5.0dev0 (Draft)}
    \newcommand{\VERDATE}{\emph{Created on \today}}
   }
   {\newcommand{\VER}{5.0}

--- a/pmix.sty
+++ b/pmix.sty
@@ -244,12 +244,25 @@
 % PMIx Standard Process markers
 %
 % - Provisional items
-%   \provisionalMarker     Add a provisional label to the margin
-%   \markProvisional       Add a provisional label to the margin and highlight the provided text
+%   \provisionalMarker     Add a provisional label
+%   \markProvisional       Add a provisional label and highlight the provided text
 %
 
+% Putting this in the margin is not consistently working.
+% Instead put this marker in-line in the text.
+%\newcommand{\provisionalMarker}[0]{% -14
+%    \textInMargin{\small{\hl{\textit{Provisional}}}}%
+%}
 \newcommand{\provisionalMarker}[0]{% -14
-    \textInMargin{\small{\hl{\textit{Provisional}}}}%
+    \small{\hl{\textit{(Provisional)}}}%
+}
+
+\newcommand{\provisionalChapter}[1]{% -14
+    \chapter{#1 \small{\textit{(Provisional)}}}%
+}
+
+\newcommand{\provisionalSection}[1]{% -14
+    \section{#1 \small{\textit{(Provisional)}}}%
 }
 
 \newcommand{\markProvisional}[1]{% -14
@@ -450,7 +463,7 @@
 }
 
 \newcommand{\declareconstitemProvisional}[1]{%
-  \item[\hl{\code{#1}}]\provisionalMarker{}%
+  \item[\hl{\code{#1}}] \provisionalMarker{}%
   \index[index_const]{#1|indexfmt} \label{const:#1}%
   \hspace{1em}%
 }
@@ -507,7 +520,7 @@
 }
 
 \newcommand{\declareEnvarProvisional}[2]{%
-    \hl{\code{#1}}\provisionalMarker{}%
+    \hl{\code{#1}} \provisionalMarker{}%
     \index[index_envars]{#1|indexfmt} \label{envar:#1}%
     \InternaldeclareEnvar{#1}{#2}%
 }
@@ -566,7 +579,7 @@
 }
 
 \newcommand{\declareAttributeProvisional}[4]{%
-    \hl{\code{#1} ~~\code{#2}~~(\code{#3})}\provisionalMarker{}%
+    \hl{\code{#1} ~~\code{#2}~~(\code{#3})} \provisionalMarker{}%
     \index[index_attribute]{#1|indexfmt} \label{attr:#1}%
     \InternaldeclareAttributeBody{#1}{#2}{#3}{#4}%
 }
@@ -624,7 +637,7 @@
 }
 
 \newcommand{\declareapiProvisional}[1]{%
-  \index[index_api]{#1|indexfmt} \label{apifn:#1}\provisionalMarker{}%
+  \index[index_api]{#1|indexfmt} \label{apifn:#1} \provisionalMarker{}%
 }
 
 \newcommand{\declareapiDEPNODISP}[1]{%
@@ -666,7 +679,7 @@
   \index[index_macro]{#1|indexfmt} \label{macro:#1}%
 }
 \newcommand{\declaremacroProvisional}[1]{%
-  \index[index_macro]{#1|indexfmt} \label{macro:#1}\provisionalMarker{}%
+  \index[index_macro]{#1|indexfmt} \label{macro:#1} \provisionalMarker{}%
 }
 
 \newcommand{\refmacro}[1]{\index[index_macro]{#1}\hyperref[macro:#1]{\code{#1}}}


### PR DESCRIPTION
 * The prior mechanism put the marker in the margin, but was not
   working consistently. So instead put them in-line by the provisional
   text.
 * Fixes #352 (in sync with the v4 branch)