### PR TITLE
Remove 4.2 revision section. Move items to 5.0.

### DIFF
--- a/Chap_Revisions.tex
+++ b/Chap_Revisions.tex
@@ -1429,7 +1429,7 @@ Renamed to \refattr{PMIX_DEBUG_STOP_IN_APP}
 
 \subsection{Deprecated macros}
 
-The following macros were deprecated in v4.2:
+The following macros were deprecated in v5.0:
 
 \begin{compactitemize}
   \item \declaremacroDEP{PMIX_VALUE_LOAD} Replaced by the \refapi{PMIx_Value_load} \ac{API}

--- a/Chap_Revisions.tex
+++ b/Chap_Revisions.tex
@@ -1302,57 +1302,30 @@ Buffer.
 \pasteAttributeItem{PMIX_STORAGE_IOPS_CUR}
 \pasteAttributeItem{PMIX_STORAGE_ACCESS_TYPE}
 
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%%%%%%%%%% History: Version 4.2
-\section{Version 4.2: TBD}
+%%%%%%%%%% History: Version 5.0
+\section{Version 5.0: TBD}
 
-The v4.2 update includes the following changes from the v4.1 document:
-
-\begin{compactitemize}
-    \item Define when \refattr{PMIX_PARENT_ID} is set
-    \item Add adefinition for \refterm{tool}
-    \item Clarify \refattr{PMIX_CMD_LINE} in \refapi{PMIx_Spawn}
-\end{compactitemize}
-
-\subsection{Deprecated constants}
-
-The following constants were deprecated in v4.2:
-
-\begin{constantdesc}
-%
-\declareconstitemDEP{PMIX_DEBUG_WAITING_FOR_NOTIFY}
-Renamed to \refconst{PMIX_READY_FOR_DEBUG}
-%
-\end{constantdesc}
-
-
-\subsection{Deprecated attributes}
-
-The following attributes were deprecated in v4.2:
-
-%
-\declareAttributeDEP{PMIX_DEBUG_WAIT_FOR_NOTIFY}{"pmix.dbg.notify"}{bool}{
-Renamed to \refattr{PMIX_DEBUG_STOP_IN_APP}
-}
-
-\subsection{Deprecated macros}
-
-The following macros were deprecated in v4.2:
+The v5.0 update includes the following changes from the v4.1 document:
 
 \begin{compactitemize}
