### PR TITLE
Add authors for the v5.0 release

### DIFF
--- a/Acknowledgements.tex
+++ b/Acknowledgements.tex
@@ -8,6 +8,96 @@ This document represents the work of many people who have contributed to the PMI
 Without the hard work and dedication of these people this document would not have been possible.
 The sections below list some of the active participants and organizations in the various PMIx standard iterations.
 
+%%%%%%%%%% Version 5.0
+\section{Version 5.0}
+
+The following list includes some of the active participants in the PMIx v5 standardization process.
+
+%TODO general decision, where is the cut-off point for alumnis involved prior to dec. 2020 (when we published v4.0), in particular people that participated in establishing ASC rules used for the first time in this document.
+
+\paragraph*{Release Managers for v5.0}
+
+\begin{itemize}
+    \item Ken Raffenetti
+    \item David Solt
+\end{itemize}
+
+\paragraph*{ASC Chairs terms during v5.0 preparation}
+
+\begin{itemize}
+    \item Aurelien Bouteiller (2023-2025)
+    \item Joshua Hursey (2019-2024)
+    \item Kathryn Mohror (2020-2023)
+    \item Ralph Castain (2018-2020)
+\end{itemize}
+
+\paragraph*{Working Group Chairs during v5.0 preparation}
+
+%TODO decide what to do with inactive WGs chairs, alumnis
+\begin{itemize}
+    \item David Solt (Implementation Agnostic Document Working Group)
+    \item Isaías A. Comprés (Tools Working Group)
+\end{itemize}
+
+\paragraph*{ASC Secretaries terms during v5.0 preparation}
+
+\begin{itemize}
+    \item Norbert Eicker (2023-2025)
+    \item Thomas Naughton (2020-2024)
+    \item Aurelien Bouteiller (2021-2023)
+    \item Stephen Herbein (2019-2021)
+\end{itemize}
+
+\paragraph*{Contributors}
+
+%TODO review list (copied from v4, updated with current reps and alts, all commit-authors, PR reviewers, etc should also appear here)
+\begin{itemize}
+    \item Ralph H. Castain
+    \item Joshua Hursey and David Solt
+    \item Dirk Schubert
+    \item John DelSignore
+    \item Aurelien Bouteiller
+    \item Michael A Raymond
+    \item Howard Pritchard
+    \item Brice Goglin
+    \item Kathryn Mohror
+    \item Thomas Naughton and Swaroop Pophale
+    \item William E. Allcock and Paul Rich
+    \item Michael Karo
+    \item Artem Polyakov
+    \item Ken Raffenetti and Shane Snyder
+    \item Norbert Eicker
+    \item Brice Goglin and Guillaume Mercier
+    \item Hari Subramoni and Nat Shineman
+    \item Martin Schulz
+\end{itemize}
+
+\paragraph*{Institutions}
+
+The following institutions supported this effort through time and travel support for the people listed above.
+
+%TODO review list (copied from v4, updated with current members and reps)
+\begin{itemize}
+    \item Intel Corporation
+    \item IBM, Inc.
+    \item Allinea (ARM) %TODO not current, supported effort for v5?
+    \item Perforce %TODO not current, supported effort for v5?
+    \item University of Tennessee, Knoxville
+    \item The Exascale Computing Project, an initiative of the US Department of Energy
+    \item National Science Foundation
+    \item HPE Co.
+    \item Los Alamos National Laboratory
+    \item INRIA
+    \item Lawrence Livermore National Laboratory
+    \item Oak Ridge National Laboratory
+    \item Argonne National Laboratory
+    \item Nanook Consulting
+    \item Altair
+    \item NVIDIA
+    \item TU Munich
+    \item Ohio State University
+\end{itemize}
+
 %%%%%%%%%% Version 4.0
 \section{Version 4.0}
 


### PR DESCRIPTION
Create the 'acknowledgment' for contributors to the v5.0 release.

Since we are for the first time using the ASC procedures to create the document, the section organization reflects the roles accordingly.

At the moment the PR contains only people obtained from skimming the ASC governance 'roles'.

* [ ] use commit history to complete the contributors list
* [ ] use review history to find more contributors
* [ ] use ASC Qx meeting notes to find more contributors 
* [ ] contact WG heads to check that major participants in WG discussions have been properly credited. 
* [ ] review list of institutions (in particular w.r.t. institutions that do not currently have a representative, but did during the v5.0 cycle) 
