### PR TITLE
Add missing values for some provisional constants

### DIFF
--- a/Chap_API_Proc_Mgmt.tex
+++ b/Chap_API_Proc_Mgmt.tex
@@ -326,16 +326,16 @@ The launcher was unable to map the processes for the specified job request.
 \declareconstitemvalue{PMIX_ERR_JOB_FAILED_TO_LAUNCH}{-181}
 One or more processes in the job request failed to launch
 %
-\declareconstitemProvisional{PMIX_ERR_JOB_EXE_NOT_FOUND}
+\declareconstitemvalueProvisional{PMIX_ERR_JOB_EXE_NOT_FOUND}{-190}
 Specified executable not found
 %
-\declareconstitemProvisional{PMIX_ERR_JOB_INSUFFICIENT_RESOURCES}
+\declareconstitemvalueProvisional{PMIX_ERR_JOB_INSUFFICIENT_RESOURCES}{-234}
 Insufficient resources to spawn job
 %
-\declareconstitemProvisional{PMIX_ERR_JOB_SYS_OP_FAILED}
+\declareconstitemvalueProvisional{PMIX_ERR_JOB_SYS_OP_FAILED}{-235}
 System library operation failed
 %
-\declareconstitemProvisional{PMIX_ERR_JOB_WDIR_NOT_FOUND}
+\declareconstitemvalueProvisional{PMIX_ERR_JOB_WDIR_NOT_FOUND}{-233}
 Specified working directory not found
 %
 \end{constantdesc}


### PR DESCRIPTION
These were missed when we assigned values to most of the constants in the document.