-  \item \declaremacroDEP{PMIX_VALUE_LOAD} Replaced by the \refapi{PMIx_Value_load} \ac{API}
-  \item \declaremacroDEP{PMIX_VALUE_UNLOAD} Replaced by the \refapi{PMIx_Value_unload} \ac{API}
-  \item \declaremacroDEP{PMIX_VALUE_XFER} Replaced by the \refapi{PMIx_Value_xfer} \ac{API}
-  \item \declaremacroDEP{PMIX_INFO_LOAD} Replaced by the \refapi{PMIx_Info_load} \ac{API}
-  \item \declaremacroDEP{PMIX_INFO_XFER} Replaced by the \refapi{PMIx_Info_xfer} \ac{API}
-  \item \declaremacroDEP{PMIX_INFO_LIST_START} Replaced by the \refapi{PMIx_Info_list_start} \ac{API}
-  \item \declaremacroDEP{PMIX_INFO_LIST_ADD} Replaced by the \refapi{PMIx_Info_list_add} \ac{API}
-  \item \declaremacroDEP{PMIX_INFO_LIST_XFER} Replaced by the \refapi{PMIx_Info_list_xfer} \ac{API}
-  \item \declaremacroDEP{PMIX_INFO_LIST_CONVERT} Replaced by the \refapi{PMIx_Info_list_convert} \ac{API}
-  \item \declaremacroDEP{PMIX_INFO_LIST_RELEASE} Replaced by the \refapi{PMIx_Info_list_release} \ac{API}
-  \item \declaremacroDEP{PMIX_TOPOLOGY_DESTRUCT} Replaced by the \refapi{PMIx_Topology_destruct} \ac{API}
-  \item \declaremacroDEP{PMIX_TOPOLOGY_FREE} Not replaced.
+  \item First release prepared using procedures defined in the PMIx
+    Governance v1.7 document\footnote{\url{https://github.com/pmix/governance/releases/tag/v1.7}}.
+  \item Add specific values to constant definitions to ensure
+    consistency across implementations.
+  \item Add \nameref{app:use-cases} appendix with descriptions for Business Card
+    Exchange, Debugging, Hybrid Applications, MPI Sessions, and
+    Cross-Version Compatibility.
+  \item Add guidance on how PMIx defines an Application Binary Interface (ABI).
+  \item Add ABI query attributes.
+  \item Clarify three roles of consumers of the PMIx interface (client, server, tool).
+  \item Clarify when \refattr{PMIX_PARENT_ID} attribute is provided.
+  \item Clarify the value of \refattr{PMIX_CMD_LINE} attribute in spawn case.
+  \item Clarifications to Terms and Conventions chapter and addition of additional term definitions.
+  \item Re-organize the presentation of data access, synchronization, reserved keys and non-reserved keys.
+  \item Make presentation of return values consistent across APIs.
+  \item Attributes supported by PRRTE are no longer color coded.  Refer to PRRTE documentation to see what is supported for a particular PRRTE version.
+  \item NEW markers are removed from item declarations. Refer to \nameref{chap:revisions} to see when something was added.
 \end{compactitemize}
 
 \subsection{Added Functions (Provisional)}
@@ -1405,6 +1378,12 @@ The following macros were deprecated in v4.2:
   \item \refconst{PMIX_ERR_JOB_WDIR_NOT_FOUND}
 \end{compactitemize}
 
+\subsection{Added Attributes}
+
+\littleheader{ABI attributes}
+\pasteAttributeItem{PMIX_QUERY_STABLE_ABI_VERSION}
+\pasteAttributeItem{PMIX_QUERY_PROVISIONAL_ABI_VERSION}
+
 \subsection{Added Attributes (Provisional)}
 
 \littleheader{Spawn attributes}
@@ -1427,55 +1406,45 @@ The following macros were deprecated in v4.2:
 \pasteAttributeItem{PMIX_BREAKPOINT}
 \pasteAttributeItem{PMIX_DEBUG_STOP_IN_APP}
 
+\subsection{Deprecated constants}
+
+The following constants were deprecated in v5.0:
+
+\begin{constantdesc}
+%
+\declareconstitemDEP{PMIX_DEBUG_WAITING_FOR_NOTIFY}
+Renamed to \refconst{PMIX_READY_FOR_DEBUG}
+%
+\end{constantdesc}
 
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%%%%%%%%%% History: Version 5.0
-\section{Version 5.0: TBD}
+\subsection{Deprecated attributes}
+
+The following attributes were deprecated in v4.2:
+
+%
+\declareAttributeDEP{PMIX_DEBUG_WAIT_FOR_NOTIFY}{"pmix.dbg.notify"}{bool}{
+Renamed to \refattr{PMIX_DEBUG_STOP_IN_APP}
+}
+
+\subsection{Deprecated macros}
+
+The following macros were deprecated in v4.2:
 
 \begin{compactitemize}
-  \item First release prepared using procedures defined in the PMIx
-    Governance v1.7 document\footnote{\url{https://github.com/pmix/governance/releases/tag/v1.7}}.
-  \item Add specific values to constant definitions to ensure
-    consistency across implementations.
-  \item Add \nameref{app:use-cases} appendix with descriptions for Business Card
-    Exchange, Debugging, Hybrid Applications, MPI Sessions, and
-    Cross-Version Compatibility.
-  \item Add guidance on how PMIx defines an Application Binary Interface (ABI).
-  \item Add ABI query attributes.
-  \item Clarify three roles of consumers of the PMIx interface (client, server, tool).
-  \item Clarify when \refattr{PMIX_PARENT_ID} attribute is provided.
-  \item Clarify the value of \refattr{PMIX_CMD_LINE} attribute in spawn case.
-  \item Clarifications to Terms and Conventions chapter and addition of additional term definitions.
-  \item Re-organize the presentation of data access, synchronization, reserved keys and non-reserved keys.
-  \item Make presentation of return values consistent across APIs.
-  \item Attributes supported by PRRTE are no longer color coded.  Refer to PRRTE documentation to see what is supported for a particular PRRTE version.
-  \item NEW markers are removed from item declarations. Refer to \nameref{chap:revisions} to see when something was added.
+  \item \declaremacroDEP{PMIX_VALUE_LOAD} Replaced by the \refapi{PMIx_Value_load} \ac{API}
+  \item \declaremacroDEP{PMIX_VALUE_UNLOAD} Replaced by the \refapi{PMIx_Value_unload} \ac{API}
+  \item \declaremacroDEP{PMIX_VALUE_XFER} Replaced by the \refapi{PMIx_Value_xfer} \ac{API}
+  \item \declaremacroDEP{PMIX_INFO_LOAD} Replaced by the \refapi{PMIx_Info_load} \ac{API}
+  \item \declaremacroDEP{PMIX_INFO_XFER} Replaced by the \refapi{PMIx_Info_xfer} \ac{API}
+  \item \declaremacroDEP{PMIX_INFO_LIST_START} Replaced by the \refapi{PMIx_Info_list_start} \ac{API}
+  \item \declaremacroDEP{PMIX_INFO_LIST_ADD} Replaced by the \refapi{PMIx_Info_list_add} \ac{API}
+  \item \declaremacroDEP{PMIX_INFO_LIST_XFER} Replaced by the \refapi{PMIx_Info_list_xfer} \ac{API}
+  \item \declaremacroDEP{PMIX_INFO_LIST_CONVERT} Replaced by the \refapi{PMIx_Info_list_convert} \ac{API}
+  \item \declaremacroDEP{PMIX_INFO_LIST_RELEASE} Replaced by the \refapi{PMIx_Info_list_release} \ac{API}
+  \item \declaremacroDEP{PMIX_TOPOLOGY_DESTRUCT} Replaced by the \refapi{PMIx_Topology_destruct} \ac{API}
+  \item \declaremacroDEP{PMIX_TOPOLOGY_FREE} Not replaced.
 \end{compactitemize}
-
-%
-%\subsection{Added \acp{API}}
-%
-%\subsection{Added Constants}
-%
-\subsection{Added Attributes}
-
-\littleheader{ABI attributes}
-\pasteAttributeItem{PMIX_QUERY_STABLE_ABI_VERSION}
-\pasteAttributeItem{PMIX_QUERY_PROVISIONAL_ABI_VERSION}
-
-%
-%\subsection{Added Macros}
-%
-%\subsection{Deprecated \acp{API}}
-%
-%\subsection{Deprecated Constants}
-%
-%\subsection{Deprecated Attributes}
-%
-%\subsection{Deprecated Macros}
-%
-%\subsection{Removed \acp{API}}
 
 \subsection{Removed Constants}
 
@@ -1486,10 +1455,5 @@ The following constants were removed:
 Some, but not all, of the requested information was returned.
 Replaced by \refconst{PMIX_ERR_PARTIAL_SUCCESS}.
 \end{constantdesc}
-
-%\subsection{Removed Attributes}
-%
-%\subsection{Removed Macros}
-
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/Chap_Revisions.tex
+++ b/Chap_Revisions.tex
@@ -1420,7 +1420,7 @@ Renamed to \refconst{PMIX_READY_FOR_DEBUG}
 
 \subsection{Deprecated attributes}
 
-The following attributes were deprecated in v4.2:
+The following attributes were deprecated in v5.0:
 
 %
 \declareAttributeDEP{PMIX_DEBUG_WAIT_FOR_NOTIFY}{"pmix.dbg.notify"}{bool}{


### PR DESCRIPTION
Version 4.2 is yet to be released, while 5.0 has been approved. To avoid confusion, move all items previously listed under 4.2 to 5.0. Add sentence to the beginning of the 5.0 section stating these are changes since the 4.1 release.

Signed-off-by: Ken Raffenetti <raffenet@mcs.anl.gov>