### PR TITLE
Add const to string parameters not meant to be modified

### DIFF
--- a/Chap_API_Data_Mgmt.tex
+++ b/Chap_API_Data_Mgmt.tex
@@ -332,13 +332,13 @@ Pretty-print a data value.
 
 \copySignature{PMIx_Data_print}{2.0}{
 pmix_status_t \\
-PMIx_Data_print(char **output, char *prefix, \\
+PMIx_Data_print(char **output, const char *prefix, \\
 \hspace*{16\sigspace}void *src, pmix_data_type_t type);
 }
 
 \begin{arglist}
 \argin{output}{The address of a pointer into which the address of the resulting output is to be stored. (\code{char**})}
-\argin{prefix}{String to be prepended to the resulting output (\code{char*})}
+\argin{prefix}{String to be prepended to the resulting output (\code{const char*})}
 \argin{src}{A pointer to the memory location of the data value to be printed (handle)}
 \argin{type}{The type of the data value to be printed --- must be one of the PMIx defined data types. (\refstruct{pmix_data_type_t})}
 \end{arglist}

--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -1310,7 +1310,7 @@ Register host environment attribute support for a function.
 
 \copySignature{PMIx_Register_attributes}{4.0}{
 pmix_status_t \\
-PMIx_Register_attributes(char *function, \\
+PMIx_Register_attributes(const char *function, \\
 \hspace*{25\sigspace}pmix_regattr_t attrs[], \\
 \hspace*{25\sigspace}size_t nattrs);
 }
@@ -1867,14 +1867,14 @@ Define a \ac{PMIx} process set.
 pmix_status_t \\
 PMIx_server_define_process_set(const pmix_proc_t members[], \\
 \hspace*{31\sigspace}size_t nmembers, \\
-\hspace*{31\sigspace}char *pset_name);
+\hspace*{31\sigspace}const char *pset_name);
 }
 
 \begin{arglist}
 \argin{members}{Pointer to an array of \refstruct{pmix_proc_t} containing the
 identifiers of the processes in the process set (handle)}
 \argin{nmembers}{Number of elements in \refarg{members} (integer)}
-\argin{pset_name}{String name of the process set being defined (\code{char*})}
+\argin{pset_name}{String name of the process set being defined (\code{const char*})}
 \end{arglist}
 
 \returnsimple
@@ -1914,11 +1914,11 @@ Delete a \ac{PMIx} process set name
 
 \copySignature{PMIx_server_delete_process_set}{4.0}{
 pmix_status_t \\
-PMIx_server_delete_process_set(char *pset_name);
+PMIx_server_delete_process_set(const char *pset_name);
 }
 
 \begin{arglist}
-\argin{pset_name}{String name of the process set being deleted (\code{char*})}
+\argin{pset_name}{String name of the process set being deleted (\code{const char*})}
 \end{arglist}
 
 \returnsimple

--- a/Chap_API_Struct.tex
+++ b/Chap_API_Struct.tex
@@ -2706,7 +2706,7 @@ String representation of a \ac{PMIx} attribute.
 
 \copySignature{PMIx_Get_attribute_string}{4.0}{
 const char* \\
-PMIx_Get_attribute_string(char *attributename);
+PMIx_Get_attribute_string(const char *attributename);
 }
 
 %%%%
@@ -2717,7 +2717,7 @@ Return the \ac{PMIx} attribute name corresponding to the given attribute string.
 
 \copySignature{PMIx_Get_attribute_name}{4.0}{
 const char* \\
-PMIx_Get_attribute_name(char *attributestring);
+PMIx_Get_attribute_name(const char *attributestring);
 }
 
 %%%%


### PR DESCRIPTION
Without const, users may encounter `-Wdiscarded-qualifier` warnings at build time. While these changes modify API signatures, they should be regarded as ABI compatible. Fixes #426.