### PR TITLE
Bump version to 5.1 and add release script

### DIFF
--- a/Chap_Revisions.tex
+++ b/Chap_Revisions.tex
@@ -1304,7 +1304,7 @@ Buffer.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%% History: Version 5.0
-\section{Version 5.0: TBD}
+\section{Version 5.0: May 2023}
 
 The v5.0 update includes the following changes from the v4.1 document:
 
@@ -1455,5 +1455,50 @@ The following constants were removed:
 Some, but not all, of the requested information was returned.
 Replaced by \refconst{PMIX_ERR_PARTIAL_SUCCESS}.
 \end{constantdesc}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%% History: Version 5.1
+\section{Version 5.1: TBD}
+
+The v5.1 update includes the following changes from the v5.0 document:
+
+%\begin{compactitemize}
+%\end{compactitemize}
+
+\subsection{Added Functions (Provisional)}
+
+%\begin{compactitemize}
+%\end{compactitemize}
+
+\subsection{Added Macros (Provisional)}
+
+%\begin{compactitemize}
+%\end{compactitemize}
+
+\subsection{Added Constants (Provisional)}
+
+%\begin{compactitemize}
+%\end{compactitemize}
+
+\subsection{Added Attributes}
+
+\subsection{Added Attributes (Provisional)}
+
+\subsection{Deprecated constants}
+
+The following constants were deprecated in v5.1:
+
+\subsection{Deprecated attributes}
+
+The following attributes were deprecated in v5.1:
+
+\subsection{Deprecated macros}
+
+The following macros were deprecated in v5.1:
+
+\subsection{Removed Constants}
+
+The following constants were removed:
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/pmix-standard.tex
+++ b/pmix-standard.tex
@@ -58,10 +58,10 @@
 % Text to appear in the footer on even-numbered pages:
 % Release candidates are marked as an Unofficial Draft
 \ifthenelse{\boolean{is_unofficial_draft}}
-  {\newcommand{\VER}{5.0dev0 (Draft)}
+  {\newcommand{\VER}{5.1dev0 (Draft)}
    \newcommand{\VERDATE}{\emph{Created on \today}}
   }
-  {\newcommand{\VER}{5.0}
+  {\newcommand{\VER}{5.1}
    \newcommand{\VERDATE}{Month Year}
   }
 \newcommand{\footerText}{PMIx Standard -- Version \VER{} -- \VERDATE}


### PR DESCRIPTION
Version 5.0 was tagged and released in May 2023. The master branch is now tracking version 5.1. We neglected to update the revision history chapter with the release date, so fix that and add a stub for 5.1 and use `\VERDATE` to substitute the release date automatically.

Add a new make target `make release`. This invokes `bin/release.sh` to automatically remove the watermark and substitute the current month and year for the release date. This process can be extended to support other release checklist type items.