### PR TITLE
Correct fix for #420: pmix_key_t param in pmix_get

### DIFF
--- a/Chap_API_Sync_Access.tex
+++ b/Chap_API_Sync_Access.tex
@@ -199,7 +199,7 @@ Retrieve a key/value pair from the client's namespace.
 \cspecificstart
 \begin{codepar}
 pmix_status_t
-PMIx_Get(const pmix_proc_t *proc, const pmix_key_t key,
+PMIx_Get(const pmix_proc_t *proc, const char key[],
          const pmix_info_t info[], size_t ninfo,
          pmix_value_t **val);
 \end{codepar}
@@ -207,7 +207,7 @@ PMIx_Get(const pmix_proc_t *proc, const pmix_key_t key,
 
 \begin{arglist}
 \argin{proc}{Process identifier - a \code{NULL} value may be used in place of the caller's ID (handle)}
-\argin{key}{Key to retrieve (\refstruct{pmix_key_t})}
+\argin{key}{Key to retrieve (string)}
 \argin{info}{Array of info structures (array of handles)}
 \argin{ninfo}{Number of elements in the \refarg{info} array (integer)}
 \argout{val}{value (handle)}
@@ -277,7 +277,7 @@ Nonblocking \refapi{PMIx_Get} operation.
 \cspecificstart
 \begin{codepar}
 pmix_status_t
-PMIx_Get_nb(const pmix_proc_t *proc, const pmix_key_t key,
+PMIx_Get_nb(const pmix_proc_t *proc, const char key[],
             const pmix_info_t info[], size_t ninfo,
             pmix_value_cbfunc_t cbfunc, void *cbdata);
 \end{codepar}

--- a/Chap_Revisions.tex
+++ b/Chap_Revisions.tex
@@ -1346,8 +1346,7 @@ The v4.2 update includes the following changes from the v4.1 document:
 \subsection{Errata}
 
 \begin{compactitemize}
-  \item Parameter type for the key argument in \refapi{PMIx_Get_nb} has been changed to the equivalent type \refstruct{pmix_key_t} so that it is uniform with
-the argument in \refapi{PMIx_Get}.
+  \item Parameter type for the key argument in \refapi{PMIx_Get} has been changed from \refstruct{pmix_key_t} to \code{char []} so that it is uniform with the argument in \refapi{PMIx_Get_nb}.
   \item Parameter type for the payload argument in \refapi{pmix_iof_cbfunc_t} has been changed to a pointer to the type \refstruct{pmix_byte_object_t}.
 \end{compactitemize}
 


### PR DESCRIPTION
This does the opposite of the prior fix that was incorrectly swapping char key[] to pmix_key_t. 

