### PR TITLE
Issue421/pmix iof cbfunc arg type@v4

### DIFF
--- a/Chap_API_Server.tex
+++ b/Chap_API_Server.tex
@@ -4193,7 +4193,7 @@ Callback function for delivering forwarded \ac{IO} to a process.
 \begin{codepar}
 typedef void (*pmix_iof_cbfunc_t)(
                     size_t iofhdlr, pmix_iof_channel_t channel,
-                    pmix_proc_t *source, char *payload,
+                    pmix_proc_t *source, pmix_byte_object_t *payload,
                     pmix_info_t info[], size_t ninfo);
 \end{codepar}
 \cspecificend
@@ -4202,7 +4202,7 @@ typedef void (*pmix_iof_cbfunc_t)(
 \argin{iofhdlr}{Registration number of the handler being invoked (\code{size_t})}
 \argin{channel}{bitmask identifying the channel the data arrived on (\refstruct{pmix_iof_channel_t})}
 \argin{source}{Pointer to a \refstruct{pmix_proc_t} identifying the namespace/rank of the process that generated the data (\code{char*})}
-\argin{payload}{Pointer to character array containing the data.}
+\argin{payload}{Pointer to a \refstruct{pmix_byte_object_t} that describes the character array containing the data.}
 \argin{info}{Array of \refstruct{pmix_info_t} provided by the source containing metadata about the payload. This could include \refattr{PMIX_IOF_COMPLETE} (handle)}
 \argin{ninfo}{Number of elements in \refarg{info} (\code{size_t})}
 \end{arglist}


### PR DESCRIPTION
Import changes accepted for v5.1 into v4.2

fixes https://github.com/pmix/pmix-standard/issues/491
closes https://github.com/pmix/pmix-standard/issues/421

Errata: Type of callback pmix_iof_cbfunc_t parameter payload should be a pmix_byte_object_t *

Signed-off-by: David Solt <dsolt@us.ibm.com>
(cherry picked from commit 46c1459512d1f0f234b0f0438828215550e2bb3f) #486 
